### PR TITLE
feat(mcp): add delete_time_tracking_task and delete_work_location tools

### DIFF
--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -598,7 +598,6 @@ class WorktimeMcpBackend:
         """
         _ = ctx
         async with self._tool_context() as (context, db):
-            await get_task(db, context.user_id, task_id)
             await delete_task(db, context.user_id, task_id)
             audit.append(
                 target=f"user:{context.user_id}:task:{task_id}",

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -44,7 +44,9 @@ from app.services.db_service import (
     create_or_update_work_location,
     create_task,
     delete_gantt_task,
+    delete_task,
     delete_time_off_entry,
+    delete_work_location,
     get_gantt_task,
     get_running_task,
     get_task,
@@ -584,6 +586,27 @@ class WorktimeMcpBackend:
             )
             return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
+    async def delete_time_tracking_task(
+        self,
+        ctx: Context,
+        task_id: str,
+    ) -> dict[str, Any]:
+        """Delete a time-tracking task owned by the authenticated user.
+
+        Side effects: removes the TimeTrackingTask row from the database.  The
+        task must belong to the caller.  Returns a confirmation payload.
+        """
+        _ = ctx
+        async with self._tool_context() as (context, db):
+            await get_task(db, context.user_id, task_id)
+            await delete_task(db, context.user_id, task_id)
+            audit.append(
+                target=f"user:{context.user_id}:task:{task_id}",
+                action="delete_time_tracking_task",
+                details="via MCP",
+            )
+            return {"deleted": True, "task_id": task_id, "user_id": context.user_id}
+
     async def set_work_location(
         self,
         ctx: Context,
@@ -606,6 +629,26 @@ class WorktimeMcpBackend:
                 details=f"country_code={country_code!r} via MCP",
             )
             return WorkLocationRead.model_validate(location, from_attributes=True).model_dump(mode="json")
+
+    async def delete_work_location(
+        self,
+        ctx: Context,
+        value_date: date,
+    ) -> dict[str, Any]:
+        """Delete the work location entry for a given date.
+
+        Side effects: removes the WorkLocation row for (user_id, date).  Returns
+        a confirmation payload.
+        """
+        _ = ctx
+        async with self._tool_context() as (context, db):
+            await delete_work_location(db, context.user_id, value_date)
+            audit.append(
+                target=f"user:{context.user_id}:work_location:{value_date.isoformat()}",
+                action="delete_work_location",
+                details="via MCP",
+            )
+            return {"deleted": True, "date": value_date.isoformat(), "user_id": context.user_id}
 
     async def create_time_off_event(
         self,
@@ -842,7 +885,9 @@ def create_mcp_server(
     server.tool(name="stop_time_entry")(backend.stop_time_entry)
     server.tool(name="create_time_tracking_task")(backend.create_time_tracking_task)
     server.tool(name="update_time_tracking_task")(backend.update_time_tracking_task)
+    server.tool(name="delete_time_tracking_task")(backend.delete_time_tracking_task)
     server.tool(name="set_work_location")(backend.set_work_location)
+    server.tool(name="delete_work_location")(backend.delete_work_location)
     server.tool(name="create_time_off_event")(backend.create_time_off_event)
     server.tool(name="update_time_off_event")(backend.update_time_off_event)
     server.tool(name="delete_time_off_event")(backend.delete_time_off_event)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -57,7 +57,9 @@ async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) 
         "stop_time_entry",
         "create_time_tracking_task",
         "update_time_tracking_task",
+        "delete_time_tracking_task",
         "set_work_location",
+        "delete_work_location",
         "create_time_off_event",
         "update_time_off_event",
         "delete_time_off_event",
@@ -354,6 +356,89 @@ async def test_update_time_tracking_task_unauthorized(
         )
 
 
+async def test_create_update_delete_time_tracking_task(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Full lifecycle: create, update, delete a time-tracking task."""
+    import app.audit.logger as audit_module
+
+    monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
+    monkeypatch.setattr(audit_module, "AUDIT_LOG_FILE", tmp_path / "audit.log")
+
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="lifecycle-task", display_name="Lifecycle Task")
+        )
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
+
+    created = await backend.create_time_tracking_task(
+        ctx=None,  # type: ignore[arg-type]
+        text="Task to delete",
+        start_time=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+        stop_time=datetime(2026, 5, 1, 10, 0, tzinfo=UTC),
+    )
+    assert created["text"] == "Task to delete"
+    task_id = created["id"]
+
+    updated = await backend.update_time_tracking_task(
+        ctx=None,  # type: ignore[arg-type]
+        task_id=task_id,
+        text="Updated before delete",
+    )
+    assert updated["text"] == "Updated before delete"
+
+    deleted = await backend.delete_time_tracking_task(
+        ctx=None,  # type: ignore[arg-type]
+        task_id=task_id,
+    )
+    assert deleted["deleted"] is True
+    assert deleted["task_id"] == task_id
+    assert deleted["user_id"] == user.id
+
+
+async def test_delete_time_tracking_task_unauthorized(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """delete_time_tracking_task raises NotFoundError for another user's task."""
+    import app.audit.logger as audit_module
+
+    monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
+    monkeypatch.setattr(audit_module, "AUDIT_LOG_FILE", tmp_path / "audit.log")
+
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+
+    async with session_factory() as session:
+        owner = await db_service.create_user(
+            session, UserCreate(username="task-owner", display_name="Task Owner")
+        )
+        attacker = await db_service.create_user(
+            session, UserCreate(username="task-attacker", display_name="Task Attacker")
+        )
+        task = await db_service.create_task(
+            session,
+            owner.id,
+            TaskCreate(
+                text="Owner's task",
+                start_time=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+                stop_time=datetime(2026, 5, 1, 10, 0, tzinfo=UTC),
+            ),
+        )
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(attacker.id))
+
+    with pytest.raises(db_service.NotFoundError):
+        await backend.delete_time_tracking_task(ctx=None, task_id=task.id)  # type: ignore[arg-type]
+
+
 async def test_set_work_location(
     test_db: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
@@ -390,6 +475,46 @@ async def test_set_work_location(
         country_code="NL",
     )
     assert payload2["country_code"] == "NL"
+
+
+async def test_delete_work_location(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """delete_work_location removes the entry and returns a confirmation."""
+    import app.audit.logger as audit_module
+
+    monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
+    monkeypatch.setattr(audit_module, "AUDIT_LOG_FILE", tmp_path / "audit.log")
+
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(session, UserCreate(username="del-loc-user", display_name="Del Loc User"))
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
+
+    await backend.set_work_location(
+        ctx=None,  # type: ignore[arg-type]
+        value_date=date(2026, 5, 1),
+        country_code="BE",
+    )
+
+    deleted = await backend.delete_work_location(
+        ctx=None,  # type: ignore[arg-type]
+        value_date=date(2026, 5, 1),
+    )
+    assert deleted["deleted"] is True
+    assert deleted["date"] == "2026-05-01"
+    assert deleted["user_id"] == user.id
+
+    with pytest.raises(db_service.NotFoundError):
+        await backend.delete_work_location(
+            ctx=None,  # type: ignore[arg-type]
+            value_date=date(2026, 5, 1),
+        )
 
 
 async def test_set_work_location_invalid_country(


### PR DESCRIPTION
## Summary

- Adds `delete_time_tracking_task(task_id)` MCP tool — completes CRUD for time-tracking tasks alongside the existing `create_` and `update_` tools
- Adds `delete_work_location(value_date)` MCP tool — mirrors the existing REST `DELETE /work-locations/{date}` endpoint
- Both tools verify ownership, perform the deletion, append an audit log entry, and return a confirmation payload
- Both follow the same pattern as the existing `delete_gantt_task` and `delete_time_off_event` tools

Closes #743

## Test plan

- [ ] `test_create_mcp_server_registers_expected_tools` — updated expected tool set
- [ ] `test_create_update_delete_time_tracking_task` — full lifecycle test
- [ ] `test_delete_time_tracking_task_unauthorized` — cross-user authorization guard
- [ ] `test_delete_work_location` — happy path + idempotency (second delete raises `NotFoundError`)