### PR TITLE
Remove coming soon labels and filter keyboard shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ Worktime is a Team Shift Tracker and Time-Off Manager supporting multiple roster
 
 - **5-shift**: Continuous 24/7 rotation with 5 teams (morning/evening/night shifts)
 - **9-5**: Standard weekday schedule (Mon-Fri, single user)
-- **2-shift**: Alternating early/late shifts (coming soon)
-- **Weekend shift**: Weekend-only rotation (coming soon)
+- **2-shift**: Alternating early/late shifts
+- **Weekend shift**: Weekend-only rotation
 
 **Note**: Previously known as NextShift. Rebranded to Worktime with v4.0.0 after merging HdayPlanner's time-off management capabilities. Schedule selection and multi-roster support added in v4.4.0.
 
@@ -609,7 +609,7 @@ d1i # Every Monday in office
 
 - **Structured Roster System**: Machine-readable schedule configurations in `src/data/rosters.ts`
 - **Schedule Selection**: Onboarding wizard now includes schedule selection step
-- **Multiple Schedule Types**: Support for 5-shift, 9-5, 2-shift (coming soon), weekend-shift (coming soon)
+- **Multiple Schedule Types**: Support for 5-shift, 9-5, 2-shift, weekend-shift
 - **Runtime Validation**: Comprehensive validation of roster configurations at module load
 - **Reference Date System**: Per-schedule reference dates and teams for accurate calculations
 - **Shift Times**: Define shift names, display codes, and hours per schedule

--- a/README.md
+++ b/README.md
@@ -19,11 +19,8 @@ Worktime helps teams and individuals working in various shift schedules to quick
 
 - **5-shift**: Continuous 24/7 rotation with 5 teams (morning/evening/night shifts)
 - **9-5**: Standard weekday schedule (Mon-Fri, single user)
-- **Weekend shift**: Weekend-only rotation with alternating early/late shifts
-
-**Coming Soon:**
-
 - **2-shift**: Alternating early/late shifts
+- **Weekend shift**: Weekend-only rotation with alternating early/late shifts
 
 ## Features
 
@@ -36,7 +33,7 @@ Worktime helps teams and individuals working in various shift schedules to quick
 
 ### 📅 Schedule Selection
 
-- Choose from multiple roster patterns (5-shift, 9-5, weekend-shift)
+- Choose from multiple roster patterns (5-shift, 9-5, 2-shift, weekend-shift)
 - Switch between schedule types at any time in settings
 - Onboarding wizard for easy setup
 
@@ -110,7 +107,7 @@ Teams are numbered 1-5, with each team starting their cycle 2 days after the pre
 
 - **9-5**: Monday-Friday day shifts (09:00-17:00) with weekends off
 - **Weekend shift**: Weekend-only rotation with alternating early/late shifts
-- **2-shift**: Alternating early/late shifts (coming soon)
+- **2-shift**: Alternating early/late shifts
 
 ## Date Format
 
@@ -160,7 +157,7 @@ Examples:
 4. **Open your browser**
    - Navigate to `http://localhost:8000`
    - Follow the onboarding wizard:
-     1. Choose your schedule type (5-shift, 9-5, or weekend-shift)
+     1. Choose your schedule type (5-shift, 9-5, 2-shift, or weekend-shift)
      2. Select your team (for multi-team schedules)
      3. Configure vacation allowance (optional)
    - Start tracking your shifts!
@@ -253,7 +250,7 @@ npm run test         # Run test suite
 
 ### 📅 Multi-Schedule Support
 
-- **Schedule Selection**: Choose from 5-shift, 9-5, or weekend-shift patterns
+- **Schedule Selection**: Choose from 5-shift, 9-5, 2-shift, or weekend-shift patterns
 - **Schedule Switching**: Switch between schedule types at any time
 - **Onboarding Wizard**: 5-step wizard with schedule, team, and vacation setup
 - **Schedule-Generic Components**: All components work with any schedule type

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -105,14 +105,6 @@ export function AboutModal({ show, onHide }: AboutModalProps) {
                 <span>YYWW.D date format</span>
               </div>
             </Col>
-            {!isFiveShift && (
-              <Col xs={6}>
-                <div className="d-flex align-items-center small">
-                  <i className="bi bi-clock-history text-info me-2"></i>
-                  <span>More schedule views coming soon</span>
-                </div>
-              </Col>
-            )}
           </Row>
         </div>
 

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -1,40 +1,52 @@
+import { useMemo } from "react";
 import Modal from "react-bootstrap/Modal";
 import Button from "react-bootstrap/Button";
 
 interface KeyboardShortcutsModalProps {
   show: boolean;
   onHide: () => void;
+  enableTimeOff?: boolean;
+  enableTimeTracking?: boolean;
 }
-
-const SHORTCUTS = [
-  {
-    category: "Navigation",
-    items: [
-      { keys: ["C"], description: "Calendar tab" },
-      { keys: ["S"], description: "Schedule tab" },
-      { keys: ["O"], description: "Time Off tab" },
-      { keys: ["T"], description: "Time Tracking tab" },
-      { keys: ["←", "→"], description: "Previous / next date" },
-      { keys: ["Ctrl", ","], description: "Open settings" },
-    ],
-  },
-  {
-    category: "Time Off",
-    items: [
-      { keys: ["Ctrl", "I"], description: "Import .hday file" },
-      { keys: ["Ctrl", "S"], description: "Export .hday file" },
-      { keys: ["Delete"], description: "Delete selected events" },
-      { keys: ["Escape"], description: "Cancel edit" },
-      { keys: ["Ctrl", "Z"], description: "Undo" },
-      { keys: ["Ctrl", "Y"], description: "Redo" },
-    ],
-  },
-] as const;
 
 /**
  * Modal displaying available keyboard shortcuts organized by category.
  */
-export function KeyboardShortcutsModal({ show, onHide }: KeyboardShortcutsModalProps) {
+export function KeyboardShortcutsModal({
+  show,
+  onHide,
+  enableTimeOff = false,
+  enableTimeTracking = false,
+}: KeyboardShortcutsModalProps) {
+  const shortcuts = useMemo(() => {
+    const navigationItems = [
+      { keys: ["C"], description: "Calendar tab" },
+      { keys: ["S"], description: "Schedule tab" },
+      ...(enableTimeOff ? [{ keys: ["O"], description: "Time Off tab" }] : []),
+      ...(enableTimeTracking ? [{ keys: ["T"], description: "Time Tracking tab" }] : []),
+      { keys: ["←", "→"], description: "Previous / next date" },
+      { keys: ["Ctrl", ","], description: "Open settings" },
+    ];
+
+    const categories = [{ category: "Navigation", items: navigationItems }];
+
+    if (enableTimeOff) {
+      categories.push({
+        category: "Time Off",
+        items: [
+          { keys: ["Ctrl", "I"], description: "Import .hday file" },
+          { keys: ["Ctrl", "S"], description: "Export .hday file" },
+          { keys: ["Delete"], description: "Delete selected events" },
+          { keys: ["Escape"], description: "Cancel edit" },
+          { keys: ["Ctrl", "Z"], description: "Undo" },
+          { keys: ["Ctrl", "Y"], description: "Redo" },
+        ],
+      });
+    }
+
+    return categories;
+  }, [enableTimeOff, enableTimeTracking]);
+
   return (
     <Modal show={show} onHide={onHide} centered>
       <Modal.Header closeButton>
@@ -44,7 +56,7 @@ export function KeyboardShortcutsModal({ show, onHide }: KeyboardShortcutsModalP
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {SHORTCUTS.map(({ category, items }) => (
+        {shortcuts.map(({ category, items }) => (
           <div key={category} className="mb-3">
             <h6 className="text-muted mb-2">{category}</h6>
             <div className="row g-2">

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -501,7 +501,12 @@ export function SettingsPanel({
       <ChangelogModal show={showChangelog} onHide={handleChangelogClose} />
 
       {/* Keyboard Shortcuts Modal */}
-      <KeyboardShortcutsModal show={showShortcuts} onHide={handleShortcutsClose} />
+      <KeyboardShortcutsModal
+        show={showShortcuts}
+        onHide={handleShortcutsClose}
+        enableTimeOff={settings.enableTimeOff}
+        enableTimeTracking={settings.enableTimeTracking}
+      />
 
       {/* Developer Options Modal */}
       <DevOptionsPanel show={showDevOptions} onHide={handleDevOptionsClose} />

--- a/tests/components/AboutModal.test.tsx
+++ b/tests/components/AboutModal.test.tsx
@@ -53,14 +53,12 @@ describe("AboutModal", () => {
     expect(screen.getByText("5-team shift tracking")).toBeInTheDocument();
     expect(screen.getByText("Transfer detection")).toBeInTheDocument();
     expect(screen.queryByText(/Schedule type:/)).not.toBeInTheDocument();
-    expect(screen.queryByText("More schedule views coming soon")).not.toBeInTheDocument();
   });
 
   it("shows schedule-specific features for non-5-shift schedules", () => {
     renderWithScheduleType("9-5");
 
     expect(screen.getByText("Schedule type: 9-5")).toBeInTheDocument();
-    expect(screen.getByText("More schedule views coming soon")).toBeInTheDocument();
     expect(screen.queryByText("5-team shift tracking")).not.toBeInTheDocument();
     expect(screen.queryByText("Transfer detection")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Closes #235, closes #236, closes #237, closes #256

## Summary
- Remove stale "coming soon" labels for 2-shift and weekend-shift schedules from AboutModal, README.md, and AGENTS.md (#235, #236, #237)
- Add 2-shift to schedule lists in README.md that were missing it
- Filter KeyboardShortcutsModal shortcuts based on enabled features — Time Off and Time Tracking tab shortcuts and the Time Off category only appear when those features are enabled (#256)

## Test plan
- [x] `npm run lint` passes (0 warnings, 0 errors)
- [x] `npm test` passes (1097 tests)
- [ ] Verify AboutModal no longer shows "More schedule views coming soon" for non-5-shift users
- [ ] Verify keyboard shortcuts modal only shows Time Off/Time Tracking shortcuts when those features are enabled in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)