### PR TITLE
Fix WFH limit zero handling and add SettingsContext tests

### DIFF
--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -258,7 +258,7 @@ export function MonthCalendar({
 
   // Compute which ISO weeks in the current view exceed the WFH limit
   const wfhLimitExceededWeeks = useMemo(() => {
-    if (!wfhWeeklyLimit || !workLocationMap) return new Set<string>();
+    if (wfhWeeklyLimit == null || !workLocationMap) return new Set<string>();
     const exceeded = new Set<string>();
     const checkedWeeks = new Set<string>();
     for (const day of days) {

--- a/tests/contexts/SettingsContext.test.tsx
+++ b/tests/contexts/SettingsContext.test.tsx
@@ -206,6 +206,51 @@ describe("SettingsContext unified user state", () => {
     expect(document.documentElement.getAttribute("data-bs-theme")).toBeNull();
   });
 
+
+  describe("WFH weekly limit settings", () => {
+    it("updates WFH weekly limit with valid integer values", async () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      await act(async () => {
+        result.current.updateWfhWeeklyLimit(0);
+      });
+      expect(result.current.settings.wfhWeeklyLimit).toBe(0);
+
+      await act(async () => {
+        result.current.updateWfhWeeklyLimit(3);
+      });
+      expect(result.current.settings.wfhWeeklyLimit).toBe(3);
+
+      await act(async () => {
+        result.current.updateWfhWeeklyLimit(7);
+      });
+      expect(result.current.settings.wfhWeeklyLimit).toBe(7);
+    });
+
+    it("normalizes invalid WFH weekly limit values to default", async () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      await act(async () => {
+        result.current.updateWfhWeeklyLimit(-1);
+      });
+      expect(result.current.settings.wfhWeeklyLimit).toBe(2);
+
+      await act(async () => {
+        result.current.updateWfhWeeklyLimit(Number.NaN);
+      });
+      expect(result.current.settings.wfhWeeklyLimit).toBe(2);
+    });
+
+    it("floors fractional WFH weekly limit values", async () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      await act(async () => {
+        result.current.updateWfhWeeklyLimit(2.9);
+      });
+      expect(result.current.settings.wfhWeeklyLimit).toBe(2);
+    });
+  });
+
   describe("Vacation Allowance Settings", () => {
     it("should have default vacation allowance on initialization", () => {
       const { result } = renderHook(() => useSettings(), { wrapper });
@@ -795,6 +840,80 @@ describe("SettingsContext unified user state", () => {
 
       expect(result.current.settings.homeCountry).toBe("NL");
       expect(result.current.settings.officeCountry).toBe("BE");
+    });
+  });
+
+
+  describe("v3 to v4 migration (WFH weekly limit)", () => {
+    it("adds wfhWeeklyLimit default when upgrading from v3", () => {
+      window.localStorage.setItem(
+        "worktime_user_state",
+        JSON.stringify({
+          version: 3,
+          hasCompletedOnboarding: true,
+          myTeam: 2,
+          scheduleType: "5-shift",
+          settings: {
+            timeFormat: "24h",
+            theme: "auto",
+            notifications: "off",
+            vacationAllowance: { yearlyAmounts: { "2025": 25 }, unit: "days", hoursPerDay: 8 },
+            enableTimeOff: true,
+            enableTimeTracking: false,
+            homeCountry: null,
+            officeCountry: null,
+          },
+          lastUsed: {
+            activeTab: "calendar",
+            scheduleView: "today",
+            otherSchedule: null,
+            timeOffView: "table",
+            timeTrackingView: "daily",
+            otherTeam: null,
+          },
+        }),
+      );
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      expect(result.current.settings.wfhWeeklyLimit).toBe(2);
+      expect(result.current.myTeam).toBe(2);
+      expect(result.current.scheduleType).toBe("5-shift");
+    });
+
+    it("preserves existing wfhWeeklyLimit when present in v3 state", () => {
+      window.localStorage.setItem(
+        "worktime_user_state",
+        JSON.stringify({
+          version: 3,
+          hasCompletedOnboarding: true,
+          myTeam: 1,
+          scheduleType: "9-5",
+          settings: {
+            timeFormat: "12h",
+            theme: "dark",
+            notifications: "on",
+            vacationAllowance: { yearlyAmounts: {}, unit: "days", hoursPerDay: 8 },
+            enableTimeOff: false,
+            enableTimeTracking: false,
+            homeCountry: "NL",
+            officeCountry: "BE",
+            wfhWeeklyLimit: 0,
+          },
+          lastUsed: {
+            activeTab: "calendar",
+            scheduleView: "today",
+            otherSchedule: null,
+            timeOffView: "table",
+            timeTrackingView: "daily",
+            otherTeam: null,
+          },
+        }),
+      );
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      expect(result.current.settings.wfhWeeklyLimit).toBe(0);
     });
   });
 


### PR DESCRIPTION
### Motivation
- The month calendar logic incorrectly treated `wfhWeeklyLimit === 0` as falsy, causing weeks to be skipped from WFH-limit checks when a zero limit should be valid. 
- The change adds unit tests to ensure `updateWfhWeeklyLimit` sanitizes/normalizes inputs and that the v3→v4 migration correctly injects or preserves `wfhWeeklyLimit` (including `0`).

### Description
- Change the short-circuit guard in `src/components/calendar/MonthCalendar.tsx` to `if (wfhWeeklyLimit == null || !workLocationMap) ...` so `0` is processed by `isWfhLimitExceeded(...)` instead of being skipped. 
- Add `WFH weekly limit settings` unit tests to `tests/contexts/SettingsContext.test.tsx` covering valid integers (`0`, `3`, `7`), invalid values (`-1`, `NaN`), and fractional input (floors `2.9` → `2`).
- Add `v3 to v4 migration (WFH weekly limit)` tests to assert that migration seeds the default when missing and preserves an existing `wfhWeeklyLimit` value (including `0`).

### Testing
- Ran `npm run lint` and it completed with no warnings or errors. 
- Ran the modified test file with `npm test -- tests/contexts/SettingsContext.test.tsx` and all tests passed (`48 tests` passed). 
- Built the project with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bc016230832e918e02c275801019)