### PR TITLE
test(sync): harden SSE with MSW handler, transport tests, and contract docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,34 @@ uv run alembic upgrade head
 - `frontend/src/lib/hday/parser.ts` for frontend `.hday` parsing
 - `frontend/src/data/changelog.ts` for release notes input
 
+## Live Updates
+
+Worktime uses a **notify-then-pull** pattern over SSE. The backend signals that fresh data is available; the client fetches it via the existing incremental pull path.
+
+### SSE contract
+
+| Field | Value |
+|-------|-------|
+| Endpoint | `GET /api/sync/events` |
+| Auth | Session cookie required (`withCredentials: true`) |
+| Event name | `sync_changed` |
+| Payload | `{ "type": "sync_changed", "server_timestamp": "<ISO-8601>" }` |
+| Keepalive | `: keepalive` comment every 15 s |
+| Client behaviour | Compare `server_timestamp` against stored sync cursor; skip pull if cursor is already at or ahead of the signal |
+
+### Deployment notes
+
+- **Proxy buffering** — set `X-Accel-Buffering: no` (already sent by the endpoint) so Nginx/Caddy does not buffer the stream.
+- **Timeouts** — ensure the proxy does not close idle SSE connections before the 15 s keepalive fires. Caddy's default idle timeout is fine; Nginx needs `proxy_read_timeout` ≥ 60 s.
+- **CORS / cookies** — the frontend uses `withCredentials: true`; the backend must echo `Access-Control-Allow-Credentials: true` and a non-wildcard `Access-Control-Allow-Origin`.
+- **Postgres LISTEN/NOTIFY** — the backend subscribes to the `worktime_sync_changed` channel for cross-process broadcast. If the asyncpg LISTEN connection is unavailable (e.g. during startup or a Postgres restart), the manager falls back to in-process delivery automatically; no operator action is required.
+
+### Adding new live-update behaviour
+
+- **Reuse `SyncSignalTransport`** when the update follows the same notify-then-pull shape: the live signal is just a freshness hint and the data arrives via a normal fetch. Implement a new `SyncSignalTransport` adapter (or reuse `createSseTransport`) and pass it to `useSyncSignal`.
+- **Stay request/poll-based** for user-triggered actions, infrequent state changes, or anything that needs the full response payload inline (not a separate fetch). Adding SSE complexity for those cases is not worth it.
+- The transport abstraction also decouples the wire protocol: replacing SSE with WebSockets later only requires a new adapter — no changes to `useSyncSignal` or its callers.
+
 ## Conventions
 
 - Use American English in code, comments, and UI text

--- a/frontend/src/mocks/data/sseEmitter.ts
+++ b/frontend/src/mocks/data/sseEmitter.ts
@@ -1,0 +1,55 @@
+/**
+ * Controllable SSE emitter for MSW tests.
+ *
+ * The MSW handler for GET /api/sync/events registers each open stream
+ * controller here. Tests call `sseEmitter.emit(timestamp)` to push a
+ * `sync_changed` frame to every connected stream, simulating a live
+ * server-sent event without touching the real backend.
+ *
+ * Call `sseEmitter.reset()` in afterEach to close all open streams and
+ * prevent state from leaking between tests.
+ */
+
+const encoder = new TextEncoder();
+const controllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
+
+export const sseEmitter = {
+  /** Push a `sync_changed` event to all open SSE streams. */
+  emit(serverTimestamp: string): void {
+    const frame = `event: sync_changed\ndata: ${JSON.stringify({
+      type: "sync_changed",
+      server_timestamp: serverTimestamp,
+    })}\n\n`;
+    const encoded = encoder.encode(frame);
+    for (const ctrl of controllers) {
+      try {
+        ctrl.enqueue(encoded);
+      } catch {
+        // Stream already closed — clean up stale entry.
+        controllers.delete(ctrl);
+      }
+    }
+  },
+
+  /** Close all open streams and clear the registry. Call in afterEach. */
+  reset(): void {
+    for (const ctrl of controllers) {
+      try {
+        ctrl.close();
+      } catch {
+        // Already closed.
+      }
+    }
+    controllers.clear();
+  },
+
+  /** @internal Called by the MSW handler when a stream opens. */
+  _add(ctrl: ReadableStreamDefaultController<Uint8Array>): void {
+    controllers.add(ctrl);
+  },
+
+  /** @internal Called by the MSW handler when a stream is cancelled. */
+  _remove(ctrl: ReadableStreamDefaultController<Uint8Array>): void {
+    controllers.delete(ctrl);
+  },
+};

--- a/frontend/src/mocks/handlers/sync.ts
+++ b/frontend/src/mocks/handlers/sync.ts
@@ -2,6 +2,7 @@
  * MSW handlers for sync and preferences endpoints.
  *
  * Covers:
+ *  GET  /api/sync/events  (SSE — controllable via sseEmitter)
  *  GET  /api/sync/status
  *  POST /api/sync/push
  *  POST /api/sync/pull
@@ -14,11 +15,37 @@
  */
 
 import { http, HttpResponse } from "msw";
+import { sseEmitter } from "@/mocks/data/sseEmitter";
 import { syncStore } from "@/mocks/data/syncStore";
 import { buildAuthFailureResponse } from "./auth";
 import { getMockScenario } from "@/mocks/scenarios/state";
 
 export const syncHandlers = [
+  // GET /api/sync/events — SSE stream; push events via sseEmitter.emit(timestamp)
+  http.get("*/api/sync/events", () => {
+    const authFailure = buildAuthFailureResponse();
+    if (authFailure) return authFailure;
+
+    let ctrl: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        ctrl = c;
+        sseEmitter._add(c);
+      },
+      cancel() {
+        if (ctrl) sseEmitter._remove(ctrl);
+      },
+    });
+
+    return new HttpResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  }),
+
   // GET /api/sync/status
   http.get("*/api/sync/status", () => {
     const authFailure = buildAuthFailureResponse();

--- a/frontend/tests/hooks/useSyncSignal.test.ts
+++ b/frontend/tests/hooks/useSyncSignal.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useSyncSignal, type SyncSignalTransport } from "@/hooks/useSyncSignal";
+import { createSseTransport, useSyncSignal, type SyncSignalTransport } from "@/hooks/useSyncSignal";
 import { storeSyncCursor } from "@/utils/syncClient";
 import { getSyncCursorKey } from "@/constants/storageKeys";
 
@@ -360,7 +360,7 @@ describe("useSyncSignal", () => {
     });
   });
 
-  describe("invalid timestamp handling", () => {
+  describe("invalid timestamp handling — hook layer", () => {
     it("does NOT call triggerPull when server_timestamp is not a parseable date", () => {
       const triggerPull = vi.fn();
       const { transport, emit } = createMockTransport();
@@ -402,5 +402,157 @@ describe("useSyncSignal", () => {
       );
       expect(localStorage.getItem(getSyncCursorKey("user-1"))).toBeNull();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSseTransport — SSE adapter unit tests
+//
+// EventSource is not available in happy-dom, so we stub it globally and verify
+// the adapter's construction, message parsing, and cleanup behaviour.
+// ---------------------------------------------------------------------------
+
+function makeEventSourceStub() {
+  const listeners: Map<string, EventListener> = new Map();
+
+  const addEventListenerSpy = vi.fn((type: string, listener: EventListener) => {
+    listeners.set(type, listener);
+  });
+  const removeEventListenerSpy = vi.fn((type: string) => {
+    listeners.delete(type);
+  });
+  const closeSpy = vi.fn();
+
+  // Vitest requires mockImplementation with class syntax for constructor mocks.
+  const MockConstructor = vi.fn().mockImplementation(
+    class {
+      onerror: ((event: Event) => void) | null = null;
+      addEventListener = addEventListenerSpy;
+      removeEventListener = removeEventListenerSpy;
+      close = closeSpy;
+    },
+  );
+
+  const dispatch = (type: string, data: string) => {
+    const listener = listeners.get(type);
+    if (listener) listener(new MessageEvent(type, { data }));
+  };
+
+  return {
+    MockConstructor,
+    dispatch,
+    addEventListenerSpy,
+    removeEventListenerSpy,
+    closeSpy,
+    /** Simulate an SSE connection error on the most-recently created instance. */
+    fireError() {
+      const instance = MockConstructor.mock.instances.at(-1) as {
+        onerror: ((e: Event) => void) | null;
+      } | undefined;
+      instance?.onerror?.(new Event("error"));
+    },
+  };
+}
+
+describe("createSseTransport", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("opens an EventSource with the given URL and withCredentials: true", () => {
+    const { MockConstructor } = makeEventSourceStub();
+    vi.stubGlobal("EventSource", MockConstructor);
+
+    createSseTransport("https://api.example.com/sync/events").subscribe(vi.fn());
+
+    expect(MockConstructor).toHaveBeenCalledWith("https://api.example.com/sync/events", {
+      withCredentials: true,
+    });
+  });
+
+  it("calls onSignal with server_timestamp when a sync_changed event arrives", () => {
+    const { MockConstructor, dispatch } = makeEventSourceStub();
+    vi.stubGlobal("EventSource", MockConstructor);
+
+    const onSignal = vi.fn();
+    createSseTransport("/api/sync/events").subscribe(onSignal);
+
+    dispatch(
+      "sync_changed",
+      JSON.stringify({ type: "sync_changed", server_timestamp: "2026-03-01T12:00:00.000Z" }),
+    );
+
+    expect(onSignal).toHaveBeenCalledWith("2026-03-01T12:00:00.000Z");
+  });
+
+  it("does not call onSignal when event data is missing server_timestamp", () => {
+    const { MockConstructor, dispatch } = makeEventSourceStub();
+    vi.stubGlobal("EventSource", MockConstructor);
+
+    const onSignal = vi.fn();
+    createSseTransport("/api/sync/events").subscribe(onSignal);
+
+    dispatch("sync_changed", JSON.stringify({ type: "sync_changed" }));
+
+    expect(onSignal).not.toHaveBeenCalled();
+  });
+
+  it("does not throw and does not call onSignal when event data is malformed JSON", () => {
+    const { MockConstructor, dispatch } = makeEventSourceStub();
+    vi.stubGlobal("EventSource", MockConstructor);
+
+    const onSignal = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    createSseTransport("/api/sync/events").subscribe(onSignal);
+    dispatch("sync_changed", "not-json{{{");
+
+    expect(onSignal).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to parse SSE event data"),
+      "not-json{{{",
+    );
+  });
+
+  it("logs a debug message when the connection errors (EventSource auto-reconnects)", () => {
+    const { MockConstructor, fireError } = makeEventSourceStub();
+    vi.stubGlobal("EventSource", MockConstructor);
+
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    createSseTransport("/api/sync/events").subscribe(vi.fn());
+    fireError();
+
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("SSE connection error"));
+  });
+
+  it("cleanup removes the sync_changed listener and closes the EventSource", () => {
+    const { MockConstructor, removeEventListenerSpy, closeSpy } = makeEventSourceStub();
+    vi.stubGlobal("EventSource", MockConstructor);
+
+    const cleanup = createSseTransport("/api/sync/events").subscribe(vi.fn());
+
+    cleanup();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("sync_changed", expect.any(Function));
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onSignal after cleanup", () => {
+    const { MockConstructor, dispatch } = makeEventSourceStub();
+    vi.stubGlobal("EventSource", MockConstructor);
+
+    const onSignal = vi.fn();
+    const cleanup = createSseTransport("/api/sync/events").subscribe(onSignal);
+
+    cleanup();
+
+    dispatch(
+      "sync_changed",
+      JSON.stringify({ type: "sync_changed", server_timestamp: "2026-05-01T00:00:00.000Z" }),
+    );
+
+    expect(onSignal).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/hooks/useSyncSignal.test.ts
+++ b/frontend/tests/hooks/useSyncSignal.test.ts
@@ -414,18 +414,24 @@ describe("useSyncSignal", () => {
 
 function makeEventSourceStub() {
   const listeners: Map<string, EventListener> = new Map();
+  let activeInstance: { onerror: ((event: Event) => void) | null } | null = null;
 
   const addEventListenerSpy = vi.fn((type: string, listener: EventListener) => {
     listeners.set(type, listener);
   });
-  const removeEventListenerSpy = vi.fn((type: string) => {
-    listeners.delete(type);
+  const removeEventListenerSpy = vi.fn((type: string, listener: EventListener) => {
+    if (listeners.get(type) === listener) {
+      listeners.delete(type);
+    }
   });
   const closeSpy = vi.fn();
 
   // Vitest requires mockImplementation with class syntax for constructor mocks.
   const MockConstructor = vi.fn().mockImplementation(
     class {
+      constructor() {
+        activeInstance = this as unknown as { onerror: ((event: Event) => void) | null };
+      }
       onerror: ((event: Event) => void) | null = null;
       addEventListener = addEventListenerSpy;
       removeEventListener = removeEventListenerSpy;
@@ -446,10 +452,7 @@ function makeEventSourceStub() {
     closeSpy,
     /** Simulate an SSE connection error on the most-recently created instance. */
     fireError() {
-      const instance = MockConstructor.mock.instances.at(-1) as {
-        onerror: ((e: Event) => void) | null;
-      } | undefined;
-      instance?.onerror?.(new Event("error"));
+      activeInstance?.onerror?.(new Event("error"));
     },
   };
 }

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -11,6 +11,7 @@ import {
   workLocationsCollection,
 } from "@/db/collections";
 import { server } from "@/mocks/server";
+import { sseEmitter } from "@/mocks/data/sseEmitter";
 import { resetMockScenario } from "@/mocks/scenarios/state";
 
 // Make React available globally for JSX in tests
@@ -126,6 +127,7 @@ beforeEach(async () => {
 afterEach(async () => {
   cleanup();
   server.resetHandlers();
+  sseEmitter.reset();
   await resetTestState();
 });
 


### PR DESCRIPTION
Closes #690

## What

### Tests and fixtures

- **`frontend/src/mocks/data/sseEmitter.ts`** — controllable emitter; `sseEmitter.emit(timestamp)` pushes a real `sync_changed` SSE frame to all open test streams; `reset()` cleans up in `afterEach`
- **MSW handler for `GET /api/sync/events`** — returns a `text/event-stream` response wired to `sseEmitter`, with the same auth check as all other sync handlers; prevents `onUnhandledRequest: "error"` for any test rendering `OngoingSyncContext` and enables integration tests that simulate live sync deterministically
- **`createSseTransport` unit tests** (7) — stubs `EventSource` globally via Vitest's class-based `mockImplementation`; covers construction URL/credentials, `sync_changed` event parsing, missing/malformed data, `onerror` logging, and cleanup

### Documentation (`AGENTS.md`)

New **Live Updates** section covering:
- SSE contract table (endpoint, auth, event name, payload, keepalive, client behaviour)
- Deployment notes: proxy buffering (`X-Accel-Buffering: no`), idle timeout config, CORS/credentials requirements, Postgres LISTEN/NOTIFY fallback behaviour
- `SyncSignalTransport` reuse guidance: reuse for notify-then-pull; stay pull-based for user-triggered or infrequent updates; transport abstraction future-proofs SSE→WebSocket migration

## Test results

```
Test Files  84 passed (84)
     Tests  1436 passed (1436)
```

## What was already in place (not changed)

Backend tests in `backend/tests/test_sync.py` already cover auth, per-user isolation, multi-client broadcast, queue coalescing, broadcast-failure recovery, and `pg_listener` parsing. `useSyncSignal.test.ts` already had comprehensive hook-layer tests via mock transport.