### PR TITLE
Fix sync field-clearing semantics and stabilize since-based pull test

### DIFF
--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -64,7 +64,7 @@ def _utc(dt: datetime) -> datetime:
 
     SQLite stores datetimes without timezone information.  SQLAlchemy returns
     them as naive ``datetime`` objects.  Client-side timestamps are
-    timezone-aware (ISO 8601 with ``+00:00``).  This helper normalises both
+    timezone-aware (ISO 8601 with ``+00:00``).  This helper normalizes both
     ends so comparisons work correctly.
     """
     if dt.tzinfo is None:
@@ -185,15 +185,16 @@ def _push_task(
             server_updated_at=task.updated_at,
             conflict_reason="server version is newer",
         )
-    if item.text is not None:
+    provided_fields = getattr(item, "model_fields_set", getattr(item, "__fields_set__", set()))
+    if "text" in provided_fields:
         task.text = item.text
-    if item.label_id is not None:
+    if "label_id" in provided_fields:
         task.label_id = item.label_id
-    if item.start_time is not None:
+    if "start_time" in provided_fields:
         task.start_time = item.start_time
-    if item.stop_time is not None:
+    if "stop_time" in provided_fields:
         task.stop_time = item.stop_time
-    if item.includes_break is not None:
+    if "includes_break" in provided_fields:
         task.includes_break = item.includes_break
     if task.deleted_at is not None:
         task.deleted_at = None

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import time
 from uuid import uuid4
 
 import pytest
@@ -123,6 +124,7 @@ class TestSyncPull:
             headers=headers,
         )
         since = datetime.now(timezone.utc).isoformat()
+        time.sleep(0.01)
         db_client.post(
             f"/v1/db/time-tracking/labels?user_id={user_id}",
             json={"name": "After", "color": "#223344"},


### PR DESCRIPTION
### Motivation
- Ensure sync update behavior allows clients to explicitly clear nullable fields (e.g., `label_id`, `stop_time`) instead of silently skipping None assignments.
- Use American English spelling in the UTC helper docstring for consistency.
- Make the `since`-based pull test deterministic to avoid timing-related flakes.

### Description
- Change `_utc` docstring wording from "normalises" to American English "normalizes" in `backend/app/services/sync_service.py`.
- Update `_push_task` update logic to inspect which fields the client actually provided (`model_fields_set` or `__fields_set__`) and assign those fields (including explicit `null`) so clients can clear optional fields, in `backend/app/services/sync_service.py`.
- Stabilize `test_pull_respects_since_parameter` by adding a short `time.sleep(0.01)` after capturing `since` and add the `time` import in `backend/tests/test_sync.py`.

### Testing
- Ran targeted backend sync tests with `PYTHONPATH=. pytest -q tests/test_sync.py`, and the suite completed successfully with `16 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af0743d904832e8fbcd7d9c0b77ed6)