### PR TITLE
Harden AuthContext token expiry and validation race handling

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -116,7 +116,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return stored !== null && Date.now() < stored.expiresAt - 60_000;
   });
   const currentTokenRef = useRef<string | null>(token);
-  currentTokenRef.current = token;
+
+  const clearAuthState = useCallback(() => {
+    currentTokenRef.current = null;
+    clearStoredAuth();
+    setToken(null);
+    setUserId(null);
+    setDisplayName(null);
+    setExpiresAt(null);
+  }, []);
 
   useEffect(() => {
     if (!token || expiresAt === null) {
@@ -126,25 +134,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     const timeoutMs = expiresAt - 60_000 - Date.now();
     if (timeoutMs <= 0) {
+      clearAuthState();
       setIsAuthenticated(false);
       return;
     }
 
     setIsAuthenticated(true);
     const timeoutId = window.setTimeout(() => {
+      clearAuthState();
       setIsAuthenticated(false);
     }, timeoutMs);
 
     return () => window.clearTimeout(timeoutId);
-  }, [token, expiresAt]);
-
-  const clearAuthState = useCallback(() => {
-    clearStoredAuth();
-    setToken(null);
-    setUserId(null);
-    setDisplayName(null);
-    setExpiresAt(null);
-  }, []);
+  }, [token, expiresAt, clearAuthState]);
 
   /**
    * When the backend connects, validate any stored token via GET /v1/auth/me.
@@ -182,14 +184,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
       })
       .then((user) => {
         if (!user || isStaleRequest()) return;
+        currentTokenRef.current = stored.token;
         setToken(stored.token);
         setUserId(user.id);
         setDisplayName(user.display_name);
         setExpiresAt(stored.expiresAt);
       })
       .catch((error: unknown) => {
-        if (isStaleRequest()) return;
-        if (error instanceof Error && error.name === "AbortError") return;
+        if (isStaleRequest()) {
+          setIsValidating(false);
+          return;
+        }
+        if (error instanceof Error && error.name === "AbortError") {
+          setIsValidating(false);
+          return;
+        }
         clearAuthState();
         setShowLoginModal(true);
       })
@@ -247,6 +256,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         expiresAt: newExpiresAt,
       });
 
+      currentTokenRef.current = tokenData.access_token;
       setToken(tokenData.access_token);
       setUserId(user.id);
       setDisplayName(user.display_name);

--- a/tests/contexts/AuthContext.test.tsx
+++ b/tests/contexts/AuthContext.test.tsx
@@ -36,20 +36,21 @@ function AuthActions() {
 interface RenderOptions {
   enabled?: boolean;
   connectionStatus?: "disconnected" | "connecting" | "connected" | "error";
+  autoConnect?: boolean;
 }
 
 function renderWithProviders(ui: React.ReactElement, options: RenderOptions = {}) {
-  const { enabled, connectionStatus } = options;
+  const { enabled, connectionStatus, autoConnect } = options;
 
-  if (enabled !== undefined || connectionStatus !== undefined) {
-    sessionStorage.setItem(
+  if (enabled !== undefined || connectionStatus !== undefined || autoConnect !== undefined) {
+    localStorage.setItem(
       DEVELOPER_OPTIONS_STORAGE_KEY,
       JSON.stringify({
         enabled: enabled ?? false,
         apiUrl: "http://localhost:8000",
         connectionStatus: connectionStatus ?? "disconnected",
         lastConnectionTest: null,
-        autoConnect: false,
+        autoConnect: autoConnect ?? false,
         isDevMode: false,
       }),
     );
@@ -67,11 +68,13 @@ function renderWithProviders(ui: React.ReactElement, options: RenderOptions = {}
 describe("AuthContext", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    localStorage.clear();
     vi.restoreAllMocks();
   });
 
   afterEach(() => {
     sessionStorage.clear();
+    localStorage.clear();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -89,8 +92,30 @@ describe("AuthContext", () => {
       expect(screen.getByTestId("show-login-modal")).toHaveTextContent("false");
     });
 
-    it("loads valid token from sessionStorage", () => {
+    it("loads valid token from sessionStorage", async () => {
       const expiresAt = Date.now() + 3_600_000;
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/v1/health")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ status: "ok" }),
+          };
+        }
+
+        if (url.endsWith("/v1/auth/me")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ id: 7, display_name: "Bob" }),
+          };
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
       sessionStorage.setItem(
         "worktime_auth",
         JSON.stringify({
@@ -100,7 +125,17 @@ describe("AuthContext", () => {
           expiresAt,
         }),
       );
-      renderWithProviders(<AuthStatusDisplay />, { enabled: true, connectionStatus: "connected" });
+      renderWithProviders(<AuthStatusDisplay />, { enabled: true, connectionStatus: "connected", autoConnect: true });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith("http://localhost:8000/v1/auth/me", {
+          headers: {
+            Authorization: "Bearer stored-token",
+            Accept: "application/json",
+          },
+          signal: expect.any(AbortSignal),
+        });
+      });
       expect(screen.getByTestId("is-authenticated")).toHaveTextContent("true");
       expect(screen.getByTestId("user-id")).toHaveTextContent("7");
       expect(screen.getByTestId("display-name")).toHaveTextContent("Bob");


### PR DESCRIPTION
### Motivation
- Prevent a stale `isAuthenticated` = true from persisting after the expiry threshold (`expiresAt - 60_000`) is reached so requests stop using an expired JWT.  
- Avoid races where an in-flight `/v1/auth/me` validation (or an aborted request) can overwrite newer login/logout state.  
- Make tests exercise mount-time validation paths and avoid leaking global stubs between tests.

### Description
- Replace the computed `isAuthenticated` `useMemo` with a stateful `isAuthenticated` and schedule a timeout based on `expiresAt - 60_000` to flip authentication when the threshold is hit.  
- Track the current token in a `ref` and capture the `requestToken` for the `/v1/auth/me` call, adding an `isStaleRequest` check that bails out of `.then/.catch/.finally` handlers when the request is aborted or the token has changed.  
- Treat `AbortError` and stale responses as non-fatal (do not clear auth state) and only clear auth state / show the login modal when an active, non-aborted validation truly failed.  
- Update tests in `tests/contexts/AuthContext.test.tsx` to add an optional `renderWithProviders` `options` parameter that seeds `DEVELOPER_OPTIONS_STORAGE_KEY`, run stored-token tests with `{ enabled: true, connectionStatus: "connected" }` so mount-time validation runs, and call `vi.unstubAllGlobals()` in `afterEach` to remove global stubs like `fetch`.

### Testing
- Ran lint with `npm run lint` and fixed the warning so `oxlint` reports no warnings or errors. (passed)  
- Ran the targeted test file with `npm run test -- tests/contexts/AuthContext.test.tsx` and all tests passed. (13 tests passed)  
- Verified the modified files are `src/contexts/AuthContext.tsx` and `tests/contexts/AuthContext.test.tsx` and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af32f0f618832e97b672859acc30f7)