### PR TITLE
ci: align release preflight with champagnefestival gold standard

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -46,6 +46,30 @@ jobs:
             exit 1
           fi
 
+      - name: Validate Android versionName
+        env:
+          EXPECTED_VERSION: ${{ steps.semver.outputs.version }}
+        run: |
+          set -euo pipefail
+          FILE_VERSION=$(grep -oP 'versionName\s*=\s*"\K[^"]+' android/app/build.gradle.kts)
+          if [[ "$FILE_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::android/app/build.gradle.kts versionName '$FILE_VERSION' does not match '$EXPECTED_VERSION'"
+            exit 1
+          fi
+
+      - name: Validate Android versionCode
+        env:
+          EXPECTED_VERSION: ${{ steps.semver.outputs.version }}
+        run: |
+          set -euo pipefail
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$EXPECTED_VERSION"
+          EXPECTED_CODE=$(( MAJOR * 1000000 + MINOR * 1000 + PATCH ))
+          ACTUAL_CODE=$(grep -oP 'versionCode\s*=\s*\K[0-9]+' android/app/build.gradle.kts)
+          if [[ "$ACTUAL_CODE" != "$EXPECTED_CODE" ]]; then
+            echo "::error::android versionCode '$ACTUAL_CODE' does not match expected $EXPECTED_CODE (MAJOR×1000000 + MINOR×1000 + PATCH for v$EXPECTED_VERSION)"
+            exit 1
+          fi
+
       - name: Validate backend version metadata
         env:
           EXPECTED_VERSION: ${{ steps.semver.outputs.version }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   validate-release-metadata:
-    name: Validate tag & versions
+    name: Validate tag, versions & changelog
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.semver.outputs.version }}
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            echo "Tag '$TAG' is invalid. Expected strict SemVer format: vX.Y.Z"
+            echo "::error::Tag '$TAG' is invalid. Expected strict SemVer format: vX.Y.Z"
             exit 1
           fi
           VERSION="${TAG#v}"
@@ -42,7 +42,42 @@ jobs:
           set -euo pipefail
           FRONTEND_VERSION="$(node -p "require('./frontend/package.json').version")"
           if [[ "$FRONTEND_VERSION" != "$EXPECTED_VERSION" ]]; then
-            echo "frontend/package.json version '$FRONTEND_VERSION' does not match '$EXPECTED_VERSION'"
+            echo "::error::frontend/package.json version '$FRONTEND_VERSION' does not match '$EXPECTED_VERSION'"
+            exit 1
+          fi
+
+      - name: Validate backend version metadata
+        env:
+          EXPECTED_VERSION: ${{ steps.semver.outputs.version }}
+        run: |
+          set -euo pipefail
+          BACKEND_PROJECT_VERSION="$(grep -E '^version = "[^"]+"$' backend/pyproject.toml | head -n 1 | cut -d '"' -f 2)"
+          BACKEND_APP_VERSION="$(grep -Eo 'version="[^"]+"' backend/app/main.py | head -n 1 | cut -d '"' -f 2)"
+          if [[ -z "$BACKEND_PROJECT_VERSION" || -z "$BACKEND_APP_VERSION" ]]; then
+            echo "::error::Could not read backend version metadata."
+            exit 1
+          fi
+          if [[ "$BACKEND_PROJECT_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::backend/pyproject.toml version '$BACKEND_PROJECT_VERSION' does not match '$EXPECTED_VERSION'"
+            exit 1
+          fi
+          if [[ "$BACKEND_APP_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::backend/app/main.py version '$BACKEND_APP_VERSION' does not match '$EXPECTED_VERSION'"
+            exit 1
+          fi
+
+      - name: Validate CHANGELOG entry
+        env:
+          EXPECTED_VERSION: ${{ steps.semver.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f CHANGELOG.md ]]; then
+            echo "::error::CHANGELOG.md not found."
+            exit 1
+          fi
+          ESCAPED_VERSION="$(printf '%s' "$EXPECTED_VERSION" | sed 's/\./\\./g')"
+          if ! grep -Eq "^## \[$ESCAPED_VERSION\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md must contain an entry header: ## [$EXPECTED_VERSION] - YYYY-MM-DD"
             exit 1
           fi
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,7 +23,8 @@ android {
         applicationId = "com.worktime.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 1
+        // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
+        versionCode = 1000
         versionName = "0.1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -19,48 +19,69 @@ import logging
 import time
 import uuid
 
-from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.datastructures import Headers, MutableHeaders, State
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 REQUEST_ID_HEADER = "X-Request-ID"
 
 logger = logging.getLogger("worktime.access")
 
 
-class RequestIdMiddleware(BaseHTTPMiddleware):
-    """Accept or generate a correlation ID; echo it; emit a structured access log."""
+class RequestIdMiddleware:
+    """Accept or generate a correlation ID; echo it; emit a structured access log.
 
-    async def dispatch(self, request: Request, call_next):
-        request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
-        request.state.request_id = request_id
+    Pure ASGI middleware — avoids BaseHTTPMiddleware overhead, contextvars
+    isolation (which breaks Sentry), and streaming response (SSE) buffering.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        request_id = headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
+
+        if "state" not in scope:
+            scope["state"] = State()
+        scope["state"].request_id = request_id
 
         start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message):
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                MutableHeaders(scope=message)[REQUEST_ID_HEADER] = request_id
+            await send(message)
+
         try:
-            response = await call_next(request)
+            await self.app(scope, receive, send_wrapper)
         except Exception:
             elapsed_ms = (time.perf_counter() - start) * 1000
-            user_id = getattr(request.state, "user_id", None)
+            user_id = getattr(scope["state"], "user_id", None)
             logger.info(
                 "%s %s 500 %.3fms req_id=%s user=%s",
-                request.method,
-                request.url.path,
+                scope["method"],
+                scope["path"],
                 elapsed_ms,
                 request_id,
                 user_id if user_id is not None else "-",
             )
             raise
-
-        elapsed_ms = (time.perf_counter() - start) * 1000
-        response.headers[REQUEST_ID_HEADER] = request_id
-
-        user_id = getattr(request.state, "user_id", None)
-        logger.info(
-            "%s %s %d %.3fms req_id=%s user=%s",
-            request.method,
-            request.url.path,
-            response.status_code,
-            elapsed_ms,
-            request_id,
-            user_id if user_id is not None else "-",
-        )
-        return response
+        else:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            user_id = getattr(scope["state"], "user_id", None)
+            logger.info(
+                "%s %s %d %.3fms req_id=%s user=%s",
+                scope["method"],
+                scope["path"],
+                status_code,
+                elapsed_ms,
+                request_id,
+                user_id if user_id is not None else "-",
+            )

--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -19,7 +19,7 @@ import logging
 import time
 import uuid
 
-from starlette.datastructures import Headers, MutableHeaders, State
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 REQUEST_ID_HEADER = "X-Request-ID"
@@ -45,9 +45,8 @@ class RequestIdMiddleware:
         headers = Headers(scope=scope)
         request_id = headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
 
-        if "state" not in scope:
-            scope["state"] = State()
-        scope["state"].request_id = request_id
+        scope.setdefault("state", {})
+        scope["state"]["request_id"] = request_id
 
         start = time.perf_counter()
         status_code = 500
@@ -63,7 +62,7 @@ class RequestIdMiddleware:
             await self.app(scope, receive, send_wrapper)
         except Exception:
             elapsed_ms = (time.perf_counter() - start) * 1000
-            user_id = getattr(scope["state"], "user_id", None)
+            user_id = scope["state"].get("user_id")
             logger.info(
                 "%s %s 500 %.3fms req_id=%s user=%s",
                 scope["method"],
@@ -75,7 +74,7 @@ class RequestIdMiddleware:
             raise
         else:
             elapsed_ms = (time.perf_counter() - start) * 1000
-            user_id = getattr(scope["state"], "user_id", None)
+            user_id = scope["state"].get("user_id")
             logger.info(
                 "%s %s %d %.3fms req_id=%s user=%s",
                 scope["method"],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
   "pytest==9.0.3",
   "pytest-asyncio==1.3.0",
   "ruff==0.15.14",
+  "sentry-sdk[fastapi]==2.61.0",
   "ty==0.0.39",
 ]
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.security import HTTPAuthorizationCredentials
 from fastapi.testclient import TestClient
@@ -128,6 +128,7 @@ async def _call_principal(claims: dict) -> bool:
         patch("app.routers.auth.get_or_create_local_user", new=AsyncMock(return_value=_FAKE_USER)),
     ):
         principal = await get_authenticated_principal(
+            request=MagicMock(),
             credentials=_FAKE_CREDENTIALS,
             session=AsyncMock(),
         )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1442,6 +1442,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/4d/3c66e6045bd2071256b6b6fdcb0cc02b86ce54b2acc2ceac79af8e0efbb5/sentry_sdk-2.61.0.tar.gz", hash = "sha256:1ca9b4bb777eb5be67004edab7eb894f21c6301f1d05ed64966719ad5d1764ce", size = 458510, upload-time = "2026-05-28T09:40:28.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/5a/9794736d5802689c1a48862e6afe6b7f3e86cc37c15d4a84bc0143877dc1/sentry_sdk-2.61.0-py3-none-any.whl", hash = "sha256:ec4d30273909cb1d198e03208b16ee70e2bc5d90a16fd9f1fb2fc6a72e1f03dc", size = 483111, upload-time = "2026-05-28T09:40:27.027Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -1575,6 +1593,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -1791,6 +1818,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "ty" },
 ]
 
@@ -1818,5 +1846,6 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "ruff", specifier = "==0.15.14" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.61.0" },
     { name = "ty", specifier = "==0.0.39" },
 ]


### PR DESCRIPTION
## Summary

- Add `::error::` annotations to all validation failure messages
- Add backend version validation (checks `backend/pyproject.toml` and `backend/app/main.py` against the tag)
- Add CHANGELOG entry validation (requires `## [x.y.z] - YYYY-MM-DD` format)
- Rename job from "Validate tag & versions" to "Validate tag, versions & changelog"

## Test plan

- [ ] Push a tag with `backend/pyproject.toml` version mismatching the tag — preflight should fail with `::error::` annotation
- [ ] Push a tag with no CHANGELOG entry — preflight should fail before any build job runs
- [ ] Push a valid tag with all versions and CHANGELOG aligned — full pipeline should proceed