### PR TITLE
feat(frontend): upgrade to TypeScript 7 via @typescript/native-preview

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,9 +26,9 @@
   "scripts": {
     "dev": "vite",
     "dev:playwright:start": "vite --host 0.0.0.0 --port 4173",
-    "build": "pnpm paraglide:compile && tsc -b && vite build",
+    "build": "pnpm paraglide:compile && tsgo -b && vite build",
     "preview": "vite preview",
-    "typecheck": "pnpm paraglide:compile && tsc -b --noEmit",
+    "typecheck": "pnpm paraglide:compile && tsgo -b --noEmit",
     "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations",
     "lint": "oxlint",
     "format": "oxfmt .",
@@ -79,7 +79,8 @@
     "sass": "^1.99.0",
     "terser": "^5.46.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.2",
+    "@typescript/native-preview": "beta",
+    "typescript": "^6.0.3",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev": "vite",
     "dev:playwright:start": "vite --host 0.0.0.0 --port 4173",
-    "build": "pnpm paraglide:compile && tsgo -b && vite build",
+    "build": "pnpm paraglide:compile && tsgo -b --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "pnpm paraglide:compile && tsgo -b --noEmit",
     "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations",
@@ -79,7 +79,7 @@
     "sass": "^1.99.0",
     "terser": "^5.46.0",
     "tsx": "^4.21.0",
-    "@typescript/native-preview": "beta",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,7 @@
     "sass": "^1.99.0",
     "terser": "^5.46.0",
     "tsx": "^4.21.0",
-    "@typescript/native-preview": "7.0.0-dev.20260421.2",
+    "@typescript/native-preview": "beta",
     "typescript": "^6.0.3",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev": "vite",
     "dev:playwright:start": "vite --host 0.0.0.0 --port 4173",
-    "build": "pnpm paraglide:compile && tsgo -b --noEmit && vite build",
+    "build": "pnpm paraglide:compile && tsgo -b && vite build",
     "preview": "vite preview",
     "typecheck": "pnpm paraglide:compile && tsgo -b --noEmit",
     "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@tanstack/query-db-collection':
         specifier: ^1.0.36
-        version: 1.0.36(@tanstack/query-core@5.99.0)(typescript@6.0.2)
+        version: 1.0.36(@tanstack/query-core@5.99.0)(typescript@6.0.3)
       '@tanstack/react-db':
         specifier: ^0.1.83
-        version: 0.1.83(react@19.2.5)(typescript@6.0.2)
+        version: 0.1.83(react@19.2.5)(typescript@6.0.3)
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.0(react@19.2.5)
@@ -87,6 +87,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@typescript/native-preview':
+        specifier: beta
+        version: 7.0.0-dev.20260421.2
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
@@ -104,7 +107,7 @@ importers:
         version: 1.32.0
       msw:
         specifier: ^2.13.2
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.2)
+        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
       oxfmt:
         specifier: ^0.45.0
         version: 0.45.0
@@ -121,14 +124,14 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
 
 packages:
 
@@ -1095,6 +1098,45 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
+    hasBin: true
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2009,8 +2051,8 @@ packages:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
     engines: {node: '>=20'}
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2817,18 +2859,18 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tanstack/db-ivm@0.1.18(typescript@6.0.2)':
+  '@tanstack/db-ivm@0.1.18(typescript@6.0.3)':
     dependencies:
       fractional-indexing: 3.2.0
       sorted-btree: 1.8.1
-      typescript: 6.0.2
+      typescript: 6.0.3
 
-  '@tanstack/db@0.6.5(typescript@6.0.2)':
+  '@tanstack/db@0.6.5(typescript@6.0.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@tanstack/db-ivm': 0.1.18(typescript@6.0.2)
+      '@tanstack/db-ivm': 0.1.18(typescript@6.0.3)
       '@tanstack/pacer-lite': 0.2.1
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   '@tanstack/history@1.161.6': {}
 
@@ -2836,16 +2878,16 @@ snapshots:
 
   '@tanstack/query-core@5.99.0': {}
 
-  '@tanstack/query-db-collection@1.0.36(@tanstack/query-core@5.99.0)(typescript@6.0.2)':
+  '@tanstack/query-db-collection@1.0.36(@tanstack/query-core@5.99.0)(typescript@6.0.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@tanstack/db': 0.6.5(typescript@6.0.2)
+      '@tanstack/db': 0.6.5(typescript@6.0.3)
       '@tanstack/query-core': 5.99.0
-      typescript: 6.0.2
+      typescript: 6.0.3
 
-  '@tanstack/react-db@0.1.83(react@19.2.5)(typescript@6.0.2)':
+  '@tanstack/react-db@0.1.83(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@tanstack/db': 0.6.5(typescript@6.0.2)
+      '@tanstack/db': 0.6.5(typescript@6.0.3)
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
     transitivePeerDependencies:
@@ -2959,6 +3001,37 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -2973,13 +3046,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.2(@types/node@25.6.0)(typescript@6.0.2)
+      msw: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.4':
@@ -3009,7 +3082,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -3408,7 +3481,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2):
+  msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@25.6.0)
       '@mswjs/interceptors': 0.41.3
@@ -3429,7 +3502,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -3858,7 +3931,7 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
   uncontrollable@9.0.0(react@19.2.5):
     dependencies:
@@ -3908,10 +3981,10 @@ snapshots:
       terser: 5.46.1
       tsx: 4.21.0
 
-  vitest@4.1.4(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@typescript/native-preview':
-        specifier: beta
+        specifier: 7.0.0-dev.20260421.2
         version: 7.0.0-dev.20260421.2
       '@vitejs/plugin-react':
         specifier: ^6.0.1

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260421.2
+        specifier: beta
         version: 7.0.0-dev.20260421.2
       '@vitejs/plugin-react':
         specifier: ^6.0.1


### PR DESCRIPTION
## Summary

- Add `@typescript/native-preview@beta` (`7.0.0-dev.20260421.2`) — the TypeScript 7 Go-based rewrite, providing the `tsgo` CLI with ~10x faster type checking
- Keep `typescript@6` alongside it for Vite, Vitest, and IDE toolchain compatibility (per the official [TypeScript 7 upgrade guidance](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/))
- Switch `typecheck` and `build` scripts from `tsc` → `tsgo`; `tsgo` is a drop-in for `tsc` in behavior, just much faster

No tsconfig changes were needed — the project was already compatible:
- No `baseUrl` (uses `paths` directly) ✅
- `types` explicitly listed in both tsconfigs ✅
- `moduleResolution: bundler` ✅
- `target: ES2022+` ✅
- `strict: true` ✅

## Test plan

- [x] `pnpm install` — clean install
- [x] `pnpm typecheck` — passes with `tsgo` (no type errors)
- [ ] `pnpm build` — verify full build works
- [ ] `pnpm test` — verify Vitest still uses TypeScript 6 API correctly

https://claude.ai/code/session_0196NE39zyuegVibtzkMuKET