### PR TITLE
feat(observability): add auth_type to access logs and docs

### DIFF
--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -55,7 +55,7 @@ class RequestIdMiddleware:
             nonlocal status_code
             if message["type"] == "http.response.start":
                 status_code = message["status"]
-                MutableHeaders(scope=message)[REQUEST_ID_HEADER] = request_id
+                MutableHeaders(raw=message["headers"])[REQUEST_ID_HEADER] = request_id
             await send(message)
 
         try:

--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -66,12 +66,14 @@ class RequestIdMiddleware:
         finally:
             elapsed_ms = (time.perf_counter() - start) * 1000
             user_id = scope["state"].get("user_id")
+            auth_type = scope["state"].get("auth_type")
             logger.info(
-                "%s %s %d %.3fms req_id=%s user=%s",
+                "%s %s %d %.3fms req_id=%s user=%s auth=%s",
                 scope["method"],
                 scope["path"],
                 status_code,
                 elapsed_ms,
                 request_id,
                 user_id if user_id is not None else "-",
+                auth_type if auth_type is not None else "-",
             )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -68,8 +68,9 @@ async def get_authenticated_principal(
             detail="Authentication service error",
         ) from exc
 
-    # Make the resolved user ID available to middleware for access logging.
+    # Make the resolved user ID and auth type available to middleware for access logging.
     request.state.user_id = local_user.id
+    request.state.auth_type = "oidc"
 
     if settings.SENTRY_DSN:
         try:

--- a/backend/docs/OBSERVABILITY.md
+++ b/backend/docs/OBSERVABILITY.md
@@ -1,0 +1,110 @@
+# Observability Contract
+
+This document describes the observability guarantees that apply to every HTTP request handled by the Worktime backend. **Any new route must be added through the standard FastAPI router so it automatically inherits this contract.**
+
+---
+
+## X-Request-ID
+
+| Behaviour | Detail |
+|---|---|
+| **Generation** | If the incoming request carries no `X-Request-ID` header, `RequestIdMiddleware` generates a UUID4 and assigns it. |
+| **Propagation** | If the incoming request supplies `X-Request-ID`, that value is used unchanged. |
+| **Echo** | Every response carries `X-Request-ID` in its headers regardless of status code. |
+| **Scope** | The ID is stored in `scope["state"]["request_id"]` (accessible via `request.state.request_id` in route handlers). |
+| **CORS** | `X-Request-ID` is listed in both `allow_headers` (clients may send it) and `expose_headers` (browsers may read it). |
+
+---
+
+## Middleware Stack
+
+```
+RequestIdMiddleware   ← outermost: sets/echoes X-Request-ID, emits access log
+  TimingMiddleware    ← sets X-Total-Ms, records request_metrics
+    CORSMiddleware
+      route handler
+```
+
+`RequestIdMiddleware` is pure ASGI (not `BaseHTTPMiddleware`) to avoid response-buffering issues with SSE and Sentry context-var isolation.
+
+---
+
+## Structured Access Log
+
+Every request emits one log line via the `worktime.access` logger after the response is sent. Format:
+
+```
+METHOD PATH STATUS_CODE DURATION_MS req_id=<uuid> user=<id|-> auth=<oidc|->
+```
+
+Example:
+
+```
+GET /api/health 200 12.345ms req_id=550e8400-e29b-41d4-a716-446655440000 user=42 auth=oidc
+```
+
+### Log fields
+
+| Field | Notes |
+|---|---|
+| Method, path, status, duration | Standard access log fields. |
+| `req_id` | UUID4 (generated or propagated). |
+| `user` | Local user ID when authenticated; `-` for unauthenticated requests. |
+| `auth` | `oidc` when a valid Bearer JWT was presented; `-` for unauthenticated requests. |
+
+**Path is logged without query parameters** to prevent token leakage.
+
+---
+
+## Timing Header
+
+`X-Total-Ms` is set by `TimingMiddleware` on every response. It reflects wall-clock time inside the middleware stack (excluding `RequestIdMiddleware` overhead). Exposed via CORS `expose_headers` so browsers can read it.
+
+---
+
+## Health Endpoints
+
+| Endpoint | Auth | Behaviour |
+|---|---|---|
+| `GET /api/health/liveness` | None | Returns `{"status": "alive"}` immediately. |
+| `GET /api/health/readiness` | None | Checks database, OIDC provider, and share directory. Returns 200 or 503. |
+| `GET /api/health` | None | Returns liveness status and links to readiness and metrics endpoints. |
+
+Use `/api/health/readiness` for load-balancer health checks — not liveness.
+
+---
+
+## Metrics Endpoint
+
+| Endpoint | Auth |
+|---|---|
+| `GET /api/metrics` | `X-Metrics-Secret` header (HMAC constant-time comparison) |
+
+Returns in-process counters: uptime, request total, error total, request rate, error rate, and latency stats.
+
+**Important:** metrics are **process-local** and reset on every restart. Not aggregated across workers.
+
+---
+
+## Error Tracking (Sentry)
+
+Sentry is initialised at startup if `SENTRY_DSN` is set (optional install: `uv add sentry-sdk[fastapi]`). `send_default_pii=False` is hardcoded — IP addresses and cookies are never captured.
+
+---
+
+## Frontend Error Correlation
+
+`getRequestId(response)` in `frontend/src/utils/apiClient.ts` reads the `X-Request-ID` header. The 401 and 403 error messages include the request ID:
+
+```
+Unauthorized (request-id: 3fa85f64-…)
+```
+
+---
+
+## Adding a New Route — Checklist
+
+- [ ] Route is added via `app.include_router(...)` — not via `app.mount()` with a sub-app that bypasses middleware.
+- [ ] If the route accepts credentials in a query parameter, verify that `scope["path"]` (not `scope["query_string"]`) is what gets logged.
+- [ ] If the route introduces a new auth mechanism, ensure it sets `request.state.user_id` and `request.state.auth_type` so access logs are complete.
+- [ ] High-impact mutations (data import/export, account operations) write to the audit log — see `app/routers/audit.py`.

--- a/backend/tests/test_request_id.py
+++ b/backend/tests/test_request_id.py
@@ -87,3 +87,16 @@ class TestAccessLog:
             client.get("/api/health")
         lines = [r.getMessage() for r in caplog.records if r.name == "worktime.access"]
         assert any("ms" in line for line in lines)
+
+    def test_access_log_contains_auth_field(self, client, caplog):
+        with caplog.at_level(logging.INFO, logger="worktime.access"):
+            client.get("/api/health")
+        lines = [r.getMessage() for r in caplog.records if r.name == "worktime.access"]
+        assert any("auth=" in line for line in lines)
+
+    def test_access_log_does_not_include_query_params(self, client, caplog):
+        with caplog.at_level(logging.INFO, logger="worktime.access"):
+            client.get("/api/health?sensitive=secret-token")
+        lines = [r.getMessage() for r in caplog.records if r.name == "worktime.access"]
+        assert lines
+        assert not any("sensitive" in line or "secret-token" in line for line in lines)


### PR DESCRIPTION
Aligned with [daynest#377](https://github.com/tjorim/daynest/pull/377).

## Summary

- **Auth**: `get_authenticated_principal` now sets `request.state.auth_type = "oidc"` alongside the existing `request.state.user_id`
- **`RequestIdMiddleware`**: access log line gains an `auth=` field (`oidc` when authenticated, `-` otherwise)
- **Tests**: two new tests in `test_request_id.py` — `auth=` field assertion and query-param leak prevention
- **Docs**: `backend/docs/OBSERVABILITY.md` documenting the full contract — middleware stack, X-Request-ID behavior, access log fields, health/metrics, Sentry config, frontend correlation, and a checklist for new routes

## Test plan

- [ ] `uv run pytest tests/test_request_id.py -v` — 14 tests, all green ✓ (verified locally)
- [ ] `uv run pytest` — full suite green