### PR TITLE
Add quick start/stop timer to daily time tracking

### DIFF
--- a/src/components/timeTracking/TimeTrackerPanel.tsx
+++ b/src/components/timeTracking/TimeTrackerPanel.tsx
@@ -96,7 +96,7 @@ function validateImportPayload(parsed: unknown): parsed is ImportPayload {
 type TimeTrackerPanelProps = {
   tasks: StoredTimeTrackingTask[];
   templates: TimeTrackingTemplate[];
-  onAddTask: (payload: StoredTimeTrackingTask) => void;
+  onAddTask: (payload: StoredTimeTrackingTask) => boolean;
   onUpdateTaskTimes: (payload: {
     id: string;
     newStartTime: string;
@@ -235,13 +235,17 @@ export function TimeTrackerPanel({
       return;
     }
 
-    onAddTask({
+    const added = onAddTask({
       id: crypto.randomUUID(),
       text,
       tag,
       startTime: `${date}T${start}`,
       stopTime: `${date}T${stop}`,
     });
+    if (!added) {
+      setError("A task is already running. Stop it before adding another task.");
+      return;
+    }
     setText("");
     setStart("");
     setStop("");
@@ -259,12 +263,16 @@ export function TimeTrackerPanel({
     }
     const startTime = dayjs().format("YYYY-MM-DDTHH:mm");
     const startDate = startTime.substring(0, 10);
-    onAddTask({
+    const added = onAddTask({
       id: crypto.randomUUID(),
       text: text.trim(),
       tag,
       startTime,
     });
+    if (!added) {
+      setError("A task is already running. Stop it before starting another.");
+      return;
+    }
     setDate(startDate);
     setText("");
   };

--- a/src/hooks/useTimeTrackingStorage.ts
+++ b/src/hooks/useTimeTrackingStorage.ts
@@ -125,7 +125,14 @@ export function useTimeTrackingStorage() {
 
   const addTask = useCallback(
     (payload: StoredTimeTrackingTask) => {
+      if (
+        payload.stopTime === undefined &&
+        rawTasksRef.current.some((task) => task.stopTime === undefined || task.stopTime === null)
+      ) {
+        return false;
+      }
       setRawTasks((prev) => [...prev, payload]);
+      return true;
     },
     [setRawTasks],
   );


### PR DESCRIPTION
### Motivation
- Provide a lightweight way for users to start a task immediately, see the currently running task with an ongoing elapsed timer, and stop it without filling manual start/stop fields.

### Description
- Added a Quick Timer section to `TimeTrackerPanel` that shows running/idle status, current running task, live elapsed time, and Start/Stop buttons using `useLiveTime` for second precision. 
- Implemented `formatDuration` and `tagToClass` helpers and computed `runningTask` / `runningElapsed` to display live elapsed time for the most-recent running task. 
- Added `handleStartNow` and `handleStopNow` handlers that create a new running task (`onAddTask`) or close it (`onUpdateTaskTimes`) with validation to prevent overlapping running tasks and to ensure same-day stop times. 
- Kept existing task entry, template, and overlap validation logic intact so manual entry and imports continue to work.

### Testing
- Ran lint with `npm run lint` (oxlint) which completed with 0 warnings/errors. 
- Started the dev server and ran an automated Playwright script to load the Time Tracking view and capture a screenshot of the Quick Timer UI, which executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876c4b3b78832ea9ad63838c879aff)