### PR TITLE
Align auth path documentation with infra routing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -170,11 +170,17 @@ DATABASE_ECHO=false
 # SUPERTOKENS_API_BASE_PATH: Path prefix for SuperTokens API routes.
 #   - Local development default: /auth
 #   - Standard setup: keep this on /auth
+#   - If you mount the backend under an extra public prefix via a proxy,
+#     the effective public auth path includes that prefix. Example:
+#     backend mounted under /api -> public auth API path /api/auth/*
 #
 # SUPERTOKENS_WEBSITE_BASE_PATH: Path prefix for the frontend auth UI routes.
 #   - Local development default: /auth
 #   - Standard setup: keep this on /auth as well
 #   - The dashboard then lives under /auth/dashboard
+#   - If the backend is mounted under an extra public prefix, the public UI path
+#     is prefixed too. Example: backend under /api -> public auth UI at
+#     /api/auth and dashboard at /api/auth/dashboard
 #
 SUPERTOKENS_CONNECTION_URI=http://localhost:3567
 SUPERTOKENS_API_KEY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -168,8 +168,8 @@ DATABASE_ECHO=false
 #   - Production: https://worktime.example.com
 #
 # SUPERTOKENS_API_BASE_PATH: Path prefix for SuperTokens API routes.
-#   - Default: /auth
-#   - Change if the auth endpoints are served under a different prefix.
+#   - Local development default: /auth
+#   - Shared production infra: /api/auth
 #
 SUPERTOKENS_CONNECTION_URI=http://localhost:3567
 SUPERTOKENS_API_KEY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -169,13 +169,19 @@ DATABASE_ECHO=false
 #
 # SUPERTOKENS_API_BASE_PATH: Path prefix for SuperTokens API routes.
 #   - Local development default: /auth
-#   - Shared production infra: /api/auth
+#   - Standard setup: keep this on /auth
+#
+# SUPERTOKENS_WEBSITE_BASE_PATH: Path prefix for the frontend auth UI routes.
+#   - Local development default: /auth
+#   - Standard setup: keep this on /auth as well
+#   - The dashboard then lives under /auth/dashboard
 #
 SUPERTOKENS_CONNECTION_URI=http://localhost:3567
 SUPERTOKENS_API_KEY=
 SUPERTOKENS_API_DOMAIN=http://localhost:8000
 SUPERTOKENS_WEBSITE_DOMAIN=http://localhost:5173
 SUPERTOKENS_API_BASE_PATH=/auth
+SUPERTOKENS_WEBSITE_BASE_PATH=/auth
 
 # -----------------------------------------------------------------------------
 # Admin Users

--- a/backend/BACKEND_GUIDE.md
+++ b/backend/BACKEND_GUIDE.md
@@ -19,7 +19,11 @@ The service is built with FastAPI and currently combines:
 - in-memory caching for file-backed operations
 - a non-production debug benchmark endpoint
 
-There is no `/v1` prefix. Current routes live directly under `/health`, `/hday/*`, `/team/*`, `/db/*`, `/auth/*`, and `/debug/*`.
+There is no `/v1` prefix. Current routes live directly under `/health`, `/hday/*`, `/team/*`, `/db/*`, and `/debug/*`.
+SuperTokens auth uses:
+
+- local development default: `/auth/*`
+- shared production infra: `/api/auth/*`
 
 ## Runtime Shape
 
@@ -39,7 +43,7 @@ The app always exposes:
 - `GET /health`
 - `.hday` file endpoints
 - team endpoints
-- SuperTokens auth endpoints under `/auth/*`
+- SuperTokens auth endpoints under the configured API base path
 
 The app conditionally exposes:
 
@@ -69,9 +73,10 @@ Team metadata is read from `config/{team_id}.conf` and `config/{team_id}.people`
 
 ### Auth routes
 
-SuperTokens mounts its own auth/session routes under:
+SuperTokens mounts its own auth/session routes under the configured API base path:
 
-- `/auth/*`
+- local development default: `/auth/*`
+- shared production infra: `/api/auth/*`
 
 The backend uses those sessions for database-backed endpoints.
 
@@ -170,7 +175,8 @@ Current configuration lives in:
 Important points:
 
 - the backend talks to a self-hosted SuperTokens core
-- auth/session routes live under `/auth`
+- auth/session routes live under `SUPERTOKENS_API_BASE_PATH`
+- in the shared production infra, the backend auth API is `/api/auth` while the frontend auth UI remains `/auth`
 - DB endpoints depend on authenticated sessions
 - production requires `SUPERTOKENS_API_KEY`
 - user creation, rename, and deletion must stay consistent between the local DB and SuperTokens

--- a/backend/BACKEND_GUIDE.md
+++ b/backend/BACKEND_GUIDE.md
@@ -22,8 +22,8 @@ The service is built with FastAPI and currently combines:
 There is no `/v1` prefix. All backend routers are mounted under `/api`, so the effective route groups are `/api/health`, `/api/hday/*`, `/api/team/*`, `/api/users/*`, `/api/time-tracking/*`, `/api/work-locations/*`, `/api/gantt-tasks/*`, `/api/sync/*`, `/api/preferences`, `/api/time-off/*`, `/api/me`, and `/api/debug/*`.
 SuperTokens auth uses:
 
-- local development default: `/auth/*`
-- recommended shared path when the backend also serves the dashboard: `/auth/*`
+- internal SuperTokens base path: `/auth/*`
+- public shared-host path in this repo: `/auth/*`
 
 ## Runtime Shape
 
@@ -75,8 +75,12 @@ Team metadata is read from `config/{team_id}.conf` and `config/{team_id}.people`
 
 SuperTokens mounts its own auth/session routes under the configured API base path:
 
-- local development default: `/auth/*`
-- recommended shared path when the backend also serves the dashboard: `/auth/*`
+- internal SuperTokens base path: `/auth/*`
+- public shared-host path in this repo: `/auth/*`
+
+In this deployment, `SUPERTOKENS_API_BASE_PATH=/auth` and Caddy forwards `/auth*`
+directly to `worktime-api`, so the internal base path and the effective public path
+are the same.
 
 The backend uses those sessions for database-backed endpoints.
 

--- a/backend/BACKEND_GUIDE.md
+++ b/backend/BACKEND_GUIDE.md
@@ -19,11 +19,11 @@ The service is built with FastAPI and currently combines:
 - in-memory caching for file-backed operations
 - a non-production debug benchmark endpoint
 
-There is no `/v1` prefix. Current routes live directly under `/health`, `/hday/*`, `/team/*`, `/db/*`, and `/debug/*`.
+There is no `/v1` prefix. All backend routers are mounted under `/api`, so the effective route groups are `/api/health`, `/api/hday/*`, `/api/team/*`, `/api/users/*`, `/api/time-tracking/*`, `/api/work-locations/*`, `/api/gantt-tasks/*`, `/api/sync/*`, `/api/preferences`, `/api/time-off/*`, `/api/me`, and `/api/debug/*`.
 SuperTokens auth uses:
 
 - local development default: `/auth/*`
-- shared production infra: `/api/auth/*`
+- recommended shared path when the backend also serves the dashboard: `/auth/*`
 
 ## Runtime Shape
 
@@ -40,34 +40,34 @@ At startup, [main.py](app/main.py):
 The app always exposes:
 
 - `GET /`
-- `GET /health`
+- `GET /api/health`
 - `.hday` file endpoints
 - team endpoints
 - SuperTokens auth endpoints under the configured API base path
 
 The app conditionally exposes:
 
-- database-backed routes under `/db/*` when `DATABASE_ENABLED=true`
-- `/debug/benchmark` when `ENVIRONMENT != production`
+- database-backed routes under `/api/users/*`, `/api/time-tracking/*`, `/api/work-locations/*`, `/api/gantt-tasks/*`, `/api/sync/*`, `/api/preferences`, `/api/time-off/*`, and `/api/me` when `DATABASE_ENABLED=true`
+- `/api/debug/benchmark` when `ENVIRONMENT != production`
 
 ## Route Groups
 
 ### Core routes
 
 - `GET /` returns the API title and version
-- `GET /health` verifies share-directory accessibility and returns JSON health status
+- `GET /api/health` verifies share-directory accessibility and returns JSON health status
 
 ### Shared `.hday` routes
 
-- `GET /hday/{username}`
-- `PUT /hday/{username}`
+- `GET /api/hday/{username}`
+- `PUT /api/hday/{username}`
 
 These endpoints read and write `.hday` files in the share root and use ETags for optimistic concurrency on writes.
 
 ### Team routes
 
-- `GET /team/{team_id}`
-- `GET /team/{team_id}/hday`
+- `GET /api/team/{team_id}`
+- `GET /api/team/{team_id}/hday`
 
 Team metadata is read from `config/{team_id}.conf` and `config/{team_id}.people` under the share directory.
 
@@ -76,24 +76,24 @@ Team metadata is read from `config/{team_id}.conf` and `config/{team_id}.people`
 SuperTokens mounts its own auth/session routes under the configured API base path:
 
 - local development default: `/auth/*`
-- shared production infra: `/api/auth/*`
+- recommended shared path when the backend also serves the dashboard: `/auth/*`
 
 The backend uses those sessions for database-backed endpoints.
 
 ### Database user routes
 
-- `POST /db/users/`
-- `GET /db/users/`
-- `GET /db/users/{user_id}`
-- `GET /db/users/by-username/{username}`
-- `PUT /db/users/{user_id}`
-- `DELETE /db/users/{user_id}`
+- `POST /api/users/`
+- `GET /api/users/`
+- `GET /api/users/{user_id}`
+- `GET /api/users/by-username/{username}`
+- `PUT /api/users/{user_id}`
+- `DELETE /api/users/{user_id}`
 
 These routes manage app users and keep local users aligned with SuperTokens identities.
 
 ### Database time-tracking routes
 
-Under `/db/time-tracking`:
+Under `/api/time-tracking`:
 
 - label CRUD under `/labels`
 - task CRUD under `/tasks`
@@ -102,7 +102,7 @@ Under `/db/time-tracking`:
 
 ### Database work-location routes
 
-Under `/db/work-locations`:
+Under `/api/work-locations`:
 
 - `POST /`
 - `GET /`
@@ -111,7 +111,7 @@ Under `/db/work-locations`:
 
 ### Database Gantt routes
 
-Under `/db/gantt-tasks`:
+Under `/api/gantt-tasks`:
 
 - `POST`
 - `GET`
@@ -121,17 +121,34 @@ Under `/db/gantt-tasks`:
 
 ### Database sync routes
 
-Under `/db/sync`:
+Under `/api/sync`:
 
 - `POST /push`
 - `GET /pull`
 - `GET /status`
 
+### Database preferences route
+
+- `GET /api/preferences`
+- `PUT /api/preferences`
+
+### Database time-off routes
+
+- `POST /api/time-off/`
+- `GET /api/time-off/`
+- `GET /api/time-off/{entry_id}`
+- `PATCH /api/time-off/{entry_id}`
+- `DELETE /api/time-off/{entry_id}`
+
+### Account route
+
+- `GET /api/me`
+
 ### Debug routes
 
 In non-production only:
 
-- `GET /debug/benchmark`
+- `GET /api/debug/benchmark`
 
 ## Storage Model
 
@@ -176,7 +193,8 @@ Important points:
 
 - the backend talks to a self-hosted SuperTokens core
 - auth/session routes live under `SUPERTOKENS_API_BASE_PATH`
-- in the shared production infra, the backend auth API is `/api/auth` while the frontend auth UI remains `/auth`
+- the standard SuperTokens setup uses `/auth` for both the frontend auth UI and the backend auth APIs
+- the dashboard then lives at `/auth/dashboard`
 - DB endpoints depend on authenticated sessions
 - production requires `SUPERTOKENS_API_KEY`
 - user creation, rename, and deletion must stay consistent between the local DB and SuperTokens
@@ -254,7 +272,7 @@ Current Docker characteristics:
 - dependency installation via `uv`
 - runtime data directory rooted at `/var/data/worktime`
 - default `SHARE_DIR=/var/data/worktime/hday_files`
-- healthcheck against `GET /health`
+- healthcheck against `GET /api/health`
 - non-root runtime user
 
 ## Testing

--- a/backend/QUICKSTART.md
+++ b/backend/QUICKSTART.md
@@ -61,7 +61,7 @@ uv run python -m app.main
 
 ## API Endpoints
 
-- **GET /health** - Health check endpoint
+- **GET /api/health** - Health check endpoint
 - **GET /** - API information (title and version)
 - **GET /docs** - Interactive API documentation (Swagger UI)
 - **GET /redoc** - Alternative API documentation (ReDoc)
@@ -138,7 +138,7 @@ Cache:           enabled (TTL: 10s)
 Health check:
 
 ```bash
-curl http://localhost:8000/health
+curl http://localhost:8000/api/health
 ```
 
 API information:

--- a/backend/README.md
+++ b/backend/README.md
@@ -82,9 +82,9 @@ The shared directory is expected to look like this:
 
 - File/share endpoints: `/api/hday/*`, `/api/team/*`, `/api/health`
 - Auth endpoints:
-  - local development default: `/auth/*`
-  - recommended shared path when the backend also serves the dashboard: `/auth/*`
-- Registration endpoint (public): `POST /users/register`
+  - internal SuperTokens base path: `/auth/*`
+  - public shared-host path in this repo: `/auth/*`
+- Registration endpoint (public): `POST /api/users/register`
 - Database endpoints: `/api/users/*`, `/api/time-tracking/*`, `/api/work-locations/*`, `/api/gantt-tasks/*`, `/api/sync/*`, `/api/preferences`, `/api/time-off/*`, `/api/me`
 - Debug endpoint in non-production only: `/api/debug/benchmark`
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -81,7 +81,9 @@ The shared directory is expected to look like this:
 ## API Groups
 
 - File/share endpoints: `/hday/*`, `/team/*`, `/health`
-- Auth endpoints: `/auth/*`
+- Auth endpoints:
+  - local development default: `/auth/*`
+  - shared production infra: `/api/auth/*`
 - Registration endpoint (public): `POST /users/register`
 - Database endpoints: `/db/users/*`, `/db/time-tracking/*`, `/db/work-locations/*`, `/db/gantt-tasks/*`, `/db/sync/*`
 - Debug endpoint in non-production only: `/debug/benchmark`

--- a/backend/README.md
+++ b/backend/README.md
@@ -80,13 +80,13 @@ The shared directory is expected to look like this:
 
 ## API Groups
 
-- File/share endpoints: `/hday/*`, `/team/*`, `/health`
+- File/share endpoints: `/api/hday/*`, `/api/team/*`, `/api/health`
 - Auth endpoints:
   - local development default: `/auth/*`
-  - shared production infra: `/api/auth/*`
+  - recommended shared path when the backend also serves the dashboard: `/auth/*`
 - Registration endpoint (public): `POST /users/register`
-- Database endpoints: `/db/users/*`, `/db/time-tracking/*`, `/db/work-locations/*`, `/db/gantt-tasks/*`, `/db/sync/*`
-- Debug endpoint in non-production only: `/debug/benchmark`
+- Database endpoints: `/api/users/*`, `/api/time-tracking/*`, `/api/work-locations/*`, `/api/gantt-tasks/*`, `/api/sync/*`, `/api/preferences`, `/api/time-off/*`, `/api/me`
+- Debug endpoint in non-production only: `/api/debug/benchmark`
 
 Use `/docs` or `/redoc` for the full OpenAPI view while the server is running.
 

--- a/backend/app/config/supertokens_config.py
+++ b/backend/app/config/supertokens_config.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 
 from sqlalchemy import select
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.recipe import emailpassword, session
+from supertokens_python.recipe import dashboard, emailpassword, session
 from supertokens_python.recipe.session.interfaces import (
     RecipeInterface as SessionRecipeInterface,
 )
@@ -137,6 +137,7 @@ def init_supertokens() -> None:
                     functions=_override_session_functions,
                 ),
             ),
+            dashboard.init(api_key=api_key),
         ],
         mode="asgi",
     )

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -28,6 +28,7 @@ def test_default_settings():
     assert settings.SUPERTOKENS_API_DOMAIN == "http://localhost:8000"
     assert settings.SUPERTOKENS_WEBSITE_DOMAIN == "http://localhost:5173"
     assert settings.SUPERTOKENS_API_BASE_PATH == "/auth"
+    assert settings.SUPERTOKENS_WEBSITE_BASE_PATH == "/auth"
 
 
 def test_custom_settings():
@@ -204,6 +205,7 @@ def test_supertokens_defaults() -> None:
     assert settings.SUPERTOKENS_API_DOMAIN == "http://localhost:8000"
     assert settings.SUPERTOKENS_WEBSITE_DOMAIN == "http://localhost:5173"
     assert settings.SUPERTOKENS_API_BASE_PATH == "/auth"
+    assert settings.SUPERTOKENS_WEBSITE_BASE_PATH == "/auth"
 
 
 def test_supertokens_custom_values() -> None:
@@ -214,9 +216,11 @@ def test_supertokens_custom_values() -> None:
         SUPERTOKENS_API_DOMAIN="https://api.example.com",
         SUPERTOKENS_WEBSITE_DOMAIN="https://worktime.example.com",
         SUPERTOKENS_API_BASE_PATH="/custom-auth",
+        SUPERTOKENS_WEBSITE_BASE_PATH="/signin",
     )
     assert settings.SUPERTOKENS_CONNECTION_URI == "http://supertokens:3567"
     assert settings.SUPERTOKENS_API_KEY == "my-api-key"
     assert settings.SUPERTOKENS_API_DOMAIN == "https://api.example.com"
     assert settings.SUPERTOKENS_WEBSITE_DOMAIN == "https://worktime.example.com"
     assert settings.SUPERTOKENS_API_BASE_PATH == "/custom-auth"
+    assert settings.SUPERTOKENS_WEBSITE_BASE_PATH == "/signin"

--- a/backend/tests/test_supertokens_config.py
+++ b/backend/tests/test_supertokens_config.py
@@ -42,6 +42,8 @@ def test_init_supertokens_registers_dashboard_recipe(monkeypatch) -> None:
 
     assert recorded["framework"] == "fastapi"
     assert recorded["mode"] == "asgi"
+    assert recorded["app_info"].api_base_path == "/auth"
+    assert recorded["app_info"].website_base_path == "/auth"
     assert recorded["dashboard_api_key"] == "worktime-api-key"
     assert recorded["session_override"] is sentinel.override_config
     assert recorded["recipe_list"] == [

--- a/backend/tests/test_supertokens_config.py
+++ b/backend/tests/test_supertokens_config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import sentinel
+
+from app.config import supertokens_config as st_config
+
+
+def test_init_supertokens_registers_dashboard_recipe(monkeypatch) -> None:
+    recorded: dict[str, object] = {}
+    dashboard_recipe = object()
+    emailpassword_recipe = object()
+    session_recipe = object()
+
+    monkeypatch.setattr(st_config.settings, "SUPERTOKENS_CONNECTION_URI", "http://supertokens-worktime:3567")
+    monkeypatch.setattr(st_config.settings, "SUPERTOKENS_API_KEY", "worktime-api-key")
+    monkeypatch.setattr(st_config.settings, "SUPERTOKENS_API_DOMAIN", "https://worktime.tjor.im")
+    monkeypatch.setattr(st_config.settings, "SUPERTOKENS_WEBSITE_DOMAIN", "https://worktime.tjor.im")
+    monkeypatch.setattr(st_config.settings, "SUPERTOKENS_API_BASE_PATH", "/auth")
+    monkeypatch.setattr(st_config.settings, "SUPERTOKENS_WEBSITE_BASE_PATH", "/auth")
+
+    def fake_init(**kwargs):
+        recorded.update(kwargs)
+
+    def fake_emailpassword_init():
+        return emailpassword_recipe
+
+    def fake_session_init(*, override):
+        recorded["session_override"] = override
+        return session_recipe
+
+    def fake_dashboard_init(*, api_key):
+        recorded["dashboard_api_key"] = api_key
+        return dashboard_recipe
+
+    monkeypatch.setattr(st_config, "init", fake_init)
+    monkeypatch.setattr(st_config.emailpassword, "init", fake_emailpassword_init)
+    monkeypatch.setattr(st_config.session, "init", fake_session_init)
+    monkeypatch.setattr(st_config.dashboard, "init", fake_dashboard_init)
+    monkeypatch.setattr(st_config.session, "InputOverrideConfig", lambda *, functions: sentinel.override_config)
+
+    st_config.init_supertokens()
+
+    assert recorded["framework"] == "fastapi"
+    assert recorded["mode"] == "asgi"
+    assert recorded["dashboard_api_key"] == "worktime-api-key"
+    assert recorded["session_override"] is sentinel.override_config
+    assert recorded["recipe_list"] == [
+        emailpassword_recipe,
+        session_recipe,
+        dashboard_recipe,
+    ]

--- a/infra/worktime.env.example
+++ b/infra/worktime.env.example
@@ -60,8 +60,9 @@ SUPERTOKENS_API_DOMAIN=https://worktime.tjor.im
 SUPERTOKENS_WEBSITE_DOMAIN=https://worktime.tjor.im
 
 # Path prefix for SuperTokens API routes in production.
-# Keep this on /api/auth so the frontend SPA can own /auth.
-SUPERTOKENS_API_BASE_PATH=/api/auth
+# Keep this on /auth to follow the standard SuperTokens setup.
+SUPERTOKENS_API_BASE_PATH=/auth
 
 # Path prefix for SuperTokens frontend routes on the website domain.
+# Keep this on /auth as well; the dashboard then lives at /auth/dashboard.
 SUPERTOKENS_WEBSITE_BASE_PATH=/auth

--- a/infra/worktime.env.example
+++ b/infra/worktime.env.example
@@ -59,8 +59,9 @@ SUPERTOKENS_API_DOMAIN=https://worktime.tjor.im
 # Public URL of the frontend (used for cookie domain / redirect URLs).
 SUPERTOKENS_WEBSITE_DOMAIN=https://worktime.tjor.im
 
-# Path prefix for SuperTokens API routes (default: /v1/auth).
-SUPERTOKENS_API_BASE_PATH=/v1/auth
+# Path prefix for SuperTokens API routes in production.
+# Keep this on /api/auth so the frontend SPA can own /auth.
+SUPERTOKENS_API_BASE_PATH=/api/auth
 
-# Path prefix for SuperTokens frontend routes on the website domain (default: /auth).
+# Path prefix for SuperTokens frontend routes on the website domain.
 SUPERTOKENS_WEBSITE_BASE_PATH=/auth


### PR DESCRIPTION
## Summary
- document the production split between frontend auth UI (`/auth`) and backend SuperTokens API (`/api/auth`)
- update backend and infra env examples to match the shared VPS routing
- clarify the production auth-path behavior in the backend docs

## Context
The shared infra stack keeps the Worktime SPA auth UI on `/auth`, but routes the backend SuperTokens API through `/api/auth` to avoid path collisions on the same host.
