### PR TITLE
Add SettingsPage tests for sync, data, general, and features sections

### DIFF
--- a/frontend/tests/components/SettingsPage.test.tsx
+++ b/frontend/tests/components/SettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
@@ -10,6 +10,9 @@ import { EventStoreProvider } from "@/contexts/EventStoreContext";
 import { SettingsProvider } from "@/contexts/SettingsContext";
 import { ToastProvider } from "@/contexts/ToastContext";
 import { server } from "@/mocks/server";
+import { labelsCollection } from "@/db/collections";
+import { USER_STATE_STORAGE_KEY } from "@/constants/storageKeys";
+import * as m from "@/paraglide/messages.js";
 
 // Global SuperTokens mocks come from tests/setup.ts (no-session default).
 // Override for authenticated state tests using vi.mocked().
@@ -19,6 +22,7 @@ const mockSignOut = vi.mocked(
   (await import("supertokens-auth-react/recipe/session")).default.signOut,
 );
 let useSessionContextSpy: { mockRestore: () => void } | undefined;
+let useOngoingSyncContextSpy: { mockRestore: () => void } | undefined;
 
 function renderWithProviders(ui: React.ReactElement) {
   return render(
@@ -38,6 +42,8 @@ describe("SettingsPage Account Section", () => {
   afterEach(() => {
     useSessionContextSpy?.mockRestore();
     useSessionContextSpy = undefined;
+    useOngoingSyncContextSpy?.mockRestore();
+    useOngoingSyncContextSpy = undefined;
     vi.clearAllMocks();
   });
 
@@ -151,5 +157,175 @@ describe("SettingsPage Account Section", () => {
     renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
     expect(screen.getByText("Automatic cloud backup")).toBeInTheDocument();
     expect(screen.getByText("Cross-device access")).toBeInTheDocument();
+  });
+});
+
+describe("SettingsPage Sync Section", () => {
+  afterEach(() => {
+    useSessionContextSpy?.mockRestore();
+    useSessionContextSpy = undefined;
+    useOngoingSyncContextSpy?.mockRestore();
+    useOngoingSyncContextSpy = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("shows signed-out messaging when unauthenticated", () => {
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
+    expect(screen.getByText(m.sync_signed_out_description())).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: m.sync_manual_pull_btn() })).not.toBeInTheDocument();
+  });
+
+  it("renders signed-in status and calls pull action when button is enabled", async () => {
+    const triggerPullMock = vi.fn();
+    const sessionMod = await import("supertokens-auth-react/recipe/session");
+    useSessionContextSpy = vi.spyOn(sessionMod, "useSessionContext").mockReturnValue({
+      loading: false,
+      doesSessionExist: true,
+      userId: "u1",
+      accessTokenPayload: { displayName: "Alice" },
+      invalidClaims: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    useOngoingSyncContextSpy = vi.spyOn(await import("@/contexts/OngoingSyncContext"), "useOngoingSyncContext").mockReturnValue({
+      isSyncing: false,
+      lastSyncedAt: "2026-04-20T00:00:00Z",
+      outboxCount: 2,
+      hasSyncError: false,
+      conflictCount: 1,
+      conflictedPayload: null,
+      retryAfter: null,
+      enqueueChange: vi.fn(),
+      triggerPull: triggerPullMock,
+      resolveOngoingConflicts: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
+
+    expect(screen.getByText(/Last synced:/i)).toBeInTheDocument();
+    const pullButton = screen.getByRole("button", { name: m.sync_manual_pull_btn() });
+    expect(pullButton).toBeEnabled();
+    await user.click(pullButton);
+    expect(triggerPullMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables pull action button while sync is in progress", async () => {
+    const sessionMod = await import("supertokens-auth-react/recipe/session");
+    useSessionContextSpy = vi.spyOn(sessionMod, "useSessionContext").mockReturnValue({
+      loading: false,
+      doesSessionExist: true,
+      userId: "u1",
+      accessTokenPayload: { displayName: "Alice" },
+      invalidClaims: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    useOngoingSyncContextSpy = vi.spyOn(await import("@/contexts/OngoingSyncContext"), "useOngoingSyncContext").mockReturnValue({
+      isSyncing: true,
+      lastSyncedAt: "2026-04-20T00:00:00Z",
+      outboxCount: 0,
+      hasSyncError: false,
+      conflictCount: 0,
+      conflictedPayload: null,
+      retryAfter: null,
+      enqueueChange: vi.fn(),
+      triggerPull: vi.fn(),
+      resolveOngoingConflicts: vi.fn(),
+    });
+
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
+    expect(screen.getByRole("button", { name: m.sync_manual_pull_busy() })).toBeDisabled();
+  });
+});
+
+describe("SettingsPage Data Section", () => {
+  it("opens reset confirmation, toggles clear options, and confirms side effects", async () => {
+    labelsCollection.insert({ id: "label-1", name: "Urgent", color: "#ff0000" });
+
+    const onHide = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<SettingsContent onHide={onHide} activeSection="data" />);
+
+    await user.click(screen.getByRole("button", { name: new RegExp(`^${m.reset_settings_label()}`) }));
+    const resetDialog = screen.getByRole("dialog");
+
+    const clearTimeTracking = within(resetDialog).getByRole("checkbox", {
+      name: m.reset_also_clear_time_tracking(),
+    });
+    const clearTimeOff = within(resetDialog).getByRole("checkbox", {
+      name: m.reset_also_clear_time_off(),
+    });
+
+    expect(clearTimeTracking).not.toBeChecked();
+    expect(clearTimeOff).not.toBeChecked();
+
+    await user.click(clearTimeTracking);
+    await user.click(clearTimeOff);
+
+    expect(clearTimeTracking).toBeChecked();
+    expect(clearTimeOff).toBeChecked();
+    expect(screen.getByText(m.reset_warning())).toBeInTheDocument();
+
+    await user.click(within(resetDialog).getByRole("button", { name: m.reset_now() }));
+
+    await waitFor(() => {
+      expect(onHide).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(labelsCollection.toArray).toHaveLength(0);
+    });
+
+    const stored = localStorage.getItem(USER_STATE_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored ?? "{}").scheduleType).toBeNull();
+  });
+});
+
+describe("SettingsPage General Section", () => {
+  it("handles schedule selection clicks and shows team selection for multi-team schedules", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="general" />);
+
+    expect(screen.queryByText(m.select_team_label())).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("2-shift"));
+
+    expect(screen.getByText(m.select_team_label())).toBeInTheDocument();
+    const teamOneButton = screen.getByRole("button", {
+      name: m.wizard_team_btn_aria({ team: "1" }),
+    });
+    await user.click(teamOneButton);
+    expect(teamOneButton).toHaveAttribute("aria-pressed", "true");
+  });
+});
+
+describe("SettingsPage Features Section", () => {
+  it("toggles features and shows cross-border setup when enabled", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="features" />);
+
+    const timeOffToggle = screen.getByRole("checkbox", { name: "Toggle time off" });
+    const timeTrackingToggle = screen.getByRole("checkbox", { name: "Toggle time tracking" });
+    const ganttToggle = screen.getByRole("checkbox", { name: "Toggle personal gantt" });
+    const crossBorderToggle = screen.getByRole("checkbox", { name: "Toggle cross-border tracking" });
+
+    expect(timeOffToggle).not.toBeChecked();
+    expect(timeTrackingToggle).not.toBeChecked();
+    expect(ganttToggle).not.toBeChecked();
+    expect(crossBorderToggle).not.toBeChecked();
+    expect(screen.queryByText(m.cross_border_setup_label())).not.toBeInTheDocument();
+
+    await user.click(timeOffToggle);
+    await user.click(timeTrackingToggle);
+    await user.click(ganttToggle);
+    await user.click(crossBorderToggle);
+
+    expect(timeOffToggle).toBeChecked();
+    expect(timeTrackingToggle).toBeChecked();
+    expect(ganttToggle).toBeChecked();
+    expect(crossBorderToggle).toBeChecked();
+    expect(screen.getByText(m.cross_border_setup_label())).toBeInTheDocument();
+    expect(screen.getByLabelText(m.home_country_label())).toBeInTheDocument();
+    expect(screen.getByLabelText(m.office_country_label())).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/SettingsPage.test.tsx
+++ b/frontend/tests/components/SettingsPage.test.tsx
@@ -38,7 +38,7 @@ const createMockSyncContext = (overrides = {}) => ({
   ...overrides,
 });
 
-afterEach(() => {
+function cleanupSettingsPageTests() {
   useSessionContextSpy?.mockRestore();
   useSessionContextSpy = undefined;
   useOngoingSyncContextSpy?.mockRestore();
@@ -47,7 +47,9 @@ afterEach(() => {
   labelsCollection.toArray.forEach((label) => {
     labelsCollection.delete(label.id);
   });
-});
+}
+
+afterEach(cleanupSettingsPageTests);
 
 function renderWithProviders(ui: React.ReactElement) {
   return render(

--- a/frontend/tests/components/SettingsPage.test.tsx
+++ b/frontend/tests/components/SettingsPage.test.tsx
@@ -45,7 +45,11 @@ afterEach(() => {
   useOngoingSyncContextSpy?.mockRestore();
   useOngoingSyncContextSpy = undefined;
   vi.clearAllMocks();
-  labelsCollection.toArray.forEach((label) => {
+
+  localStorage.removeItem(USER_STATE_STORAGE_KEY);
+
+  const labelsSnapshot = [...labelsCollection.toArray];
+  labelsSnapshot.forEach((label) => {
     labelsCollection.delete(label.id);
   });
 });

--- a/frontend/tests/components/SettingsPage.test.tsx
+++ b/frontend/tests/components/SettingsPage.test.tsx
@@ -38,7 +38,8 @@ const createMockSyncContext = (overrides = {}) => ({
   ...overrides,
 });
 
-function cleanupSettingsPageTests() {
+// Shared test cleanup for every section suite in this file.
+afterEach(() => {
   useSessionContextSpy?.mockRestore();
   useSessionContextSpy = undefined;
   useOngoingSyncContextSpy?.mockRestore();
@@ -47,9 +48,7 @@ function cleanupSettingsPageTests() {
   labelsCollection.toArray.forEach((label) => {
     labelsCollection.delete(label.id);
   });
-}
-
-afterEach(cleanupSettingsPageTests);
+});
 
 function renderWithProviders(ui: React.ReactElement) {
   return render(

--- a/frontend/tests/components/SettingsPage.test.tsx
+++ b/frontend/tests/components/SettingsPage.test.tsx
@@ -24,6 +24,31 @@ const mockSignOut = vi.mocked(
 let useSessionContextSpy: { mockRestore: () => void } | undefined;
 let useOngoingSyncContextSpy: { mockRestore: () => void } | undefined;
 
+const createMockSyncContext = (overrides = {}) => ({
+  isSyncing: false,
+  lastSyncedAt: "2026-04-20T00:00:00Z",
+  outboxCount: 0,
+  hasSyncError: false,
+  conflictCount: 0,
+  conflictedPayload: null,
+  retryAfter: null,
+  enqueueChange: vi.fn(),
+  triggerPull: vi.fn(),
+  resolveOngoingConflicts: vi.fn(),
+  ...overrides,
+});
+
+afterEach(() => {
+  useSessionContextSpy?.mockRestore();
+  useSessionContextSpy = undefined;
+  useOngoingSyncContextSpy?.mockRestore();
+  useOngoingSyncContextSpy = undefined;
+  vi.clearAllMocks();
+  labelsCollection.toArray.forEach((label) => {
+    labelsCollection.delete(label.id);
+  });
+});
+
 function renderWithProviders(ui: React.ReactElement) {
   return render(
     <SettingsProvider>
@@ -39,14 +64,6 @@ function renderWithProviders(ui: React.ReactElement) {
 }
 
 describe("SettingsPage Account Section", () => {
-  afterEach(() => {
-    useSessionContextSpy?.mockRestore();
-    useSessionContextSpy = undefined;
-    useOngoingSyncContextSpy?.mockRestore();
-    useOngoingSyncContextSpy = undefined;
-    vi.clearAllMocks();
-  });
-
   it("renders connect account and sign in buttons when not authenticated", () => {
     renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
     expect(screen.getByText("Connect Account")).toBeInTheDocument();
@@ -161,14 +178,6 @@ describe("SettingsPage Account Section", () => {
 });
 
 describe("SettingsPage Sync Section", () => {
-  afterEach(() => {
-    useSessionContextSpy?.mockRestore();
-    useSessionContextSpy = undefined;
-    useOngoingSyncContextSpy?.mockRestore();
-    useOngoingSyncContextSpy = undefined;
-    vi.clearAllMocks();
-  });
-
   it("shows signed-out messaging when unauthenticated", () => {
     renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
     expect(screen.getByText(m.sync_signed_out_description())).toBeInTheDocument();
@@ -186,18 +195,15 @@ describe("SettingsPage Sync Section", () => {
       invalidClaims: [],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    useOngoingSyncContextSpy = vi.spyOn(await import("@/contexts/OngoingSyncContext"), "useOngoingSyncContext").mockReturnValue({
-      isSyncing: false,
-      lastSyncedAt: "2026-04-20T00:00:00Z",
-      outboxCount: 2,
-      hasSyncError: false,
-      conflictCount: 1,
-      conflictedPayload: null,
-      retryAfter: null,
-      enqueueChange: vi.fn(),
-      triggerPull: triggerPullMock,
-      resolveOngoingConflicts: vi.fn(),
-    });
+    useOngoingSyncContextSpy = vi
+      .spyOn(await import("@/contexts/OngoingSyncContext"), "useOngoingSyncContext")
+      .mockReturnValue(
+        createMockSyncContext({
+          outboxCount: 2,
+          conflictCount: 1,
+          triggerPull: triggerPullMock,
+        }),
+      );
 
     const user = userEvent.setup();
     renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
@@ -219,18 +225,9 @@ describe("SettingsPage Sync Section", () => {
       invalidClaims: [],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    useOngoingSyncContextSpy = vi.spyOn(await import("@/contexts/OngoingSyncContext"), "useOngoingSyncContext").mockReturnValue({
-      isSyncing: true,
-      lastSyncedAt: "2026-04-20T00:00:00Z",
-      outboxCount: 0,
-      hasSyncError: false,
-      conflictCount: 0,
-      conflictedPayload: null,
-      retryAfter: null,
-      enqueueChange: vi.fn(),
-      triggerPull: vi.fn(),
-      resolveOngoingConflicts: vi.fn(),
-    });
+    useOngoingSyncContextSpy = vi
+      .spyOn(await import("@/contexts/OngoingSyncContext"), "useOngoingSyncContext")
+      .mockReturnValue(createMockSyncContext({ isSyncing: true }));
 
     renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
     expect(screen.getByRole("button", { name: m.sync_manual_pull_busy() })).toBeDisabled();


### PR DESCRIPTION
### Motivation

- Improve test coverage for the Settings UI by exercising the non-account sections (sync, data, general, features) and their interactive behaviours. 
- Verify important side effects such as triggering a sync pull, opening and confirming the reset flow, clearing local collections, and conditional UI (team picker and cross-border setup).

### Description

- Expanded `frontend/tests/components/SettingsPage.test.tsx` with new test suites for `activeSection="sync"`, `"data"`, `"general"`, and `"features"` that cover signed-out messaging, authenticated sync status and pull action, reset-modal flows and clear-option toggles, schedule/team selection and multi-team behaviour, and feature toggle interactions including cross-border setup visibility. 
- Added imports and helpers used by the tests (`within`, `labelsCollection`, `USER_STATE_STORAGE_KEY`, and message strings), and introduced a `useOngoingSyncContext` spy to simulate sync state in signed-in tests. 
- Made the reset-modal assertions robust by scoping queries with `within(resetDialog)` and changed the reset-item button lookup to use a RegExp prefix to avoid ambiguous matches with the modal title. 

### Testing

- Ran the focused test file with `cd frontend && pnpm vitest run tests/components/SettingsPage.test.tsx` and the file's test run passed with all tests succeeding (`15 tests, 15 passed`).
- The added tests assert UI state and side effects (modal visibility, checkbox state, `labelsCollection` cleared, and persisted settings reset) and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9198316e8832e84c234639e40668d)