### PR TITLE
Add Dependabot config for submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Motivation
- Ensure git submodules are kept up-to-date automatically without manual intervention.
- The repository contains submodules defined in `.gitmodules`, which Dependabot can manage.
- A lightweight config avoids drift in the `HdayPlanner` and `NextShift` submodules.

### Description
- Add `/.github/dependabot.yml` with `version: 2` to enable Dependabot configuration for the repository.
- Configure `package-ecosystem: "gitsubmodule"` and `directory: "/"` to target repository submodules.
- Set the update `schedule` to `interval: "weekly"` so Dependabot checks for submodule updates weekly.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f25e9bbcc832e973b1106ec2583e2)