### PR TITLE
Integrate Personal Gantt into settings, shortcuts, and build chunks

### DIFF
--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -7,6 +7,7 @@ interface KeyboardShortcutsModalProps {
   onHide: () => void;
   enableTimeOff?: boolean;
   enableTimeTracking?: boolean;
+  enableGantt?: boolean;
 }
 
 /**
@@ -17,6 +18,7 @@ export function KeyboardShortcutsModal({
   onHide,
   enableTimeOff = false,
   enableTimeTracking = false,
+  enableGantt = false,
 }: KeyboardShortcutsModalProps) {
   const shortcuts = useMemo(() => {
     const navigationItems = [
@@ -24,6 +26,7 @@ export function KeyboardShortcutsModal({
       { keys: ["S"], description: "Schedule tab" },
       ...(enableTimeOff ? [{ keys: ["O"], description: "Time Off tab" }] : []),
       ...(enableTimeTracking ? [{ keys: ["T"], description: "Time Tracking tab" }] : []),
+      ...(enableGantt ? [{ keys: ["G"], description: "Gantt tab" }] : []),
       { keys: ["←", "→"], description: "Previous / next date" },
       { keys: ["Ctrl", ","], description: "Open settings" },
     ];
@@ -45,7 +48,7 @@ export function KeyboardShortcutsModal({
     }
 
     return categories;
-  }, [enableTimeOff, enableTimeTracking]);
+  }, [enableTimeOff, enableTimeTracking, enableGantt]);
 
   return (
     <Modal show={show} onHide={onHide} centered>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -123,6 +123,7 @@ export function SettingsPanel({
     updateTheme,
     updateTimeOffEnabled,
     updateTimeTrackingEnabled,
+    updateGanttEnabled,
     updateCrossBorderTrackingEnabled,
     updateHomeCountry,
     updateOfficeCountry,
@@ -436,6 +437,23 @@ export function SettingsPanel({
                 <ListGroup.Item>
                   <div className="d-flex justify-content-between align-items-center">
                     <div>
+                      <div className="fw-medium">Personal Gantt</div>
+                      <small className="text-muted">
+                        Timeline view for tracking personal tasks and projects
+                      </small>
+                    </div>
+                    <Form.Check
+                      type="switch"
+                      id="toggle-gantt"
+                      checked={settings.enableGantt}
+                      onChange={(event) => updateGanttEnabled(event.target.checked)}
+                      aria-label="Toggle personal gantt"
+                    />
+                  </div>
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <div className="d-flex justify-content-between align-items-center">
+                    <div>
                       <div className="fw-medium">Cross-Border Tracking</div>
                       <small className="text-muted">
                         Track work location per day for tax reporting
@@ -661,6 +679,7 @@ export function SettingsPanel({
         onHide={handleShortcutsClose}
         enableTimeOff={settings.enableTimeOff}
         enableTimeTracking={settings.enableTimeTracking}
+        enableGantt={settings.enableGantt}
       />
 
       {/* Developer Options Modal */}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ interface KeyboardShortcuts {
   onTabSchedule?: () => void;
   onTabTimeOff?: () => void;
   onTabTimeTracking?: () => void;
+  onTabGantt?: () => void;
   onToggleSettings?: () => void;
 }
 
@@ -120,6 +121,7 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcuts) {
               s: { cb: shortcuts.onTabSchedule, name: "onTabSchedule" },
               o: { cb: shortcuts.onTabTimeOff, name: "onTabTimeOff" },
               t: { cb: shortcuts.onTabTimeTracking, name: "onTabTimeTracking" },
+              g: { cb: shortcuts.onTabGantt, name: "onTabGantt" },
             };
 
             const shortcut = tabShortcuts[key];

--- a/tests/hooks/useKeyboardShortcuts.test.ts
+++ b/tests/hooks/useKeyboardShortcuts.test.ts
@@ -9,6 +9,7 @@ describe("useKeyboardShortcuts", () => {
     onNext: vi.fn(),
     onTeamSelect: vi.fn(),
     onTabTimeTracking: vi.fn(),
+    onTabGantt: vi.fn(),
   };
 
   beforeEach(() => {
@@ -115,4 +116,14 @@ describe("useKeyboardShortcuts", () => {
 
     expect(mockShortcuts.onTabTimeTracking).not.toHaveBeenCalled();
   });
+
+  it("triggers onTabGantt when G is pressed", () => {
+    renderHook(() => useKeyboardShortcuts(mockShortcuts));
+
+    const event = new KeyboardEvent("keydown", { key: "g" });
+    document.dispatchEvent(event);
+
+    expect(mockShortcuts.onTabGantt).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,9 @@ export default defineConfig(() => ({
             if (id.includes("dayjs")) {
               return "vendor-utils";
             }
+            if (id.includes("frappe-gantt")) {
+              return "vendor-gantt";
+            }
           }
         },
       },


### PR DESCRIPTION
### Motivation
- Finish wiring the Personal Gantt feature into the app so users can toggle it from Settings and discover/use the Gantt tab via keyboard shortcuts and a dedicated vendor chunk.

### Description
- Added a `Personal Gantt` feature toggle to `SettingsPanel` and wired it to `updateGanttEnabled` so `settings.enableGantt` is persisted and controllable from the UI. 
- Passed `enableGantt` into `KeyboardShortcutsModal` and conditionally added the `G` shortcut entry to the navigation list. 
- Extended the `useKeyboardShortcuts` hook with `onTabGantt` and mapped the single-key `g` to trigger that callback. 
- Added unit coverage for the new `G` key case in `tests/hooks/useKeyboardShortcuts.test.ts` and updated Vite `manualChunks` in `vite.config.ts` to create a dedicated `vendor-gantt` chunk for `frappe-gantt`.

### Testing
- Ran targeted tests with `npm run test -- tests/hooks/useKeyboardShortcuts.test.ts tests/components/MainTabs.test.tsx` and both suites passed. 
- Ran full test suite with `npm run test` and all tests passed (`67` test files, `1286` tests passed). 
- Verified build with `npm run build` completed successfully and lint with `npm run lint` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d1d48b78832eacf27f1bb30ad4d7)