### PR TITLE
feat(mcp): fix get_next_shift and add get_team_status / get_next_shifts_for_team

### DIFF
--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -37,6 +37,7 @@ from app.schemas import (
     WorkLocationCreate,
     WorkLocationRead,
 )
+from app.routers.auth import AuthenticatedPrincipal
 from app.services.db_service import (
     NotFoundError,
     create_gantt_task,
@@ -61,6 +62,7 @@ from app.services.db_service import (
     update_task,
     update_time_off_entry,
 )
+from app.services.read_models_service import build_dashboard_read_model, compute_next_shifts_for_team
 from app.services.sync_service import get_sync_status
 
 
@@ -285,15 +287,83 @@ class WorktimeMcpBackend:
 
     async def get_next_shift(self, ctx: Context) -> dict[str, Any]:
         _ = ctx
-        today = datetime.now(UTC).date()
         async with self._tool_context() as (context, db):
-            tasks = await list_gantt_tasks(db, user_id=context.user_id)
-            upcoming = next((task for task in tasks if task.end_date >= today), None)
-            if upcoming is None:
-                return {"date": _to_iso_date(today), "next_shift": None}
+            principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
+            dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
+            as_of = dashboard.next_shifts.as_of
+            items = dashboard.next_shifts.items
+            if not items:
+                return {"as_of": _to_iso_datetime(as_of), "next_shift": None}
+            item = items[0]
+            return {
+                "as_of": _to_iso_datetime(as_of),
+                "next_shift": {
+                    "team_number": item.team_number,
+                    "date": _to_iso_date(item.date),
+                    "shift_code": item.shift_code,
+                    "shift": item.shift.model_dump(mode="json"),
+                },
+            }
 
-            task_payload = GanttTaskRead.model_validate(upcoming, from_attributes=True).model_dump(mode="json")
-            return {"date": _to_iso_date(today), "next_shift": task_payload}
+    async def get_team_status(self, ctx: Context) -> dict[str, Any]:
+        _ = ctx
+        async with self._tool_context() as (context, db):
+            principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
+            dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
+            return {
+                "as_of": _to_iso_datetime(dashboard.team_status.as_of),
+                "schedule_type": dashboard.work_context.schedule_type,
+                "items": [
+                    {
+                        "team_number": item.team_number,
+                        "date": _to_iso_date(item.date),
+                        "shift_day": _to_iso_date(item.shift_day),
+                        "shift_code": item.shift_code,
+                        "shift": item.shift.model_dump(mode="json"),
+                        "is_currently_working": item.is_currently_working,
+                    }
+                    for item in dashboard.team_status.items
+                ],
+            }
+
+    async def get_next_shifts_for_team(
+        self,
+        ctx: Context,
+        team_number: int,
+        limit: int = 5,
+    ) -> dict[str, Any]:
+        _ = ctx
+        async with self._tool_context() as (context, db):
+            principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
+            dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
+            schedule_type = dashboard.work_context.schedule_type
+            if schedule_type is None:
+                return {
+                    "as_of": _to_iso_datetime(dashboard.as_of),
+                    "schedule_type": None,
+                    "team_number": team_number,
+                    "items": [],
+                }
+            items = compute_next_shifts_for_team(
+                schedule_type,
+                team_number,
+                as_of=dashboard.as_of,
+                limit=limit,
+            )
+            return {
+                "as_of": _to_iso_datetime(dashboard.as_of),
+                "schedule_type": schedule_type,
+                "team_number": team_number,
+                "items": [
+                    {
+                        "team_number": item.team_number,
+                        "date": _to_iso_date(item.date),
+                        "shift_code": item.shift_code,
+                        "shift": item.shift.model_dump(mode="json"),
+                    }
+                    for item in items
+                ],
+            }
 
     async def get_time_off_summary(
         self,
@@ -874,6 +944,8 @@ def create_mcp_server(
     server.tool(name="whoami")(backend.whoami)
     server.tool(name="get_current_status")(backend.get_current_status)
     server.tool(name="get_next_shift")(backend.get_next_shift)
+    server.tool(name="get_team_status")(backend.get_team_status)
+    server.tool(name="get_next_shifts_for_team")(backend.get_next_shifts_for_team)
     server.tool(name="get_time_off_summary")(backend.get_time_off_summary)
     server.tool(name="get_work_location_summary")(backend.get_work_location_summary)
     server.tool(name="get_time_tracking_summary")(backend.get_time_tracking_summary)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -333,6 +333,9 @@ class WorktimeMcpBackend:
         limit: int = 5,
     ) -> dict[str, Any]:
         _ = ctx
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        limit = min(limit, 50)
         async with self._tool_context() as (context, db):
             principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
             dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.audit import logger as audit
 from app.config import settings
 from app.database.engine import get_session_factory
+from app.routers.auth import AuthenticatedPrincipal
 from app.schemas import (
     EntryFlag,
     EntryKind,
@@ -37,7 +38,6 @@ from app.schemas import (
     WorkLocationCreate,
     WorkLocationRead,
 )
-from app.routers.auth import AuthenticatedPrincipal
 from app.services.db_service import (
     NotFoundError,
     create_gantt_task,

--- a/backend/app/services/read_models_service.py
+++ b/backend/app/services/read_models_service.py
@@ -273,6 +273,17 @@ def _get_current_working_team(
     return None
 
 
+def compute_next_shifts_for_team(
+    schedule_type: ScheduleType,
+    team_number: int,
+    *,
+    as_of: dt_datetime,
+    limit: int,
+) -> list[NextShiftItemReadModel]:
+    """Return upcoming working shifts for any team in the given schedule."""
+    return _get_next_shifts(schedule_type, team_number, as_of=as_of, limit=limit)
+
+
 def _get_next_shifts(
     schedule_type: ScheduleType,
     team_number: int,

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -47,6 +47,8 @@ async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) 
         "whoami",
         "get_current_status",
         "get_next_shift",
+        "get_team_status",
+        "get_next_shifts_for_team",
         "get_time_off_summary",
         "get_work_location_summary",
         "get_time_tracking_summary",

--- a/backend/tests/test_shift_calculations.py
+++ b/backend/tests/test_shift_calculations.py
@@ -1,0 +1,128 @@
+"""Unit tests for shift schedule calculations.
+
+These tests cover the pure functions in read_models_service and require no
+database — they mirror the structural + behavioural coverage in the frontend's
+rosters.test.ts while adding deterministic shift-resolution assertions.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.read_models_service import compute_next_shifts_for_team
+
+# Anchor used in test_read_models.py and the frontend rosters.test.ts examples.
+_AS_OF_5SHIFT = datetime(2025, 7, 17, 8, 30, tzinfo=UTC)
+
+
+class TestScheduleStructure:
+    """Mirror of the structural assertions in the frontend rosters.test.ts."""
+
+    def test_all_four_schedules_are_defined(self) -> None:
+        # Import the private dict only here so tests fail loudly if it moves.
+        from app.services.read_models_service import _SCHEDULES  # noqa: PLC2701
+
+        assert set(_SCHEDULES.keys()) == {"9-5", "2-shift", "weekend-shift", "5-shift"}
+
+    def test_team_counts(self) -> None:
+        from app.services.read_models_service import _SCHEDULES  # noqa: PLC2701
+
+        assert _SCHEDULES["9-5"].team_count == 1
+        assert _SCHEDULES["2-shift"].team_count == 4
+        assert _SCHEDULES["weekend-shift"].team_count == 2
+        assert _SCHEDULES["5-shift"].team_count == 5
+
+    def test_cycle_lengths(self) -> None:
+        from app.services.read_models_service import _SCHEDULES  # noqa: PLC2701
+
+        assert _SCHEDULES["9-5"].cycle_length_days == 7
+        assert _SCHEDULES["2-shift"].cycle_length_days == 28
+        assert _SCHEDULES["weekend-shift"].cycle_length_days == 14
+        assert _SCHEDULES["5-shift"].cycle_length_days == 10
+
+    def test_5shift_pattern(self) -> None:
+        from app.services.read_models_service import _SCHEDULES  # noqa: PLC2701
+
+        assert list(_SCHEDULES["5-shift"].schedule_pattern) == [
+            "M", "M", "L", "L", "N", "N", "O", "O", "O", "O"
+        ]
+
+    def test_9_5_pattern(self) -> None:
+        from app.services.read_models_service import _SCHEDULES  # noqa: PLC2701
+
+        assert list(_SCHEDULES["9-5"].schedule_pattern) == [
+            "D", "D", "D", "D", "D", "O", "O"
+        ]
+
+    def test_night_shift_spans_midnight(self) -> None:
+        from app.services.read_models_service import _SCHEDULES  # noqa: PLC2701
+
+        night = _SCHEDULES["5-shift"].shift_times["N"]
+        assert night.start is not None and night.end is not None
+        # Night shift: start > end means it crosses midnight
+        assert night.start > night.end
+
+    def test_non_night_shifts_do_not_span_midnight(self) -> None:
+        from app.services.read_models_service import _SCHEDULES  # noqa: PLC2701
+
+        for schedule in _SCHEDULES.values():
+            for code, defn in schedule.shift_times.items():
+                if code == "O" or defn.start is None or defn.end is None:
+                    continue
+                if code == "N":
+                    continue
+                assert defn.start < defn.end, f"{code} in {schedule} should not span midnight"
+
+
+class TestComputeNextShiftsForTeam:
+    """Behavioural tests for the public compute_next_shifts_for_team helper."""
+
+    def test_returns_only_working_shifts(self) -> None:
+        items = compute_next_shifts_for_team("5-shift", 1, as_of=_AS_OF_5SHIFT, limit=10)
+        assert all(item.shift.is_working for item in items)
+
+    def test_respects_limit(self) -> None:
+        for limit in (1, 3, 5):
+            items = compute_next_shifts_for_team("5-shift", 1, as_of=_AS_OF_5SHIFT, limit=limit)
+            assert len(items) == limit
+
+    def test_items_are_in_chronological_order(self) -> None:
+        items = compute_next_shifts_for_team("5-shift", 1, as_of=_AS_OF_5SHIFT, limit=5)
+        dates = [item.date for item in items]
+        assert dates == sorted(dates)
+
+    def test_team_number_is_set_on_each_item(self) -> None:
+        items = compute_next_shifts_for_team("5-shift", 3, as_of=_AS_OF_5SHIFT, limit=3)
+        assert all(item.team_number == 3 for item in items)
+
+    # -- Deterministic shift assertions anchored to 2025-07-17 --
+
+    def test_5shift_team1_next_two_shifts(self) -> None:
+        # Verified against test_read_models.py: next shifts are L on 18th, L on 19th.
+        items = compute_next_shifts_for_team("5-shift", 1, as_of=_AS_OF_5SHIFT, limit=2)
+        assert items[0].date.isoformat() == "2025-07-18"
+        assert items[0].shift.code == "L"
+        assert items[1].date.isoformat() == "2025-07-19"
+        assert items[1].shift.code == "L"
+
+    def test_5shift_team3_next_nightshift(self) -> None:
+        # Team 3 offset = (3-1)*2 = 4 days. Working backwards from reference
+        # date 2025-07-16: team 3's next night shifts fall on 2025-07-24/25.
+        items = compute_next_shifts_for_team("5-shift", 3, as_of=_AS_OF_5SHIFT, limit=10)
+        night_items = [item for item in items if item.shift.code == "N"]
+        assert len(night_items) >= 1
+        assert night_items[0].date.isoformat() == "2025-07-24"
+
+    def test_9_5_returns_only_day_shifts(self) -> None:
+        items = compute_next_shifts_for_team("9-5", 1, as_of=_AS_OF_5SHIFT, limit=5)
+        assert all(item.shift.code == "D" for item in items)
+
+    def test_invalid_team_number_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid team number"):
+            compute_next_shifts_for_team("5-shift", 6, as_of=_AS_OF_5SHIFT, limit=1)
+
+    def test_team_number_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid team number"):
+            compute_next_shifts_for_team("5-shift", 0, as_of=_AS_OF_5SHIFT, limit=1)


### PR DESCRIPTION
## Summary

- **Fix `get_next_shift`**: was scanning `GanttTask` records (always returned `null` unless tasks were manually maintained); now reads from the real roster schedule via `build_dashboard_read_model`, returning the authenticated user's actual next shift
- **Add `get_team_status`**: returns all teams' current shift for today — answers queries like _"which shift does team 2 have today?"_
- **Add `get_next_shifts_for_team(team_number, limit=5)`**: returns the next N working shifts for any team — an AI client can filter by `shift.name` to answer _"when does team 3 have their next nightshift?"_

A new public helper `compute_next_shifts_for_team` was added to `read_models_service.py` to expose the existing private `_get_next_shifts` for use outside the module.

Closes #744

## Test plan

- [ ] `test_create_mcp_server_registers_expected_tools` updated to include both new tool names
- [ ] `uv run ty check app/mcp_server.py app/services/read_models_service.py` passes
- [ ] Manual: call `get_team_status` — verify all teams returned with correct shift for today
- [ ] Manual: call `get_next_shifts_for_team` with a valid team number — verify upcoming shifts match the frontend calendar
- [ ] Manual: call `get_next_shifts_for_team` with an out-of-range team number — verify `ValueError` propagates as an MCP error
- [ ] Manual: call `get_next_shift` — verify it now returns roster-backed shift data instead of `null`