### PR TITLE
Fix gantt typings and stabilize related tests

### DIFF
--- a/src/components/FeatureIntroAlert.tsx
+++ b/src/components/FeatureIntroAlert.tsx
@@ -11,11 +11,15 @@ interface FeatureIntroAlertProps {
 }
 
 export function FeatureIntroAlert({ features, onDismiss }: FeatureIntroAlertProps) {
+  if (!features || features.length === 0) {
+    return null;
+  }
+
   return (
     <Alert variant="info" dismissible onClose={onDismiss} className="rounded-0 mb-0 border-start-0 border-end-0">
       <strong>New since your last visit:</strong>{" "}
       {features.map((f, i) => (
-        <span key={f.name}>
+        <span key={`${f.name}-${i}`}>
           {i > 0 && " · "}
           <strong>{f.name}</strong> — {f.detail}
         </span>

--- a/src/types/frappe-gantt.d.ts
+++ b/src/types/frappe-gantt.d.ts
@@ -17,10 +17,23 @@ declare module "frappe-gantt" {
     on_progress_change?: (task: GanttTaskLike, progress: number) => void;
   }
 
+  export type GanttViewModeName = NonNullable<GanttOptions["view_mode"]>;
+
+  export interface GanttViewMode {
+    name: string;
+    step?: string;
+    padding?: string;
+    lower_text?: string;
+    upper_text?: string;
+    upper_text_frequency?: number;
+    thick_line?: string;
+    date_format?: string;
+  }
+
   export class Gantt {
     constructor(wrapper: string | Element, tasks: GanttTaskLike[], options?: GanttOptions);
     refresh(tasks: GanttTaskLike[]): void;
-    change_view_mode(mode: GanttOptions["view_mode"], maintain_pos?: boolean): void;
+    change_view_mode(mode: GanttViewModeName | GanttViewMode, maintain_pos?: boolean): void;
     update_options(options: GanttOptions): void;
   }
 

--- a/tests/components/gantt/GanttChart.test.tsx
+++ b/tests/components/gantt/GanttChart.test.tsx
@@ -69,7 +69,7 @@ describe("GanttChart", () => {
     const [instance] = mockInstances;
 
     instance.options.on_click?.(undefined);
-    instance.options.on_date_change?.(null, new Date("2026-03-02"), new Date("2026-03-04"));
+    instance.options.on_date_change?.(null, new Date(2026, 2, 2), new Date(2026, 2, 4));
     instance.options.on_progress_change?.({ id: "" }, 50);
 
     expect(onTaskClick).not.toHaveBeenCalled();
@@ -102,8 +102,8 @@ describe("GanttChart", () => {
     instance.options.on_click?.({ id: " task-1 " });
     instance.options.on_date_change?.(
       { id: " task-1 " },
-      new Date("2026-03-02"),
-      new Date("2026-03-04"),
+      new Date(2026, 2, 2),
+      new Date(2026, 2, 4),
     );
     instance.options.on_progress_change?.({ id: " task-1 " }, 75);
 
@@ -162,8 +162,8 @@ describe("GanttChart", () => {
     instance.options.on_click?.({ id: "task-1" });
     instance.options.on_date_change?.(
       { id: "task-1" },
-      new Date("2026-03-02"),
-      new Date("2026-03-04"),
+      new Date(2026, 2, 2),
+      new Date(2026, 2, 4),
     );
     instance.options.on_progress_change?.({ id: "task-1" }, 75);
 

--- a/tests/components/gantt/GanttView.test.tsx
+++ b/tests/components/gantt/GanttView.test.tsx
@@ -164,6 +164,7 @@ describe("GanttView", () => {
 
     expect(screen.getByTestId("mock-view-mode")).toHaveTextContent("Day");
     expect(screen.queryByRole("button", { name: "Day" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Week" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Month" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Year" })).not.toBeInTheDocument();
   });


### PR DESCRIPTION
### Motivation

- Ensure the TypeScript declarations for the `frappe-gantt` wrapper match the runtime API so `change_view_mode` can accept both named view modes and object-based custom modes. 
- Prevent the `FeatureIntroAlert` UI from rendering empty chrome when no features are present and avoid React key collisions. 
- Make Gantt-related tests timezone-agnostic and add a missing assertion to avoid flaky failures across locales.

### Description

- Extended the `frappe-gantt` typings by adding `GanttViewModeName` and `GanttViewMode` and changed `change_view_mode` to accept `GanttViewModeName | GanttViewMode` while keeping `maintain_pos?: boolean` and `update_options(options: GanttOptions)` unchanged (`src/types/frappe-gantt.d.ts`).
- Updated `FeatureIntroAlert` to early-return `null` when `features` is falsy or empty and changed the mapped key to a collision-safe string `
`${f.name}-${i}`` to avoid duplicate React keys (`src/components/FeatureIntroAlert.tsx`).
- Stabilized tests in `tests/components/gantt/GanttChart.test.tsx` by replacing `new Date("YYYY-MM-DD")` with local-time constructors like `new Date(2026, 2, 2)` at the callback sites so assertions comparing local date strings are stable; left `on_progress_change` calls intact.
- Added the missing assertion in `tests/components/gantt/GanttView.test.tsx` to assert the `Week` top-level mode button is not present, covering all mode options and preventing duplicate top-level button regressions.

### Testing

- Ran `npm run test -- tests/components/gantt/GanttChart.test.tsx tests/components/gantt/GanttView.test.tsx` and both test files passed (all tests green).
- Ran `npm run lint` and the linter completed with zero warnings/errors.
- Ran `npm run build` which failed in this environment due to pre-existing missing `react-select` module/type declarations unrelated to these changes, so build failure is not caused by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36a265b38832eaee4b5c033a01e06)