### PR TITLE
Refactor settings panel state into dedicated settings hooks

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { ChangeEvent } from "react";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
@@ -27,8 +27,9 @@ import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 import { DevOptionsPanel } from "./DevOptionsPanel";
 import { useApiClient } from "@/hooks/useApiClient";
 import { useOngoingSyncContext } from "@/contexts/OngoingSyncContext";
-import { labelsCollection, tasksCollection, templatesCollection } from "@/db/collections";
-import { dayjs } from "@/utils/dateTimeUtils";
+import { useSettingsAccount } from "@/pages/settings/hooks/useSettingsAccount";
+import { useSettingsSyncStatus } from "@/pages/settings/hooks/useSettingsSyncStatus";
+import { useSettingsResetFlow } from "@/pages/settings/hooks/useSettingsResetFlow";
 import * as m from "@/paraglide/messages.js";
 import { getLocale, setLocale } from "@/paraglide/runtime.js";
 
@@ -76,28 +77,6 @@ export type SettingsSection =
   | "data"
   | "about";
 
-interface AccountProfile {
-  id: number;
-  username: string;
-  display_name: string;
-  is_admin: boolean;
-  capabilities: {
-    backup_enabled: boolean;
-  };
-}
-
-function clearCollectionById(collection: {
-  toArray: Array<{ id: string }>;
-  has: (id: string) => boolean;
-  delete: (id: string) => void;
-}): void {
-  for (const item of [...collection.toArray]) {
-    if (collection.has(item.id)) {
-      collection.delete(item.id);
-    }
-  }
-}
-
 /**
  * Render the settings sidebar with preferences, information and quick actions.
  *
@@ -115,16 +94,8 @@ export function SettingsPanel({
 }: SettingsPanelProps) {
   const [showChangelog, setShowChangelog] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
-  const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [showDevOptions, setShowDevOptions] = useState(false);
   const [showBackupDialog, setShowBackupDialog] = useState(false);
-  const [clearTimeTrackingData, setClearTimeTrackingData] = useState(false);
-  const [clearTimeOffData, setClearTimeOffData] = useState(false);
-  const [accountProfile, setAccountProfile] = useState<AccountProfile | null>(null);
-  const [profileDraft, setProfileDraft] = useState("");
-  const [isProfileLoading, setIsProfileLoading] = useState(false);
-  const [isProfileSaving, setIsProfileSaving] = useState(false);
-  const [profileError, setProfileError] = useState<string | null>(null);
   const versionClickCountRef = useRef(0);
   const versionClickTimeoutRef = useRef<number | null>(null);
   const restoreFileInputRef = useRef<HTMLInputElement>(null);
@@ -152,137 +123,43 @@ export function SettingsPanel({
     updateOfficeCountry,
     resetSettings,
   } = useSettings();
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      setAccountProfile(null);
-      setProfileDraft("");
-      setProfileError(null);
-      setIsProfileLoading(false);
-      return;
-    }
-
-    let isCancelled = false;
-    setIsProfileLoading(true);
-    setProfileError(null);
-
-    fetchFn("/api/me")
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error(`Unexpected status: ${response.status}`);
-        }
-        const profile = (await response.json()) as AccountProfile;
-        if (isCancelled) return;
-        setAccountProfile(profile);
-        setProfileDraft(profile.display_name);
-      })
-      .catch((error) => {
-        if (isCancelled) return;
-        console.error("Failed to load account profile:", error);
-        setProfileError(m.account_profile_load_failed());
-      })
-      .finally(() => {
-        if (!isCancelled) {
-          setIsProfileLoading(false);
-        }
-      });
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [isAuthenticated, fetchFn]);
-
-  const handleSaveProfile = async () => {
-    if (!accountProfile) return;
-    const nextDisplayName = profileDraft.trim();
-    if (!nextDisplayName) {
-      setProfileError(m.account_profile_display_name_required());
-      return;
-    }
-
-    setIsProfileSaving(true);
-    setProfileError(null);
-
-    try {
-      const response = await fetchFn(`/api/users/${accountProfile.id}`, {
-        method: "PUT",
-        body: JSON.stringify({ display_name: nextDisplayName }),
-      });
-      if (!response.ok) {
-        throw new Error(`Unexpected status: ${response.status}`);
-      }
-      const updatedProfile = (await response.json()) as {
-        id: number;
-        username: string;
-        display_name: string;
-      };
-      setAccountProfile((current) =>
-        current
-          ? {
-              ...current,
-              username: updatedProfile.username,
-              display_name: updatedProfile.display_name,
-            }
-          : current,
-      );
-      setProfileDraft(updatedProfile.display_name);
-      toast.showSuccess(m.account_profile_saved(), "bi-person-check");
-    } catch (error) {
-      console.error("Failed to save account profile:", error);
-      setProfileError(m.account_profile_save_failed());
-    } finally {
-      setIsProfileSaving(false);
-    }
-  };
-
-  const syncStatus = useMemo(() => {
-    if (!isAuthenticated) {
-      return {
-        icon: "bi-cloud-slash",
-        label: m.account_not_signed_in(),
-        variant: "muted",
-      };
-    }
-    if (hasSyncError) {
-      return { icon: "bi-cloud-slash", label: m.sync_indicator_error(), variant: "danger" };
-    }
-    if (conflictCount > 0) {
-      return {
-        icon: "bi-exclamation-triangle",
-        label: m.sync_indicator_conflicts({ count: String(conflictCount) }),
-        variant: "warning",
-      };
-    }
-    if (isSyncing) {
-      return { icon: "bi-arrow-repeat", label: m.sync_indicator_syncing(), variant: "info" };
-    }
-    if (outboxCount > 0) {
-      return {
-        icon: "bi-cloud-upload",
-        label: m.sync_indicator_pending({ count: String(outboxCount) }),
-        variant: "warning",
-      };
-    }
-    if (lastSyncedAt) {
-      return { icon: "bi-cloud-check", label: m.sync_indicator_synced(), variant: "success" };
-    }
-    return {
-      icon: "bi-cloud",
-      label: m.sync_never_synced(),
-      variant: "muted",
-    };
-  }, [isAuthenticated, hasSyncError, conflictCount, isSyncing, outboxCount, lastSyncedAt]);
-
-  const retryInSeconds =
-    retryAfter !== null ? Math.max(0, Math.ceil((retryAfter - Date.now()) / 1_000)) : null;
-  const hasProfileChanges =
-    accountProfile !== null &&
-    profileDraft.trim() !== "" &&
-    profileDraft.trim() !== accountProfile.display_name;
-  const lastSyncedLabel = lastSyncedAt
-    ? dayjs(lastSyncedAt).format("DD MMM YYYY HH:mm")
-    : m.sync_never_synced();
-  const resolvedDisplayName = accountProfile?.display_name ?? displayName;
+  const {
+    accountProfile,
+    handleSaveProfile,
+    hasProfileChanges,
+    isProfileLoading,
+    isProfileSaving,
+    profileDraft,
+    profileError,
+    resolvedDisplayName,
+    setProfileDraft,
+  } = useSettingsAccount({ displayName, fetchFn, isAuthenticated, toast });
+  const { backupStatusLabel, lastSyncedLabel, retryInSeconds, syncStatus } =
+    useSettingsSyncStatus({
+      backupEnabled: accountProfile?.capabilities?.backup_enabled,
+      conflictCount,
+      hasSyncError,
+      isAuthenticated,
+      isSyncing,
+      lastSyncedAt,
+      outboxCount,
+      retryAfter,
+    });
+  const {
+    clearTimeOffData,
+    clearTimeTrackingData,
+    handleCloseResetModal,
+    handleConfirmReset,
+    handleOpenResetConfirm,
+    setClearTimeOffData,
+    setClearTimeTrackingData,
+    showResetConfirm,
+  } = useSettingsResetFlow({
+    clearTimeOffEvents,
+    onHide,
+    resetSettings,
+    toast,
+  });
 
   const handleChangelogClick = () => {
     setShowChangelog(true);
@@ -338,90 +215,6 @@ export function SettingsPanel({
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       handleVersionClick();
-    }
-  };
-
-  // Clear/reset all settings
-  const handleClearData = () => {
-    setShowResetConfirm(true);
-  };
-
-  const handleCloseResetModal = () => {
-    setShowResetConfirm(false);
-    setClearTimeTrackingData(false);
-    setClearTimeOffData(false);
-  };
-
-  const handleConfirmReset = () => {
-    const listFormat = new Intl.ListFormat(getLocale(), { style: "long", type: "conjunction" });
-    let settingsCleared = false;
-    let timeTrackingCleared = false;
-    let timeOffCleared = false;
-    const errors: string[] = [];
-
-    // Attempt settings reset
-    try {
-      resetSettings();
-      settingsCleared = true;
-    } catch (error) {
-      console.error("Failed to reset settings:", error);
-      errors.push(m.reset_item_settings());
-    }
-
-    // Attempt time tracking data clearing if requested
-    if (clearTimeTrackingData) {
-      try {
-        clearCollectionById(tasksCollection);
-        clearCollectionById(templatesCollection);
-        clearCollectionById(labelsCollection);
-        timeTrackingCleared = true;
-      } catch (error) {
-        console.error("Failed to clear time tracking data:", error);
-        errors.push(m.reset_item_time_tracking_data());
-      }
-    }
-
-    // Attempt time off data clearing if requested
-    if (clearTimeOffData) {
-      try {
-        clearTimeOffEvents();
-        timeOffCleared = true;
-      } catch (error) {
-        console.error("Failed to clear time off data:", error);
-        errors.push(m.reset_item_time_off_data());
-      }
-    }
-
-    // Always close modal and settings panel
-    handleCloseResetModal();
-    onHide();
-
-    // Aggregate results and show appropriate toast
-    const anythingSucceeded = settingsCleared || timeTrackingCleared || timeOffCleared;
-    const somethingFailed = errors.length > 0;
-
-    if (anythingSucceeded && !somethingFailed) {
-      // All attempted operations succeeded
-      const parts: string[] = [];
-      if (settingsCleared) parts.push(m.reset_item_settings());
-      if (timeTrackingCleared) parts.push(m.reset_item_time_tracking_data());
-      if (timeOffCleared) parts.push(m.reset_item_time_off_data());
-      toast.showSuccess(m.data_cleared({ items: listFormat.format(parts) }), "bi-trash");
-    } else if (!anythingSucceeded && somethingFailed) {
-      // All attempted operations failed
-      toast.showWarning(m.failed_to_clear({ items: listFormat.format(errors) }));
-    } else if (anythingSucceeded && somethingFailed) {
-      // Mixed results: some succeeded, some failed
-      const successParts: string[] = [];
-      if (settingsCleared) successParts.push(m.reset_item_settings());
-      if (timeTrackingCleared) successParts.push(m.reset_item_time_tracking_data());
-      if (timeOffCleared) successParts.push(m.reset_item_time_off_data());
-      toast.showWarning(
-        m.cleared_but_failed_to_clear({
-          clearedItems: listFormat.format(successParts),
-          failedItems: listFormat.format(errors),
-        }),
-      );
     }
   };
 
@@ -650,11 +443,7 @@ export function SettingsPanel({
                     </div>
                     <div>
                       <span className="fw-medium">{m.sync_backup_status_label()}:</span>{" "}
-                      {accountProfile?.capabilities?.backup_enabled === true
-                        ? m.sync_backup_status_enabled()
-                        : accountProfile?.capabilities?.backup_enabled === false
-                          ? m.sync_backup_status_disabled()
-                          : m.sync_backup_status_unknown()}
+                      {backupStatusLabel}
                     </div>
                     {hasSyncError && retryInSeconds !== null ? (
                       <div>
@@ -1088,7 +877,7 @@ export function SettingsPanel({
                 <i className="bi bi-chevron-right text-muted"></i>
               </div>
             </ListGroup.Item>
-            <ListGroup.Item action onClick={handleClearData} className="text-danger">
+            <ListGroup.Item action onClick={handleOpenResetConfirm} className="text-danger">
               <div className="d-flex justify-content-between align-items-center">
                 <div>
                   <div className="fw-medium">

--- a/frontend/src/pages/settings/hooks/useSettingsAccount.ts
+++ b/frontend/src/pages/settings/hooks/useSettingsAccount.ts
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useState } from "react";
+import * as m from "@/paraglide/messages.js";
+
+export interface AccountProfile {
+  id: number;
+  username: string;
+  display_name: string;
+  is_admin: boolean;
+  capabilities: {
+    backup_enabled: boolean;
+  };
+}
+
+interface UseSettingsAccountParams {
+  displayName: string | null;
+  fetchFn: (url: string, init?: RequestInit) => Promise<Response>;
+  isAuthenticated: boolean;
+  toast: {
+    showSuccess: (message: string, icon?: string) => void;
+  };
+}
+
+export function useSettingsAccount({
+  displayName,
+  fetchFn,
+  isAuthenticated,
+  toast,
+}: UseSettingsAccountParams) {
+  const [accountProfile, setAccountProfile] = useState<AccountProfile | null>(null);
+  const [profileDraft, setProfileDraft] = useState("");
+  const [isProfileLoading, setIsProfileLoading] = useState(false);
+  const [isProfileSaving, setIsProfileSaving] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setAccountProfile(null);
+      setProfileDraft("");
+      setProfileError(null);
+      setIsProfileLoading(false);
+      return;
+    }
+
+    let isCancelled = false;
+    setIsProfileLoading(true);
+    setProfileError(null);
+
+    fetchFn("/api/me")
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Unexpected status: ${response.status}`);
+        }
+        const profile = (await response.json()) as AccountProfile;
+        if (isCancelled) return;
+        setAccountProfile(profile);
+        setProfileDraft(profile.display_name);
+      })
+      .catch((error) => {
+        if (isCancelled) return;
+        console.error("Failed to load account profile:", error);
+        setProfileError(m.account_profile_load_failed());
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setIsProfileLoading(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isAuthenticated, fetchFn]);
+
+  const hasProfileChanges =
+    accountProfile !== null &&
+    profileDraft.trim() !== "" &&
+    profileDraft.trim() !== accountProfile.display_name;
+
+  const resolvedDisplayName = useMemo(
+    () => accountProfile?.display_name ?? displayName,
+    [accountProfile?.display_name, displayName],
+  );
+
+  const handleSaveProfile = async () => {
+    if (!accountProfile) return;
+    const nextDisplayName = profileDraft.trim();
+    if (!nextDisplayName) {
+      setProfileError(m.account_profile_display_name_required());
+      return;
+    }
+
+    setIsProfileSaving(true);
+    setProfileError(null);
+
+    try {
+      const response = await fetchFn(`/api/users/${accountProfile.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ display_name: nextDisplayName }),
+      });
+      if (!response.ok) {
+        throw new Error(`Unexpected status: ${response.status}`);
+      }
+      const updatedProfile = (await response.json()) as {
+        id: number;
+        username: string;
+        display_name: string;
+      };
+      setAccountProfile((current) =>
+        current
+          ? {
+              ...current,
+              username: updatedProfile.username,
+              display_name: updatedProfile.display_name,
+            }
+          : current,
+      );
+      setProfileDraft(updatedProfile.display_name);
+      toast.showSuccess(m.account_profile_saved(), "bi-person-check");
+    } catch (error) {
+      console.error("Failed to save account profile:", error);
+      setProfileError(m.account_profile_save_failed());
+    } finally {
+      setIsProfileSaving(false);
+    }
+  };
+
+  return {
+    accountProfile,
+    handleSaveProfile,
+    hasProfileChanges,
+    isProfileLoading,
+    isProfileSaving,
+    profileDraft,
+    profileError,
+    resolvedDisplayName,
+    setProfileDraft,
+  };
+}

--- a/frontend/src/pages/settings/hooks/useSettingsResetFlow.ts
+++ b/frontend/src/pages/settings/hooks/useSettingsResetFlow.ts
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { labelsCollection, tasksCollection, templatesCollection } from "@/db/collections";
+import { getLocale } from "@/paraglide/runtime.js";
+import * as m from "@/paraglide/messages.js";
+
+interface CollectionWithIds {
+  toArray: Array<{ id: string }>;
+  has: (id: string) => boolean;
+  delete: (id: string) => void;
+}
+
+interface ToastLike {
+  showSuccess: (message: string, icon?: string) => void;
+  showWarning: (message: string, icon?: string) => void;
+}
+
+interface UseSettingsResetFlowParams {
+  clearTimeOffEvents: () => void;
+  onHide: () => void;
+  resetSettings: () => void;
+  toast: ToastLike;
+}
+
+function clearCollectionById(collection: CollectionWithIds): void {
+  for (const item of [...collection.toArray]) {
+    if (collection.has(item.id)) {
+      collection.delete(item.id);
+    }
+  }
+}
+
+export function useSettingsResetFlow({
+  clearTimeOffEvents,
+  onHide,
+  resetSettings,
+  toast,
+}: UseSettingsResetFlowParams) {
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [clearTimeTrackingData, setClearTimeTrackingData] = useState(false);
+  const [clearTimeOffData, setClearTimeOffData] = useState(false);
+
+  const handleOpenResetConfirm = () => {
+    setShowResetConfirm(true);
+  };
+
+  const handleCloseResetModal = () => {
+    setShowResetConfirm(false);
+    setClearTimeTrackingData(false);
+    setClearTimeOffData(false);
+  };
+
+  const handleConfirmReset = () => {
+    const listFormat = new Intl.ListFormat(getLocale(), { style: "long", type: "conjunction" });
+    let settingsCleared = false;
+    let timeTrackingCleared = false;
+    let timeOffCleared = false;
+    const errors: string[] = [];
+
+    try {
+      resetSettings();
+      settingsCleared = true;
+    } catch (error) {
+      console.error("Failed to reset settings:", error);
+      errors.push(m.reset_item_settings());
+    }
+
+    if (clearTimeTrackingData) {
+      try {
+        clearCollectionById(tasksCollection);
+        clearCollectionById(templatesCollection);
+        clearCollectionById(labelsCollection);
+        timeTrackingCleared = true;
+      } catch (error) {
+        console.error("Failed to clear time tracking data:", error);
+        errors.push(m.reset_item_time_tracking_data());
+      }
+    }
+
+    if (clearTimeOffData) {
+      try {
+        clearTimeOffEvents();
+        timeOffCleared = true;
+      } catch (error) {
+        console.error("Failed to clear time off data:", error);
+        errors.push(m.reset_item_time_off_data());
+      }
+    }
+
+    handleCloseResetModal();
+    onHide();
+
+    const anythingSucceeded = settingsCleared || timeTrackingCleared || timeOffCleared;
+    const somethingFailed = errors.length > 0;
+
+    if (anythingSucceeded && !somethingFailed) {
+      const parts: string[] = [];
+      if (settingsCleared) parts.push(m.reset_item_settings());
+      if (timeTrackingCleared) parts.push(m.reset_item_time_tracking_data());
+      if (timeOffCleared) parts.push(m.reset_item_time_off_data());
+      toast.showSuccess(m.data_cleared({ items: listFormat.format(parts) }), "bi-trash");
+    } else if (!anythingSucceeded && somethingFailed) {
+      toast.showWarning(m.failed_to_clear({ items: listFormat.format(errors) }));
+    } else if (anythingSucceeded && somethingFailed) {
+      const successParts: string[] = [];
+      if (settingsCleared) successParts.push(m.reset_item_settings());
+      if (timeTrackingCleared) successParts.push(m.reset_item_time_tracking_data());
+      if (timeOffCleared) successParts.push(m.reset_item_time_off_data());
+      toast.showWarning(
+        m.cleared_but_failed_to_clear({
+          clearedItems: listFormat.format(successParts),
+          failedItems: listFormat.format(errors),
+        }),
+      );
+    }
+  };
+
+  return {
+    clearTimeOffData,
+    clearTimeTrackingData,
+    handleCloseResetModal,
+    handleConfirmReset,
+    handleOpenResetConfirm,
+    setClearTimeOffData,
+    setClearTimeTrackingData,
+    showResetConfirm,
+  };
+}

--- a/frontend/src/pages/settings/hooks/useSettingsSyncStatus.ts
+++ b/frontend/src/pages/settings/hooks/useSettingsSyncStatus.ts
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { dayjs } from "@/utils/dateTimeUtils";
+import * as m from "@/paraglide/messages.js";
+
+interface UseSettingsSyncStatusParams {
+  conflictCount: number;
+  hasSyncError: boolean;
+  isAuthenticated: boolean;
+  isSyncing: boolean;
+  lastSyncedAt: string | null;
+  outboxCount: number;
+  retryAfter: number | null;
+  backupEnabled?: boolean;
+}
+
+export function useSettingsSyncStatus({
+  backupEnabled,
+  conflictCount,
+  hasSyncError,
+  isAuthenticated,
+  isSyncing,
+  lastSyncedAt,
+  outboxCount,
+  retryAfter,
+}: UseSettingsSyncStatusParams) {
+  const syncStatus = useMemo(() => {
+    if (!isAuthenticated) {
+      return {
+        icon: "bi-cloud-slash",
+        label: m.account_not_signed_in(),
+        variant: "muted",
+      };
+    }
+    if (hasSyncError) {
+      return { icon: "bi-cloud-slash", label: m.sync_indicator_error(), variant: "danger" };
+    }
+    if (conflictCount > 0) {
+      return {
+        icon: "bi-exclamation-triangle",
+        label: m.sync_indicator_conflicts({ count: String(conflictCount) }),
+        variant: "warning",
+      };
+    }
+    if (isSyncing) {
+      return { icon: "bi-arrow-repeat", label: m.sync_indicator_syncing(), variant: "info" };
+    }
+    if (outboxCount > 0) {
+      return {
+        icon: "bi-cloud-upload",
+        label: m.sync_indicator_pending({ count: String(outboxCount) }),
+        variant: "warning",
+      };
+    }
+    if (lastSyncedAt) {
+      return { icon: "bi-cloud-check", label: m.sync_indicator_synced(), variant: "success" };
+    }
+    return {
+      icon: "bi-cloud",
+      label: m.sync_never_synced(),
+      variant: "muted",
+    };
+  }, [isAuthenticated, hasSyncError, conflictCount, isSyncing, outboxCount, lastSyncedAt]);
+
+  const lastSyncedLabel = lastSyncedAt
+    ? dayjs(lastSyncedAt).format("DD MMM YYYY HH:mm")
+    : m.sync_never_synced();
+
+  const retryInSeconds =
+    retryAfter !== null ? Math.max(0, Math.ceil((retryAfter - Date.now()) / 1_000)) : null;
+
+  const backupStatusLabel = useMemo(() => {
+    if (backupEnabled === true) return m.sync_backup_status_enabled();
+    if (backupEnabled === false) return m.sync_backup_status_disabled();
+    return m.sync_backup_status_unknown();
+  }, [backupEnabled]);
+
+  return {
+    backupStatusLabel,
+    lastSyncedLabel,
+    retryInSeconds,
+    syncStatus,
+  };
+}


### PR DESCRIPTION
### Motivation
- Reduce component complexity by extracting account, sync and reset logic from `SettingsPanel` into focused hooks to improve readability and reuse.
- Keep UI and public prop/signature behavior unchanged while making the state and side-effects easier to test and maintain.

### Description
- Added `frontend/src/pages/settings/hooks/useSettingsAccount.ts` which handles `/api/me` fetch, profile draft state, save handler (`PUT /api/users/:id`) and exposes `profileError`, `isProfileLoading`, `isProfileSaving`, `hasProfileChanges`, `resolvedDisplayName`, and setters. 
- Added `frontend/src/pages/settings/hooks/useSettingsSyncStatus.ts` which computes the `syncStatus` view model, `lastSyncedLabel`, `retryInSeconds`, and a derived backup status label. 
- Added `frontend/src/pages/settings/hooks/useSettingsResetFlow.ts` which owns `showResetConfirm`, `clearTimeTrackingData`, `clearTimeOffData`, reset open/close/confirm handlers, collection clearing, and toast aggregation logic. 
- Updated `frontend/src/components/SettingsPanel.tsx` to compose the new hooks (`useSettingsAccount`, `useSettingsSyncStatus`, `useSettingsResetFlow`) and removed the previous inline state/handler blocks while preserving existing UI wiring and behavior.

### Testing
- Ran type checks with `cd frontend && pnpm typecheck`; result: success. 
- Ran lint with `cd frontend && pnpm lint`; result: success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85c092d44832e9f07bab918f61241)