### PR TITLE
Add Phase 3 database endpoint tests and fixtures

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -105,7 +105,7 @@ def create_user_factory() -> Callable[..., int]:
             },
             headers=headers,
         )
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         return response.json()["id"]
 
     return _create_user

--- a/backend/tests/test_db_time_tracking.py
+++ b/backend/tests/test_db_time_tracking.py
@@ -76,6 +76,7 @@ def test_task_constraints_and_filtering(
         json={"name": "Client", "color": "#778899"},
         headers=headers,
     )
+    assert label_response.status_code == 201
     label_id = label_response.json()["id"]
 
     invalid_label_task = db_client.post(
@@ -186,6 +187,7 @@ def test_template_crud(
         json={"name": "Template Label", "color": "#445566"},
         headers=headers,
     )
+    assert label_response.status_code == 201
     label_id = label_response.json()["id"]
 
     create_template_response = db_client.post(

--- a/backend/tests/test_db_users.py
+++ b/backend/tests/test_db_users.py
@@ -53,6 +53,9 @@ def test_user_crud_and_settings_roundtrip(
     delete_response = db_client.delete(f"/v1/db/users/{user_id}", headers=auth_headers(user_id))
     assert delete_response.status_code == 204
 
+    deleted_get_response = db_client.get(f"/v1/db/users/{user_id}", headers=auth_headers(user_id))
+    assert deleted_get_response.status_code == 404
+
 
 def test_user_duplicate_and_not_found(
     db_client: TestClient,

--- a/backend/tests/test_db_work_locations.py
+++ b/backend/tests/test_db_work_locations.py
@@ -39,7 +39,7 @@ def test_work_location_upsert_and_filtering(
 
     other_user_location = db_client.post(
         f"/v1/db/work-locations/?user_id={other_id}",
-        json={"date": "2026-02-02", "country_code": "DE", "label": "HQ"},
+        json={"date": "2026-02-01", "country_code": "DE", "label": "HQ"},
         headers=other_headers,
     )
     assert other_user_location.status_code == 201


### PR DESCRIPTION
### Motivation
- Provide comprehensive Phase 3 test coverage for the new database-backed endpoints to ensure correctness and prevent regressions.
- Introduce reusable fixtures that make it easy to run database-enabled tests with an isolated temporary SQLite database.
- Verify that existing `.hday` and team-related endpoints remain functional when the database is enabled.

### Description
- Expand `backend/tests/conftest.py` with DB-focused fixtures: `test_db` to create a temporary SQLite file and initialize schema via `init_db()`, `db_session` for direct `Session` access, `db_client` to run `TestClient` against the temp DB, and `auth_headers` to generate JWT bearer headers for tests.
- Add `backend/tests/test_db_users.py` to exercise user CRUD, duplicate username conflict handling (`409`), not-found responses (`404`), and JSON settings round-trip behavior.
- Add `backend/tests/test_db_time_tracking.py` to cover label/task/template CRUD, label-delete cascade behavior (unlabel tasks/templates), running-task constraints (only one running task per user), invalid-label handling, and task filtering by date/label/user.
- Add `backend/tests/test_db_work_locations.py` to cover work-location upsert semantics, country code validation, and filtering by user/date range.

### Testing
- Ran targeted tests with `PYTHONPATH=. pytest tests/test_db_users.py tests/test_db_time_tracking.py tests/test_db_work_locations.py tests/test_hday_endpoints.py tests/test_team_endpoints.py` from `backend/`, and the run succeeded (62 tests passed for that scope).
- Ran a broader `PYTHONPATH=. pytest` in `backend/`, which executed the full suite and surfaced 18 failures in unrelated debug/service/team-service tests; these failures appear pre-existing and are not caused by the new DB endpoint tests.
- Verified the new DB tests execute against an isolated temporary SQLite database created per-test via the provided fixtures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c1b3a5d4832ea294e39c2a0a6788)