### PR TITLE
Add shift remaining countdown, progress bar, and urgency indicators

### DIFF
--- a/src/components/MainTabs.tsx
+++ b/src/components/MainTabs.tsx
@@ -114,79 +114,79 @@ export function MainTabs({
   return (
     <>
       <main id="main-content">
-      <Tabs
-        activeKey={activeKey}
-        onSelect={(k) => {
-          const newKey = (k || "calendar") as TabKey;
-          setActiveTab(newKey);
-        }}
-        id={tabsId}
-      >
-        <Tab
-          eventKey="calendar"
-          title={
-            <>
-              <i className="bi bi-calendar3 me-1" aria-hidden="true"></i>
-              Calendar
-            </>
-          }
+        <Tabs
+          activeKey={activeKey}
+          onSelect={(k) => {
+            const newKey = (k || "calendar") as TabKey;
+            setActiveTab(newKey);
+          }}
+          id={tabsId}
         >
-          <CalendarView
-            myTeam={myTeam}
-            onChangeSchedule={onChangeSchedule}
-            onChangeTeam={onChangeTeam}
-            onOpenScheduleTab={() => setActiveTab("schedule")}
-          />
-        </Tab>
-
-        <Tab
-          eventKey="schedule"
-          title={
-            <>
-              <i className="bi bi-calendar-week me-1" aria-hidden="true"></i>
-              Schedule
-            </>
-          }
-        >
-          <ScheduleTabView
-            myTeam={myTeam}
-            currentDate={currentDate}
-            setCurrentDate={setCurrentDate}
-            onTeamClick={handleTeamClick}
-            onChangeSchedule={onChangeSchedule}
-            onChangeTeam={onChangeTeam}
-            isActive={activeKey === "schedule"}
-          />
-        </Tab>
-
-        {timeOffEnabled && (
           <Tab
-            eventKey="timeoff"
+            eventKey="calendar"
             title={
               <>
-                <i className="bi bi-calendar-check me-1" aria-hidden="true"></i>
-                Time Off
+                <i className="bi bi-calendar3 me-1" aria-hidden="true"></i>
+                Calendar
               </>
             }
           >
-            <TimeOffView isActive={activeKey === "timeoff"} />
+            <CalendarView
+              myTeam={myTeam}
+              onChangeSchedule={onChangeSchedule}
+              onChangeTeam={onChangeTeam}
+              onOpenScheduleTab={() => setActiveTab("schedule")}
+            />
           </Tab>
-        )}
 
-        {timeTrackingEnabled && (
           <Tab
-            eventKey="timetracking"
+            eventKey="schedule"
             title={
               <>
-                <i className="bi bi-stopwatch me-1" aria-hidden="true"></i>
-                Time Tracking
+                <i className="bi bi-calendar-week me-1" aria-hidden="true"></i>
+                Schedule
               </>
             }
           >
-            <TimeTrackingView />
+            <ScheduleTabView
+              myTeam={myTeam}
+              currentDate={currentDate}
+              setCurrentDate={setCurrentDate}
+              onTeamClick={handleTeamClick}
+              onChangeSchedule={onChangeSchedule}
+              onChangeTeam={onChangeTeam}
+              isActive={activeKey === "schedule"}
+            />
           </Tab>
-        )}
-      </Tabs>
+
+          {timeOffEnabled && (
+            <Tab
+              eventKey="timeoff"
+              title={
+                <>
+                  <i className="bi bi-calendar-check me-1" aria-hidden="true"></i>
+                  Time Off
+                </>
+              }
+            >
+              <TimeOffView isActive={activeKey === "timeoff"} />
+            </Tab>
+          )}
+
+          {timeTrackingEnabled && (
+            <Tab
+              eventKey="timetracking"
+              title={
+                <>
+                  <i className="bi bi-stopwatch me-1" aria-hidden="true"></i>
+                  Time Tracking
+                </>
+              }
+            >
+              <TimeTrackingView />
+            </Tab>
+          )}
+        </Tabs>
       </main>
 
       {/* Schedule Detail Modal */}

--- a/src/components/WelcomeWizard.tsx
+++ b/src/components/WelcomeWizard.tsx
@@ -128,7 +128,11 @@ export function WelcomeWizard({
     }
   }, [startStep]);
 
-  const SETTINGS_LOCATION_TEXT = <b>Settings panel (<span aria-hidden="true">⚙️</span> in the top right)</b>;
+  const SETTINGS_LOCATION_TEXT = (
+    <b>
+      Settings panel (<span aria-hidden="true">⚙️</span> in the top right)
+    </b>
+  );
 
   const isChangeFlow = mode === "change-schedule" || mode === "change-team";
   const resolvedSchedule = isValidScheduleType(selectedSchedule) ? selectedSchedule : null;

--- a/src/components/calendar/DayCell.tsx
+++ b/src/components/calendar/DayCell.tsx
@@ -114,10 +114,7 @@ const LONG_PRESS_DURATION = 500;
 /**
  * Opens a context menu positioned at the center of the given element's bounding rect.
  */
-function openMenuFromElement(
-  el: HTMLElement,
-  handler: (x: number, y: number) => void,
-) {
+function openMenuFromElement(el: HTMLElement, handler: (x: number, y: number) => void) {
   const rect = el.getBoundingClientRect();
   handler(rect.left + rect.width / 2, rect.top + rect.height / 2);
 }
@@ -229,11 +226,7 @@ export function DayCell({
     (e: KeyboardEvent<HTMLDivElement>) => {
       if (!onDayContextMenu) return;
       // Enter or Shift+F10 or ContextMenu key opens the day context menu
-      if (
-        e.key === "Enter" ||
-        (e.key === "F10" && e.shiftKey) ||
-        e.key === "ContextMenu"
-      ) {
+      if (e.key === "Enter" || (e.key === "F10" && e.shiftKey) || e.key === "ContextMenu") {
         e.preventDefault();
         e.stopPropagation();
         openMenuFromElement(e.currentTarget, (x, y) =>
@@ -284,7 +277,9 @@ export function DayCell({
       onKeyDown={handleCellKeyDown}
       onTouchStart={(e) => {
         if (onDayContextMenu && e.touches[0]) {
-          startLongPress(e.touches[0], (x, y) => onDayContextMenu(date, x, y, e.currentTarget as HTMLElement));
+          startLongPress(e.touches[0], (x, y) =>
+            onDayContextMenu(date, x, y, e.currentTarget as HTMLElement),
+          );
         }
       }}
       onTouchEnd={clearLongPress}
@@ -317,7 +312,12 @@ export function DayCell({
             onClick={(e) => {
               e.stopPropagation();
               const rect = e.currentTarget.getBoundingClientRect();
-              onDayContextMenu(date, rect.left + rect.width / 2, rect.top + rect.height / 2, e.currentTarget);
+              onDayContextMenu(
+                date,
+                rect.left + rect.width / 2,
+                rect.top + rect.height / 2,
+                e.currentTarget,
+              );
             }}
           >
             <i className="bi bi-plus" aria-hidden="true"></i>
@@ -361,7 +361,9 @@ export function DayCell({
               onKeyDown={(e) => handleEventKeyDown(e, index)}
               onTouchStart={(e) => {
                 if (onEventContextMenu && e.touches[0]) {
-                  startLongPress(e.touches[0], (x, y) => onEventContextMenu(index, x, y, e.currentTarget as HTMLElement));
+                  startLongPress(e.touches[0], (x, y) =>
+                    onEventContextMenu(index, x, y, e.currentTarget as HTMLElement),
+                  );
                 }
               }}
               onTouchEnd={clearLongPress}

--- a/src/components/shared/CountdownBadge.tsx
+++ b/src/components/shared/CountdownBadge.tsx
@@ -1,3 +1,5 @@
+const TWO_HOURS_IN_SECONDS = 7200;
+const ONE_DAY_IN_SECONDS = 86400;
 import Badge from "react-bootstrap/Badge";
 import type { Dayjs } from "dayjs";
 import type { CountdownResult } from "../../hooks/useCountdown";
@@ -5,17 +7,21 @@ import type { CountdownResult } from "../../hooks/useCountdown";
 interface CountdownBadgeProps {
   countdown: CountdownResult | null;
   startTime: Dayjs | null;
+  label?: string;
   variant?: "info" | "warning" | "success";
+  urgency?: boolean;
   showIcon?: boolean;
   className?: string;
 }
 
 /**
- * Reusable countdown badge component for displaying time until next shift.
+ * Reusable countdown badge component for displaying time remaining.
  *
  * @param countdown - Countdown result from useCountdown hook
- * @param startTime - The target start time
+ * @param startTime - The target time
+ * @param label - Text label before the countdown (default: "Starts in")
  * @param variant - Bootstrap badge variant (default: "info")
+ * @param urgency - Auto-select variant based on remaining time (overrides variant)
  * @param showIcon - Whether to show clock icon (default: true)
  * @param className - Additional CSS classes (default: "mt-2")
  * @returns Badge with countdown or null if countdown expired/invalid
@@ -23,7 +29,9 @@ interface CountdownBadgeProps {
 export function CountdownBadge({
   countdown,
   startTime,
+  label = "Starts in",
   variant = "info",
+  urgency = false,
   showIcon = true,
   className = "mt-2",
 }: CountdownBadgeProps) {
@@ -32,9 +40,21 @@ export function CountdownBadge({
     return null;
   }
 
+  let resolvedVariant = variant;
+  if (urgency) {
+    if (countdown.totalSeconds < TWO_HOURS_IN_SECONDS) {
+      resolvedVariant = "warning";
+    } else if (countdown.totalSeconds > ONE_DAY_IN_SECONDS) {
+      resolvedVariant = "success";
+    } else {
+      resolvedVariant = "info";
+    }
+  }
+
   return (
-    <Badge bg={variant} className={className}>
-      {showIcon && <span aria-hidden="true">⏰ </span>}Starts in {countdown.formatted}
+    <Badge bg={resolvedVariant} className={className}>
+      {showIcon && <span aria-hidden="true">⏰ </span>}
+      {label} {countdown.formatted}
     </Badge>
   );
 }

--- a/src/components/status/PersonalizedStatus.tsx
+++ b/src/components/status/PersonalizedStatus.tsx
@@ -79,7 +79,36 @@ export function PersonalizedStatusContent({
     return setTimeFromFractionalHour(nextShift.date, nextShift.shift.start);
   }, [nextShift]);
 
+  // Calculate current shift start/end times for progress bar and "Ends in" countdown
+  const currentShiftStartTime = useMemo(() => {
+    if (!currentShift.shift.isWorking || currentShift.shift.start == null) return null;
+    return setTimeFromFractionalHour(currentShift.date, currentShift.shift.start);
+  }, [currentShift]);
+
+  const currentShiftEndTime = useMemo(() => {
+    const { start, end } = currentShift.shift;
+    if (!currentShift.shift.isWorking || end == null) return null;
+    // Detect midnight-crossing shifts (e.g., night shift 23h-7h)
+    const endDate =
+      start != null && start > end ? currentShift.date.add(1, "day") : currentShift.date;
+    return setTimeFromFractionalHour(endDate, end);
+  }, [currentShift]);
+
+  // Shift progress percentage (elapsed / total duration)
+  const shiftProgress = useMemo(() => {
+    if (!currentShiftStartTime || !currentShiftEndTime) return null;
+    const totalSeconds = currentShiftEndTime.diff(currentShiftStartTime, "second");
+    if (totalSeconds <= 0) return null;
+    const elapsedSeconds = today.diff(currentShiftStartTime, "second");
+    const clampedElapsedSeconds = Math.max(0, elapsedSeconds);
+    const percentage = Math.min(100, Math.max(0, (elapsedSeconds / totalSeconds) * 100));
+    const elapsedHours = Math.floor(clampedElapsedSeconds / 3600);
+    const totalHours = Math.round(totalSeconds / 3600);
+    return { percentage, elapsedHours, totalHours };
+  }, [currentShiftStartTime, currentShiftEndTime, todayMinuteKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const countdown = useCountdown(nextShiftStartTime);
+  const shiftEndCountdown = useCountdown(currentShiftEndTime);
   const formattedShiftTime = useFormattedShiftTime(currentShift.shift);
 
   // Tooltip details for current shift badge
@@ -121,6 +150,29 @@ export function PersonalizedStatusContent({
               {currentShift.shift.start != null && currentShift.shift.end != null && (
                 <ShiftTimeDisplay shift={currentShift.shift} className="small text-muted mt-1" />
               )}
+              {currentShift.shift.isWorking && (
+                <>
+                  <CountdownBadge
+                    countdown={shiftEndCountdown}
+                    startTime={currentShiftEndTime}
+                    label="Ends in"
+                    variant="warning"
+                  />
+                  {shiftProgress && (
+                    <div className="mt-2">
+                      <div className="small text-muted mb-1">
+                        Shift Progress: {shiftProgress.elapsedHours}h / {shiftProgress.totalHours}h
+                      </div>
+                      <ProgressBar
+                        now={shiftProgress.percentage}
+                        variant="warning"
+                        className="progress-thin"
+                        aria-label={`Shift progress: ${shiftProgress.elapsedHours} of ${shiftProgress.totalHours} hours`}
+                      />
+                    </div>
+                  )}
+                </>
+              )}
               {!currentShift.shift.isWorking && offDayProgress && (
                 <div className="mt-2">
                   <div className="small text-muted mb-1">
@@ -152,7 +204,7 @@ export function PersonalizedStatusContent({
                     {nextShift.date.format("ddd, MMM D")} - {nextShift.shift.name}
                   </div>
                   <ShiftTimeDisplay shift={nextShift.shift} className="small text-muted" />
-                  <CountdownBadge countdown={countdown} startTime={nextShiftStartTime} />
+                  <CountdownBadge countdown={countdown} startTime={nextShiftStartTime} urgency />
                 </div>
               ) : (
                 <EmptyState

--- a/src/components/wizard/Step2Features.tsx
+++ b/src/components/wizard/Step2Features.tsx
@@ -75,7 +75,8 @@ export function Step2Features({
         </Row>
         <Alert variant="info" className="mt-4">
           <i className="bi bi-gear me-2"></i>
-          <strong>Tip:</strong> You can customize your experience anytime in the {settingsLocationText}.
+          <strong>Tip:</strong> You can customize your experience anytime in the{" "}
+          {settingsLocationText}.
         </Alert>
       </div>
       <div className="d-flex flex-column flex-sm-row justify-content-between gap-2">

--- a/src/styles/_calendar.scss
+++ b/src/styles/_calendar.scss
@@ -125,7 +125,9 @@
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.15s, visibility 0.15s;
+  transition:
+    opacity 0.15s,
+    visibility 0.15s;
 }
 
 .month-calendar-add-btn:hover {

--- a/tests/components/CurrentStatus.test.tsx
+++ b/tests/components/CurrentStatus.test.tsx
@@ -64,23 +64,28 @@ vi.mock("../../src/hooks/useCountdown", () => ({
 
 vi.mock("../../src/utils/dateTimeUtils", async (importOriginal) => {
   const actual = await importOriginal();
-  const mockDayjsObj = {
+  const mockDayjsObj: Record<string, ReturnType<typeof vi.fn>> = {
     startOf: vi.fn(() => ({
       toISOString: vi.fn(() => "2024-01-15T00:00:00.000Z"),
     })),
     isSame: vi.fn(() => false),
     format: vi.fn(() => "2024-01-15"),
+    diff: vi.fn(() => 28800),
     hour: vi.fn(() => ({
       minute: vi.fn(() => ({
         second: vi.fn(() => ({
           isBefore: vi.fn(() => false),
           isAfter: vi.fn(() => true),
+          diff: vi.fn(() => 28800),
+          isValid: vi.fn(() => true),
         })),
       })),
     })),
-    add: vi.fn(() => mockDayjsObj),
-    subtract: vi.fn(() => mockDayjsObj),
+    add: vi.fn(),
+    subtract: vi.fn(),
   };
+  mockDayjsObj.add.mockReturnValue(mockDayjsObj);
+  mockDayjsObj.subtract.mockReturnValue(mockDayjsObj);
   return {
     ...actual,
     dayjs: vi.fn(() => mockDayjsObj),


### PR DESCRIPTION
## Summary
- **Shift "Ends in" countdown**: Shows a live countdown badge during active shifts indicating time until the shift ends
- **Shift progress bar**: Displays elapsed/total hours with a visual progress bar while working (e.g., "3h / 8h"), using the same `progress-thin` style as the off-day progress bar
- **Next shift urgency coloring**: The "Your Next Shift" countdown badge now auto-colors based on remaining time — warning (< 2h), info (2h–24h), success (> 24h)
- **CountdownBadge enhancements**: Added `label` and `urgency` props for reuse across different countdown contexts

Closes #277, closes #242

## Test plan
- [x] `npm run lint` passes (0 warnings, 0 errors)
- [x] `npm test` passes (1097/1097 tests)
- [ ] Verify "Ends in" badge and progress bar appear during an active shift
- [ ] Verify off-day progress bar still renders correctly on rest days
- [ ] Verify next shift countdown badge changes color based on proximity
- [ ] Verify midnight-crossing shifts (e.g., night 23h–7h) calculate end time correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)