### PR TITLE
feat(time-tracking): render gap segments in progress bar and improve tooltips

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -502,6 +502,7 @@
   "tt_open_daily_log_title": "Open {day} daily log",
   "tt_total_label": "Total",
   "tt_target_label": "Target",
+  "tt_copied": "Copied!",
   "tt_gap_label": "{minutes}min gap",
   "tt_gap_aria": "{minutes} minutes of untracked time",
   "timeoff_import_events_aria": "Import events",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -495,7 +495,7 @@
   "tt_open_daily_log_title": "Open daglogboek van {day}",
   "tt_total_label": "Totaal",
   "tt_target_label": "Doel",
-  "tt_gap_label": "{minutes}min gat",
+  "tt_gap_label": "{minutes}min leeg",
   "tt_gap_aria": "{minutes} minuten niet bijgehouden",
   "timeoff_import_events_aria": "Gebeurtenissen importeren",
   "timeoff_export_events_aria": "Gebeurtenissen exporteren",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -495,6 +495,7 @@
   "tt_open_daily_log_title": "Open daglogboek van {day}",
   "tt_total_label": "Totaal",
   "tt_target_label": "Doel",
+  "tt_copied": "Gekopieerd!",
   "tt_gap_label": "{minutes}min leeg",
   "tt_gap_aria": "{minutes} minuten niet bijgehouden",
   "timeoff_import_events_aria": "Gebeurtenissen importeren",

--- a/frontend/src/components/timeTracking/DailyTaskList.tsx
+++ b/frontend/src/components/timeTracking/DailyTaskList.tsx
@@ -17,7 +17,7 @@ import {
 } from "./constants";
 import { TaskEditModal, type TaskEditForm } from "./TaskEditModal";
 import type { StoredTimeTrackingTask } from "./types";
-import { BREAK_DURATION_MINUTES, MIN_GAP_DISPLAY_MINUTES } from "./timeUtils";
+import { BREAK_DURATION_MINUTES } from "./timeUtils";
 import * as m from "@/paraglide/messages.js";
 
 export type EditRequest = {
@@ -156,8 +156,7 @@ export function DailyTaskList({
   const taskWithBreak = useMemo(() => tasks.find((task) => task.includesBreak) ?? null, [tasks]);
 
   // gapAfter[i] = gap in minutes between tasks[i].stopTime and tasks[i+1].startTime (if >= threshold)
-  // gapToNow = gap in minutes between the last stopped task and liveTime (today only)
-  const { gapAfter, gapToNow } = useMemo(() => {
+  const gapAfter = useMemo(() => {
     const gaps: (number | null)[] = tasks.map(() => null);
 
     for (let i = 0; i < tasks.length - 1; i++) {
@@ -165,20 +164,11 @@ export function DailyTaskList({
       const next = tasks[i + 1];
       if (!current?.stopTime || !next) continue;
       const gap = dayjs(next.startTime).diff(dayjs(current.stopTime), "minute");
-      if (gap >= MIN_GAP_DISPLAY_MINUTES) gaps[i] = gap;
+      if (gap > 0) gaps[i] = gap;
     }
 
-    let toNow: number | null = null;
-    if (isToday && liveTime && tasks.length > 0) {
-      const last = tasks[tasks.length - 1];
-      if (last?.stopTime) {
-        const gap = liveTime.diff(dayjs(last.stopTime), "minute");
-        if (gap >= MIN_GAP_DISPLAY_MINUTES) toNow = gap;
-      }
-    }
-
-    return { gapAfter: gaps, gapToNow: toNow };
-  }, [tasks, isToday, liveTime]);
+    return gaps;
+  }, [tasks]);
 
   const nowPosition = useMemo<NowPosition>(() => {
     if (!isToday || !liveTime || tasks.length === 0) return null;
@@ -507,8 +497,6 @@ export function DailyTaskList({
                   </div>
                 </ListGroup.Item>
                 {gap != null && <GapIndicator durationMinutes={gap} />}
-                {gapToNow != null &&
-                  index === tasks.length - 1 && <GapIndicator durationMinutes={gapToNow} />}
                 {nowPosition?.type === "separator" &&
                   nowPosition.insertBeforeIndex === index + 1 &&
                   liveTime && <NowIndicator liveTime={liveTime} />}

--- a/frontend/src/components/timeTracking/LabelModal.tsx
+++ b/frontend/src/components/timeTracking/LabelModal.tsx
@@ -1,6 +1,8 @@
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import Modal from "react-bootstrap/Modal";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Tooltip from "react-bootstrap/Tooltip";
 import * as m from "@/paraglide/messages.js";
 
 type LabelForm = {
@@ -53,15 +55,19 @@ export function LabelModal({
           <Form.Group controlId="labelColor">
             <Form.Label>{m.form_label_color()}</Form.Label>
             <div className="d-flex gap-2 align-items-center">
-              <Form.Control
-                type="color"
-                value={value.color}
-                onChange={(event) => onChange({ ...value, color: event.target.value })}
-                title={m.tt_select_label_color()}
-                className="form-control-color"
-                aria-required="true"
-                required
-              />
+              <OverlayTrigger
+                placement="top"
+                overlay={<Tooltip id="label-color-picker">{m.tt_select_label_color()}</Tooltip>}
+              >
+                <Form.Control
+                  type="color"
+                  value={value.color}
+                  onChange={(event) => onChange({ ...value, color: event.target.value })}
+                  className="form-control-color"
+                  aria-required="true"
+                  required
+                />
+              </OverlayTrigger>
               <Form.Control
                 value={value.color}
                 onChange={(event) => onChange({ ...value, color: event.target.value })}

--- a/frontend/src/components/timeTracking/TimeTrackingWeeklyView.tsx
+++ b/frontend/src/components/timeTracking/TimeTrackingWeeklyView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import Badge from "react-bootstrap/Badge";
 import Card from "react-bootstrap/Card";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
@@ -70,6 +70,12 @@ export function TimeTrackingWeeklyView({
       setCopiedCellId(id);
       copyTimeoutRef.current = setTimeout(() => setCopiedCellId(null), 1500);
     });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
   }, []);
 
   const pluralRules = useMemo(() => new Intl.PluralRules(getLocale()), []);
@@ -512,7 +518,7 @@ export function TimeTrackingWeeklyView({
                             <OverlayTrigger
                               key={cellId}
                               show={copiedCellId === cellId}
-                              overlay={<Tooltip id={`copy-${cellId}`}>Copied!</Tooltip>}
+                              overlay={<Tooltip id={`copy-${cellId}`}>{m.tt_copied()}</Tooltip>}
                             >
                               <td
                                 onClick={cellValue ? () => handleCopyCell(cellId, cellValue) : undefined}
@@ -529,7 +535,7 @@ export function TimeTrackingWeeklyView({
                           return (
                             <OverlayTrigger
                               show={copiedCellId === cellId}
-                              overlay={<Tooltip id={`copy-${cellId}`}>Copied!</Tooltip>}
+                              overlay={<Tooltip id={`copy-${cellId}`}>{m.tt_copied()}</Tooltip>}
                             >
                               <td
                                 className="fw-semibold"

--- a/frontend/src/components/timeTracking/TimeTrackingWeeklyView.tsx
+++ b/frontend/src/components/timeTracking/TimeTrackingWeeklyView.tsx
@@ -1,8 +1,10 @@
-import { useMemo, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import Badge from "react-bootstrap/Badge";
 import Card from "react-bootstrap/Card";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import ProgressBar from "react-bootstrap/ProgressBar";
 import Table from "react-bootstrap/Table";
+import Tooltip from "react-bootstrap/Tooltip";
 import { useSettings } from "@/contexts/SettingsContext";
 import { useLiveTime } from "@/hooks/useLiveTime";
 import { useWorkLocationStorage } from "@/hooks/useWorkLocationStorage";
@@ -60,6 +62,16 @@ export function TimeTrackingWeeklyView({
   weeklyWorkingDays,
   onSwitchToDaily,
 }: TimeTrackingWeeklyViewProps) {
+  const [copiedCellId, setCopiedCellId] = useState<string | null>(null);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleCopyCell = useCallback((id: string, value: string) => {
+    navigator.clipboard.writeText(value).then(() => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      setCopiedCellId(id);
+      copyTimeoutRef.current = setTimeout(() => setCopiedCellId(null), 1500);
+    });
+  }, []);
+
   const pluralRules = useMemo(() => new Intl.PluralRules(getLocale()), []);
   const { settings } = useSettings();
   const crossBorderEnabled = settings.enableCrossBorderTracking;
@@ -343,6 +355,14 @@ export function TimeTrackingWeeklyView({
 
                   return (
                     <div key={day.iso} className="col">
+                      <OverlayTrigger
+                        trigger={onSwitchToDaily ? ["hover", "focus"] : []}
+                        overlay={
+                          <Tooltip id={`weekly-day-${day.iso}`}>
+                            {m.tt_open_daily_log_title({ day: day.label })}
+                          </Tooltip>
+                        }
+                      >
                       <div
                         className={`text-center p-2 rounded ${isToday ? "bg-primary bg-opacity-10" : ""}${onSwitchToDaily ? " hover-highlight" : ""}`}
                         role={onSwitchToDaily ? "button" : undefined}
@@ -350,11 +370,6 @@ export function TimeTrackingWeeklyView({
                         onClick={() => onSwitchToDaily?.(day.iso)}
                         onKeyDown={
                           onSwitchToDaily ? createDayKeyDownHandler(day.iso, true) : undefined
-                        }
-                        title={
-                          onSwitchToDaily
-                            ? m.tt_open_daily_log_title({ day: day.label })
-                            : undefined
                         }
                         style={onSwitchToDaily ? { cursor: "pointer" } : undefined}
                       >
@@ -420,6 +435,7 @@ export function TimeTrackingWeeklyView({
                           </div>
                         )}
                       </div>
+                      </OverlayTrigger>
                     </div>
                   );
                 })}
@@ -456,23 +472,13 @@ export function TimeTrackingWeeklyView({
                       <tr
                         key={day.iso}
                         className={isToday ? "table-primary" : ""}
-                        onClick={() => onSwitchToDaily?.(day.iso)}
-                        style={onSwitchToDaily ? { cursor: "pointer" } : undefined}
-                        title={
-                          onSwitchToDaily
-                            ? m.tt_open_daily_log_title({ day: day.label })
-                            : undefined
-                        }
                       >
                         <th scope="row">
                           {onSwitchToDaily ? (
                             <button
                               type="button"
                               className="btn btn-link p-0 text-decoration-none text-reset fw-semibold"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onSwitchToDaily(day.iso);
-                              }}
+                              onClick={() => onSwitchToDaily(day.iso)}
                               aria-label={m.tt_open_daily_log_title({ day: day.label })}
                             >
                               {day.label}
@@ -500,13 +506,41 @@ export function TimeTrackingWeeklyView({
                         </th>
                         {labelNames.map((label) => {
                           const hours = daySummary[label] ?? 0;
+                          const cellId = `${day.iso}-${label}`;
+                          const cellValue = hours > 0 ? hours.toFixed(2) : null;
                           return (
-                            <td key={`${day.iso}-${label}`}>
-                              {hours > 0 ? hours.toFixed(2) : "-"}
-                            </td>
+                            <OverlayTrigger
+                              key={cellId}
+                              show={copiedCellId === cellId}
+                              overlay={<Tooltip id={`copy-${cellId}`}>Copied!</Tooltip>}
+                            >
+                              <td
+                                onClick={cellValue ? () => handleCopyCell(cellId, cellValue) : undefined}
+                                style={cellValue ? { cursor: "copy" } : undefined}
+                              >
+                                {cellValue ?? "-"}
+                              </td>
+                            </OverlayTrigger>
                           );
                         })}
-                        <td className="fw-semibold">{dayTotal > 0 ? dayTotal.toFixed(2) : "-"}</td>
+                        {(() => {
+                          const cellId = `${day.iso}-total`;
+                          const cellValue = dayTotal > 0 ? dayTotal.toFixed(2) : null;
+                          return (
+                            <OverlayTrigger
+                              show={copiedCellId === cellId}
+                              overlay={<Tooltip id={`copy-${cellId}`}>Copied!</Tooltip>}
+                            >
+                              <td
+                                className="fw-semibold"
+                                onClick={cellValue ? () => handleCopyCell(cellId, cellValue) : undefined}
+                                style={cellValue ? { cursor: "copy" } : undefined}
+                              >
+                                {cellValue ?? "-"}
+                              </td>
+                            </OverlayTrigger>
+                          );
+                        })()}
                       </tr>
                     );
                   })}

--- a/frontend/src/components/timeTracking/TimelineProgressBar.tsx
+++ b/frontend/src/components/timeTracking/TimelineProgressBar.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import Overlay from "react-bootstrap/Overlay";
 import BootstrapProgressBar from "react-bootstrap/ProgressBar";
 import Tooltip from "react-bootstrap/Tooltip";
+import * as m from "@/paraglide/messages.js";
 import { dayjs } from "@/utils/dateTimeUtils";
 import {
   buildLabelColorMap,
@@ -139,37 +140,19 @@ export function TimelineProgressBar({
     return result;
   }, [tasks, colorByLabelId, liveTime, sanitizedTargetHours]);
 
-  const totalHours = useMemo(
-    () =>
-      renderSegments
-        .filter((s): s is TaskSegment => s.type === "task")
-        .reduce((sum, s) => sum + s.durationHours, 0),
-    [renderSegments],
-  );
-
-  const totalPercentage = useMemo(
-    () =>
-      renderSegments
-        .filter((s): s is TaskSegment => s.type === "task")
-        .reduce((sum, s) => sum + s.percentage, 0),
-    [renderSegments],
-  );
-
-  const totalBreakHours = useMemo(
-    () =>
-      renderSegments
-        .filter((s): s is TaskSegment => s.type === "task")
-        .reduce((sum, s) => sum + (s.breakHours ?? 0), 0),
-    [renderSegments],
-  );
-
-  const totalGapHours = useMemo(
-    () =>
-      renderSegments
-        .filter((s): s is GapSegment => s.type === "gap")
-        .reduce((sum, s) => sum + s.durationHours, 0),
-    [renderSegments],
-  );
+  const { totalHours, totalPercentage, totalBreakHours, totalGapHours } = useMemo(() => {
+    let hours = 0, percentage = 0, breakHours = 0, gapHours = 0;
+    for (const s of renderSegments) {
+      if (s.type === "task") {
+        hours += s.durationHours;
+        percentage += s.percentage;
+        breakHours += s.breakHours ?? 0;
+      } else {
+        gapHours += s.durationHours;
+      }
+    }
+    return { totalHours: hours, totalPercentage: percentage, totalBreakHours: breakHours, totalGapHours: gapHours };
+  }, [renderSegments]);
 
   const visualTotalPercentage =
     totalPercentage +
@@ -197,7 +180,7 @@ export function TimelineProgressBar({
           <BootstrapProgressBar>
             {renderSegments.map((rs) => {
               if (rs.type === "gap") {
-                const gapLabel = `${Math.round(rs.durationHours * 60)} minutes untracked`;
+                const gapLabel = m.tt_gap_aria({ minutes: Math.round(rs.durationHours * 60) });
                 return (
                   <BootstrapProgressBar
                     key={rs.id}
@@ -224,7 +207,7 @@ export function TimelineProgressBar({
                   (rs.breakHours / sanitizedTargetHours) * 100 * normalizationFactor;
                 const afterPct =
                   (rs.afterBreakHours / sanitizedTargetHours) * 100 * normalizationFactor;
-                const breakTooltipText = `Break: ${BREAK_DURATION_MINUTES}min`;
+                const breakTooltipText = m.tt_break_deducted({ minutes: BREAK_DURATION_MINUTES });
 
                 const showLabelOnBefore = beforePct >= afterPct;
                 const labelOnBefore = showLabelOnBefore && beforePct > 10;

--- a/frontend/src/components/timeTracking/TimelineProgressBar.tsx
+++ b/frontend/src/components/timeTracking/TimelineProgressBar.tsx
@@ -1,6 +1,8 @@
 import type { Dayjs } from "dayjs";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import Overlay from "react-bootstrap/Overlay";
 import BootstrapProgressBar from "react-bootstrap/ProgressBar";
+import Tooltip from "react-bootstrap/Tooltip";
 import { dayjs } from "@/utils/dateTimeUtils";
 import {
   buildLabelColorMap,
@@ -27,6 +29,7 @@ type TimelineProgressBarProps = {
 };
 
 type TaskSegment = {
+  type: "task";
   id: string;
   text: string;
   color: string;
@@ -43,27 +46,14 @@ type TaskSegment = {
   afterBreakHours?: number;
 };
 
-function calculateElapsedVisualHours(tasks: StoredTimeTrackingTask[], liveTime: Dayjs): number {
-  let elapsedVisualHours = 0;
+type GapSegment = {
+  type: "gap";
+  id: string;
+  durationHours: number;
+  percentage: number;
+};
 
-  // Assumes tasks are already sorted by startTime in the parent view.
-  for (const task of tasks) {
-    const taskStart = dayjs(task.startTime);
-    const taskStop = dayjs(task.stopTime ?? liveTime);
-
-    if (!liveTime.isAfter(taskStart)) break;
-    if (!taskStop.isAfter(taskStart)) continue;
-
-    const intervalEnd = liveTime.isBefore(taskStop) ? liveTime : taskStop;
-    const overlapHours = intervalEnd.diff(taskStart, "hour", true);
-
-    if (overlapHours > 0) {
-      elapsedVisualHours += overlapHours;
-    }
-  }
-
-  return elapsedVisualHours;
-}
+type RenderSegment = TaskSegment | GapSegment;
 
 const LABEL_STYLE: React.CSSProperties = {
   fontSize: "0.7rem",
@@ -81,16 +71,27 @@ export function TimelineProgressBar({
   liveTime,
   isToday,
 }: TimelineProgressBarProps) {
-  // Validate and sanitize targetHours: ensure it's finite and > 0
   const sanitizedTargetHours =
     Number.isFinite(targetHours) && targetHours > 0 ? targetHours : DEFAULT_TARGET_HOURS;
 
-  // Build color map from labels using shared helper
   const colorByLabelId = useMemo(() => buildLabelColorMap(labels), [labels]);
 
-  // Calculate segments for each task
-  const segments = useMemo<TaskSegment[]>(() => {
-    return tasks.map((task) => {
+  const [tooltipInfo, setTooltipInfo] = useState<{
+    label: string;
+    target: HTMLElement;
+  } | null>(null);
+
+  const showTooltip = (label: string) => (e: React.MouseEvent<HTMLElement>) =>
+    setTooltipInfo({ label, target: e.currentTarget });
+  const hideTooltip = () => setTooltipInfo(null);
+
+  const renderSegments = useMemo<RenderSegment[]>(() => {
+    const result: RenderSegment[] = [];
+
+    for (let i = 0; i < tasks.length; i++) {
+      const task = tasks[i];
+      if (!task) continue;
+
       const startDayjs = dayjs(task.startTime);
       const stopDayjs = task.stopTime ? dayjs(task.stopTime) : (liveTime ?? dayjs());
       const rawDurationHours = Math.max(stopDayjs.diff(startDayjs, "hour", true), 0);
@@ -99,6 +100,7 @@ export function TimelineProgressBar({
       const textColor = getContrastingTextColor(color);
 
       const segment: TaskSegment = {
+        type: "task",
         id: task.id,
         text: task.text,
         color,
@@ -109,7 +111,6 @@ export function TimelineProgressBar({
       };
 
       if (task.includesBreak && rawDurationHours > 0) {
-        // Calculate break position based on actual clock times and lunch window
         const taskStartMinutes = startDayjs.hour() * 60 + startDayjs.minute();
         const taskStopMinutes = stopDayjs.hour() * 60 + stopDayjs.minute();
         const pos = calculateBreakPosition(taskStartMinutes, taskStopMinutes);
@@ -118,66 +119,113 @@ export function TimelineProgressBar({
         segment.afterBreakHours = pos.afterHours;
       }
 
-      return segment;
-    });
+      result.push(segment);
+
+      // Insert a gap segment between this task and the next.
+      const next = tasks[i + 1];
+      if (task.stopTime && next?.startTime) {
+        const gapHours = dayjs(next.startTime).diff(dayjs(task.stopTime), "hour", true);
+        if (gapHours > 0) {
+          result.push({
+            type: "gap",
+            id: `gap-${task.id}`,
+            durationHours: gapHours,
+            percentage: (gapHours / sanitizedTargetHours) * 100,
+          });
+        }
+      }
+    }
+
+    return result;
   }, [tasks, colorByLabelId, liveTime, sanitizedTargetHours]);
 
-  // Calculate total hours and percentage (break already deducted from durationHours)
   const totalHours = useMemo(
-    () => segments.reduce((sum, segment) => sum + segment.durationHours, 0),
-    [segments],
+    () =>
+      renderSegments
+        .filter((s): s is TaskSegment => s.type === "task")
+        .reduce((sum, s) => sum + s.durationHours, 0),
+    [renderSegments],
   );
 
   const totalPercentage = useMemo(
-    () => segments.reduce((sum, segment) => sum + segment.percentage, 0),
-    [segments],
+    () =>
+      renderSegments
+        .filter((s): s is TaskSegment => s.type === "task")
+        .reduce((sum, s) => sum + s.percentage, 0),
+    [renderSegments],
   );
 
-  // Include break hours in the visual total for normalization
   const totalBreakHours = useMemo(
-    () => segments.reduce((sum, segment) => sum + (segment.breakHours ?? 0), 0),
-    [segments],
+    () =>
+      renderSegments
+        .filter((s): s is TaskSegment => s.type === "task")
+        .reduce((sum, s) => sum + (s.breakHours ?? 0), 0),
+    [renderSegments],
   );
-  const visualTotalPercentage = totalPercentage + (totalBreakHours / sanitizedTargetHours) * 100;
+
+  const totalGapHours = useMemo(
+    () =>
+      renderSegments
+        .filter((s): s is GapSegment => s.type === "gap")
+        .reduce((sum, s) => sum + s.durationHours, 0),
+    [renderSegments],
+  );
+
+  const visualTotalPercentage =
+    totalPercentage +
+    (totalBreakHours / sanitizedTargetHours) * 100 +
+    (totalGapHours / sanitizedTargetHours) * 100;
   const normalizationFactor = visualTotalPercentage > 100 ? 100 / visualTotalPercentage : 1;
 
   const isOvertime = totalPercentage > 100;
 
-  // Position of the "Now" line mapped to the same rendered timeline scale as the segments.
-  // This avoids drifting into task gaps or clamping before compressed overtime segments.
+  // Now line is positioned at wall-clock elapsed time from the first task's start,
+  // so it accounts for gaps between tasks correctly.
   const nowPct = useMemo(() => {
     if (!isToday || !liveTime || tasks.length === 0) return null;
-
-    const elapsedVisualHours = calculateElapsedVisualHours(tasks, liveTime);
-
-    const scaledPct = (elapsedVisualHours / sanitizedTargetHours) * 100 * normalizationFactor;
+    const firstTask = tasks[0];
+    if (!firstTask?.startTime) return null;
+    const elapsedHours = liveTime.diff(dayjs(firstTask.startTime), "hour", true);
+    const scaledPct = (elapsedHours / sanitizedTargetHours) * 100 * normalizationFactor;
     return Math.max(0, Math.min(scaledPct, 100));
   }, [isToday, liveTime, tasks, sanitizedTargetHours, normalizationFactor]);
 
   return (
     <div className="my-3">
-      {/* Stacked Progress Bar */}
-      {segments.length > 0 ? (
+      {renderSegments.length > 0 ? (
         <div style={{ position: "relative" }}>
           <BootstrapProgressBar>
-            {segments.map((segment) => {
-              const tooltipText = `${segment.text}: ${segment.durationHours.toFixed(2)}h`;
-              // For segments with a break, render three sub-segments positioned
-              // according to where the break falls within the lunch window.
+            {renderSegments.map((rs) => {
+              if (rs.type === "gap") {
+                const gapLabel = `${Math.round(rs.durationHours * 60)} minutes untracked`;
+                return (
+                  <BootstrapProgressBar
+                    key={rs.id}
+                    now={rs.percentage * normalizationFactor}
+                    style={{ backgroundColor: "var(--bs-secondary-bg-subtle, #e9ecef)" }}
+                    aria-label={gapLabel}
+                    onMouseEnter={showTooltip(gapLabel)}
+                    onMouseLeave={hideTooltip}
+                  />
+                );
+              }
+
+              const tooltipText = `${rs.text}: ${rs.durationHours.toFixed(2)}h`;
+
               if (
-                segment.includesBreak &&
-                segment.breakHours != null &&
-                segment.beforeBreakHours != null &&
-                segment.afterBreakHours != null
+                rs.includesBreak &&
+                rs.breakHours != null &&
+                rs.beforeBreakHours != null &&
+                rs.afterBreakHours != null
               ) {
                 const beforePct =
-                  (segment.beforeBreakHours / sanitizedTargetHours) * 100 * normalizationFactor;
+                  (rs.beforeBreakHours / sanitizedTargetHours) * 100 * normalizationFactor;
                 const breakPct =
-                  (segment.breakHours / sanitizedTargetHours) * 100 * normalizationFactor;
+                  (rs.breakHours / sanitizedTargetHours) * 100 * normalizationFactor;
                 const afterPct =
-                  (segment.afterBreakHours / sanitizedTargetHours) * 100 * normalizationFactor;
+                  (rs.afterBreakHours / sanitizedTargetHours) * 100 * normalizationFactor;
+                const breakTooltipText = `Break: ${BREAK_DURATION_MINUTES}min`;
 
-                // Show label on whichever work portion is larger
                 const showLabelOnBefore = beforePct >= afterPct;
                 const labelOnBefore = showLabelOnBefore && beforePct > 10;
                 const labelOnAfter = !showLabelOnBefore && afterPct > 10;
@@ -187,40 +235,39 @@ export function TimelineProgressBar({
                 if (beforePct > 0) {
                   parts.push(
                     <BootstrapProgressBar
-                      key={segment.id}
+                      key={rs.id}
                       now={beforePct}
-                      style={{ backgroundColor: segment.color, color: segment.textColor }}
-                      title={tooltipText}
+                      style={{ backgroundColor: rs.color, color: rs.textColor }}
                       aria-label={tooltipText}
-                      label={
-                        labelOnBefore ? <span style={LABEL_STYLE}>{segment.text}</span> : undefined
-                      }
+                      label={labelOnBefore ? <span style={LABEL_STYLE}>{rs.text}</span> : undefined}
+                      onMouseEnter={showTooltip(tooltipText)}
+                      onMouseLeave={hideTooltip}
                     />,
                   );
                 }
 
                 parts.push(
                   <BootstrapProgressBar
-                    key={`${segment.id}-break`}
+                    key={`${rs.id}-break`}
                     now={breakPct}
-                    style={{ backgroundColor: segment.color, opacity: 0.3 }}
-                    title={`Break: ${BREAK_DURATION_MINUTES}min`}
+                    style={{ backgroundColor: rs.color, opacity: 0.3 }}
                     aria-label={`Break deduction: ${BREAK_DURATION_MINUTES} minutes`}
-                    data-testid={`break-segment-${segment.id}`}
+                    data-testid={`break-segment-${rs.id}`}
+                    onMouseEnter={showTooltip(breakTooltipText)}
+                    onMouseLeave={hideTooltip}
                   />,
                 );
 
                 if (afterPct > 0) {
                   parts.push(
                     <BootstrapProgressBar
-                      key={`${segment.id}-after`}
+                      key={`${rs.id}-after`}
                       now={afterPct}
-                      style={{ backgroundColor: segment.color, color: segment.textColor }}
-                      title={tooltipText}
+                      style={{ backgroundColor: rs.color, color: rs.textColor }}
                       aria-label={tooltipText}
-                      label={
-                        labelOnAfter ? <span style={LABEL_STYLE}>{segment.text}</span> : undefined
-                      }
+                      label={labelOnAfter ? <span style={LABEL_STYLE}>{rs.text}</span> : undefined}
+                      onMouseEnter={showTooltip(tooltipText)}
+                      onMouseLeave={hideTooltip}
                     />,
                   );
                 }
@@ -228,24 +275,29 @@ export function TimelineProgressBar({
                 return parts;
               }
 
-              // Regular segment (no break)
-              const normalizedPercent = segment.percentage * normalizationFactor;
+              const normalizedPercent = rs.percentage * normalizationFactor;
               return (
                 <BootstrapProgressBar
-                  key={segment.id}
+                  key={rs.id}
                   now={normalizedPercent}
-                  style={{ backgroundColor: segment.color, color: segment.textColor }}
-                  title={tooltipText}
+                  style={{ backgroundColor: rs.color, color: rs.textColor }}
                   aria-label={tooltipText}
                   label={
                     normalizedPercent > 10 ? (
-                      <span style={LABEL_STYLE}>{segment.text}</span>
+                      <span style={LABEL_STYLE}>{rs.text}</span>
                     ) : undefined
                   }
+                  onMouseEnter={showTooltip(tooltipText)}
+                  onMouseLeave={hideTooltip}
                 />
               );
             })}
           </BootstrapProgressBar>
+
+          <Overlay show={tooltipInfo !== null} target={tooltipInfo?.target ?? null} placement="top">
+            <Tooltip id="progress-bar-tooltip">{tooltipInfo?.label}</Tooltip>
+          </Overlay>
+
           {nowPct !== null && liveTime && (
             <div
               style={{
@@ -267,7 +319,6 @@ export function TimelineProgressBar({
         <BootstrapProgressBar now={0} />
       )}
 
-      {/* Summary text */}
       <div className="text-muted mt-2 d-flex justify-content-between align-items-center">
         <span data-testid="timeline-total-duration">
           {totalHours.toFixed(2)}h ({totalPercentage.toFixed(1)}%)

--- a/frontend/src/components/timeTracking/timeUtils.ts
+++ b/frontend/src/components/timeTracking/timeUtils.ts
@@ -5,9 +5,6 @@
  */
 export const BREAK_DURATION_MINUTES = 30;
 
-/** Minimum gap duration in minutes before a gap indicator is shown. */
-export const MIN_GAP_DISPLAY_MINUTES = 5;
-
 /** Lunch window start in minutes from midnight (11:30). */
 const LUNCH_WINDOW_START = 11 * 60 + 30; // 690
 

--- a/frontend/tests/components/timeTracking/DailyTaskList.test.tsx
+++ b/frontend/tests/components/timeTracking/DailyTaskList.test.tsx
@@ -242,7 +242,7 @@ describe("DailyTaskList", () => {
       expect(screen.getByText("5min gap")).toBeInTheDocument();
     });
 
-    it("does not show gap indicator when gap is below 5 minutes", () => {
+    it("shows gap indicator even when gap is below 5 minutes", () => {
       const nearlyAdjacent = makeTask({
         id: "t2",
         text: "Afternoon work",
@@ -250,16 +250,15 @@ describe("DailyTaskList", () => {
         stopTime: `${DATE}T17:00`,
       });
       renderList([task1, nearlyAdjacent]);
-      expect(screen.queryByTestId("gap-indicator")).not.toBeInTheDocument();
+      expect(screen.getByTestId("gap-indicator")).toBeInTheDocument();
     });
 
-    it("shows gap-to-now indicator after last stopped task on today's view", () => {
+    it("does not show gap-to-now indicator after last stopped task on today's view", () => {
       const liveTime = dayjs(`${DATE}T18:00`);
       renderList([task1, task2], TEST_LABELS, { liveTime, isToday: true });
-      // Two gap indicators: one between tasks (120min) and one to now (60min)
+      // Only the inter-task gap indicator; gap-to-now was removed
       const indicators = screen.getAllByTestId("gap-indicator");
-      expect(indicators).toHaveLength(2);
-      expect(screen.getByText("60min gap")).toBeInTheDocument();
+      expect(indicators).toHaveLength(1);
     });
 
     it("does not show gap-to-now when isToday is false", () => {

--- a/frontend/tests/components/timeTracking/TimelineProgressBar.test.tsx
+++ b/frontend/tests/components/timeTracking/TimelineProgressBar.test.tsx
@@ -56,15 +56,14 @@ describe("TimelineProgressBar", () => {
       expect(breakBar).toHaveStyle("opacity: 0.3");
     });
 
-    it("shows break title tooltip on break segment", () => {
+    it("has an aria-label on the break segment", () => {
       const task = makeTask({ includesBreak: true });
 
       render(<TimelineProgressBar tasks={[task]} labels={TEST_LABELS} />);
 
-      const breakSegment = screen.getByLabelText(
-        `Break deduction: ${BREAK_DURATION_MINUTES} minutes`,
-      );
-      expect(breakSegment).toHaveAttribute("title", `Break: ${BREAK_DURATION_MINUTES}min`);
+      expect(
+        screen.getByLabelText(`Break deduction: ${BREAK_DURATION_MINUTES} minutes`),
+      ).toBeInTheDocument();
     });
   });
 
@@ -151,8 +150,8 @@ describe("TimelineProgressBar", () => {
         />,
       );
 
-      // One 2h segment completed on an 8h target => 25%.
-      expect(getNowLineLeft()).toBe("25%");
+      // Wall-clock elapsed from first task start (08:00) to liveTime (11:00) = 3h on 8h target => 37.5%.
+      expect(getNowLineLeft()).toBe("37.5%");
     });
 
     it("uses the same overtime compression scale as rendered segments", () => {


### PR DESCRIPTION
## Summary

- Show untracked gaps between tasks as grey segments in `TimelineProgressBar`, with a hover tooltip showing the untracked duration
- Replace native `title` attributes with Bootstrap `OverlayTrigger`/`Tooltip` in `LabelModal`, `TimeTrackingWeeklyView`, and `TimelineProgressBar` for consistent UX
- Add click-to-copy on weekly summary table cells (individual label hours and day totals) with a "Copied!" tooltip feedback
- Remove the trailing gap-to-now indicator in `DailyTaskList` (was showing a gap between the last task and the current time)
- Update Dutch translation: `"gat"` → `"leeg"` for the gap label

## Test plan

- [ ] Start time tracking with gaps between tasks — verify grey gap segments appear in the progress bar with correct durations on hover
- [ ] Hover over task segments in the progress bar — verify Bootstrap tooltip appears (not native browser tooltip)
- [ ] Open label modal, hover over the color picker — verify tooltip appears
- [ ] In weekly view, hover over a day header — verify tooltip appears
- [ ] In weekly view, click a cell with hours — verify value is copied to clipboard and "Copied!" tooltip briefly appears
- [ ] Verify the gap-to-now indicator no longer appears after the last task of today
- [ ] Switch UI to Dutch and verify the gap label reads "leeg"

🤖 Generated with [Claude Code](https://claude.com/claude-code)