### PR TITLE
Clarify 2-shift onboarding copy as multi-team schedule

### DIFF
--- a/src/data/rosters.ts
+++ b/src/data/rosters.ts
@@ -204,7 +204,7 @@ export const SCHEDULE_OPTIONS: ScheduleRoster[] = [
   {
     value: "2-shift",
     title: "2-shift",
-    description: "Alternating morning and evening shifts with rotating support weekends.",
+    description: "Alternating morning and evening shifts across 4 teams with rotating support weekends.",
     isAvailable: true,
     shiftConfig: {
       teamCount: 4,


### PR DESCRIPTION
### Motivation
- The 2-shift onboarding description did not indicate that the schedule uses multiple teams, which can make the follow-up team-selection step unexpected for users.

### Description
- Update the `description` for the `2-shift` entry in `src/data/rosters.ts` to: "Alternating morning and evening shifts across 4 teams with rotating support weekends.".

### Testing
- Ran `npm run lint` and `npm run test -- tests/data/rosters.test.ts`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976684e95c832eb1378ba7015b82ee)