### PR TITLE
Remove unused work location helper APIs

### DIFF
--- a/src/hooks/useWorkLocationStorage.ts
+++ b/src/hooks/useWorkLocationStorage.ts
@@ -167,36 +167,10 @@ export function useWorkLocationStorage(year: number) {
     [year, setStoredLocations, setPrevYearLocations, setNextYearLocations],
   );
 
-  /**
-   * Returns a WorkLocationMap that covers all seven days of the ISO week containing
-   * the given date, merging data from adjacent years when the week spans a year boundary
-   * (e.g. a week covering both 31 Dec and 1 Jan).
-   *
-   * @param weekStartDate - Any date within the target ISO week
-   * @returns A merged WorkLocationMap for the full week
-   */
-  const getLocationsForWeek = useCallback(
-    (weekStartDate: dayjs.Dayjs | Date | string): WorkLocationMap => {
-      const monday = dayjs(weekStartDate).isoWeekday(1);
-      const sunday = monday.add(6, "day");
-
-      if (monday.year() === sunday.year()) {
-        return new Map(Object.entries(storedLocations));
-      }
-
-      // Week spans two years: merge current year with the adjacent year
-      const adjacentLocations =
-        sunday.year() === year + 1 ? nextYearLocations : prevYearLocations;
-      return new Map(Object.entries({ ...storedLocations, ...adjacentLocations }));
-    },
-    [storedLocations, prevYearLocations, nextYearLocations, year],
-  );
-
   return {
     workLocationMap,
     getLocationForDate,
     setLocationForDate,
     clearLocationForDate,
-    getLocationsForWeek,
   };
 }

--- a/src/utils/workLocationUtils.ts
+++ b/src/utils/workLocationUtils.ts
@@ -31,39 +31,6 @@ export function getWfhDaysInWeek(date: Dayjs, workLocationMap: WorkLocationMap):
 }
 
 /**
- * Counts the number of WFH (work-from-home) days in a given calendar month.
- *
- * Only considers days present in workLocationMap with location "home".
- * Days without an explicit entry (including office defaults) are not counted.
- *
- * @param year - The calendar year (e.g., 2026)
- * @param month - The calendar month, 1-indexed (1=January, 12=December)
- * @param workLocationMap - Map of explicitly set work locations keyed by YYYY/MM/DD
- * @returns The number of WFH days in that month
- *
- * @example
- * // Returns 8 if 8 days in February 2026 are set to "home"
- * getWfhDaysInMonth(2026, 2, workLocationMap); // 8
- */
-export function getWfhDaysInMonth(
-  year: number,
-  month: number,
-  workLocationMap: WorkLocationMap,
-): number {
-  const startOfMonth = dayjs().year(year).month(month - 1).date(1);
-  const daysInMonth = startOfMonth.daysInMonth();
-  let count = 0;
-  for (let d = 1; d <= daysInMonth; d++) {
-    const day = startOfMonth.date(d);
-    const info = workLocationMap.get(formatHdayDate(day));
-    if (info?.location === "home") {
-      count++;
-    }
-  }
-  return count;
-}
-
-/**
  * Checks whether the WFH day count for the ISO week containing the given date
  * exceeds the specified limit.
  *


### PR DESCRIPTION
### Motivation

- `getLocationsForWeek` in `useWorkLocationStorage` was unused and its implementation returned year-level data rather than a true week-filtered map, which is misleading.
- `getWfhDaysInMonth` in `workLocationUtils` is unused and not required for current features, so removing it keeps the utilities focused and reduces dead code.

### Description

- Removed the `getLocationsForWeek` callback and stopped returning it from the `useWorkLocationStorage` hook in `src/hooks/useWorkLocationStorage.ts`.
- Removed the `getWfhDaysInMonth` function and its export from `src/utils/workLocationUtils.ts`.
- Kept `getWfhDaysInWeek` and `isWfhLimitExceeded` intact to preserve weekly WFH checks and limits.
- No other public APIs were changed and no callers needed updates because both functions were unused.

### Testing

- Ran `npm run lint` and it completed with no warnings or errors.
- Ran the full test suite with `npm run test` and all tests passed (1173 tests passed).
- Attempted to run targeted test files but the filtered run found no matching test files; this was a no-op and does not affect verification.
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ce2c998c832eab772d4a009b03dd)