### PR TITLE
fix(backend): align db service soft-delete handling

### DIFF
--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -112,8 +112,11 @@ async def get_user_export_data(
     user = await get_user(session, user_id)
 
     async def _list_rows(model: type[Base], *order_by: Any) -> list[Any]:
+        typed_model: Any = model
         result = await session.execute(
-            select(model).where(model.user_id == user_id).order_by(*order_by)
+            select(model)
+            .where(typed_model.user_id == user_id, typed_model.deleted_at.is_(None))
+            .order_by(*order_by)
         )
         return list(result.scalars().all())
 
@@ -218,7 +221,7 @@ async def _ensure_user_exists(session: AsyncSession, user_id: int) -> User:
 
 async def _ensure_label_for_user(session: AsyncSession, user_id: int, label_id: str) -> TimeTrackingLabel:
     label = await session.get(TimeTrackingLabel, label_id)
-    if label is None or label.user_id != user_id:
+    if label is None or label.user_id != user_id or label.deleted_at is not None:
         raise NotFoundError("label not found")
     return label
 
@@ -289,15 +292,20 @@ async def delete_label(session: AsyncSession, user_id: int, label_id: str) -> No
     label = await _ensure_label_for_user(session, user_id, label_id)
 
     task_count = await session.scalar(
-        select(sql_func.count()).select_from(TimeTrackingTask).where(TimeTrackingTask.label_id == label_id)
+        select(sql_func.count())
+        .select_from(TimeTrackingTask)
+        .where(TimeTrackingTask.label_id == label_id, TimeTrackingTask.deleted_at.is_(None))
     )
     template_count = await session.scalar(
-        select(sql_func.count()).select_from(TimeTrackingTemplate).where(TimeTrackingTemplate.label_id == label_id)
+        select(sql_func.count())
+        .select_from(TimeTrackingTemplate)
+        .where(TimeTrackingTemplate.label_id == label_id, TimeTrackingTemplate.deleted_at.is_(None))
     )
     if task_count or template_count:
         raise ConflictError("label is in use by tasks or templates and cannot be deleted")
 
-    await session.delete(label)
+    label.deleted_at = datetime.now(UTC)
+    session.add(label)
     await session.commit()
 
 
@@ -341,7 +349,7 @@ async def create_task(session: AsyncSession, user_id: int, payload: TaskCreate) 
 async def get_task(session: AsyncSession, user_id: int, task_id: str) -> TimeTrackingTask:
     """Get a task scoped to a specific user to prevent cross-user access."""
     task = await session.get(TimeTrackingTask, task_id)
-    if task is None or task.user_id != user_id:
+    if task is None or task.user_id != user_id or task.deleted_at is not None:
         raise NotFoundError("task not found")
     return task
 
@@ -355,7 +363,10 @@ async def list_tasks(
     label_id: str | None = None,
     gantt_task_id: str | None = None,
 ) -> list[TimeTrackingTask]:
-    statement = select(TimeTrackingTask).where(TimeTrackingTask.user_id == user_id)
+    statement = select(TimeTrackingTask).where(
+        TimeTrackingTask.user_id == user_id,
+        TimeTrackingTask.deleted_at.is_(None),
+    )
     if start_date is not None:
         statement = statement.where(TimeTrackingTask.start_time >= start_date)
     if end_date is not None:
@@ -374,6 +385,7 @@ async def get_running_task(session: AsyncSession, user_id: int) -> TimeTrackingT
         select(TimeTrackingTask).where(
             TimeTrackingTask.user_id == user_id,
             TimeTrackingTask.stop_time.is_(None),
+            TimeTrackingTask.deleted_at.is_(None),
         )
     )
     return result.scalar_one_or_none()
@@ -413,7 +425,8 @@ async def update_task(
 
 async def delete_task(session: AsyncSession, user_id: int, task_id: str) -> None:
     task = await get_task(session, user_id, task_id)
-    await session.delete(task)
+    task.deleted_at = datetime.now(UTC)
+    session.add(task)
     await session.commit()
 
 
@@ -437,7 +450,7 @@ async def get_template(
 ) -> TimeTrackingTemplate:
     """Get a template scoped to a specific user to prevent cross-user access."""
     template = await session.get(TimeTrackingTemplate, template_id)
-    if template is None or template.user_id != user_id:
+    if template is None or template.user_id != user_id or template.deleted_at is not None:
         raise NotFoundError("template not found")
     return template
 
@@ -447,7 +460,10 @@ async def list_templates_for_user(
 ) -> list[TimeTrackingTemplate]:
     result = await session.execute(
         select(TimeTrackingTemplate)
-        .where(TimeTrackingTemplate.user_id == user_id)
+        .where(
+            TimeTrackingTemplate.user_id == user_id,
+            TimeTrackingTemplate.deleted_at.is_(None),
+        )
         .order_by(TimeTrackingTemplate.created_at.desc())
     )
     return list(result.scalars().all())
@@ -472,7 +488,8 @@ async def update_template(
 
 async def delete_template(session: AsyncSession, user_id: int, template_id: str) -> None:
     template = await get_template(session, user_id, template_id)
-    await session.delete(template)
+    template.deleted_at = datetime.now(UTC)
+    session.add(template)
     await session.commit()
 
 
@@ -496,6 +513,7 @@ async def create_or_update_work_location(
     else:
         for field, value in payload.model_dump().items():
             setattr(location, field, value)
+        location.deleted_at = None
 
     session.add(location)
     await session.commit()
@@ -508,7 +526,9 @@ async def get_work_location(
 ) -> WorkLocation:
     result = await session.execute(
         select(WorkLocation).where(
-            WorkLocation.user_id == user_id, WorkLocation.date == value_date
+            WorkLocation.user_id == user_id,
+            WorkLocation.date == value_date,
+            WorkLocation.deleted_at.is_(None),
         )
     )
     location = result.scalar_one_or_none()
@@ -524,7 +544,10 @@ async def list_work_locations(
     start_date: date | None = None,
     end_date: date | None = None,
 ) -> list[WorkLocation]:
-    statement = select(WorkLocation).where(WorkLocation.user_id == user_id)
+    statement = select(WorkLocation).where(
+        WorkLocation.user_id == user_id,
+        WorkLocation.deleted_at.is_(None),
+    )
     if start_date is not None:
         statement = statement.where(WorkLocation.date >= start_date)
     if end_date is not None:
@@ -552,7 +575,8 @@ async def update_work_location(
 
 async def delete_work_location(session: AsyncSession, user_id: int, value_date: date) -> None:
     location = await get_work_location(session, user_id, value_date)
-    await session.delete(location)
+    location.deleted_at = datetime.now(UTC)
+    session.add(location)
     await session.commit()
 
 
@@ -610,7 +634,8 @@ async def update_gantt_task(
 
 async def delete_gantt_task(session: AsyncSession, user_id: int, task_id: str) -> None:
     task = await get_gantt_task(session, user_id, task_id)
-    await session.delete(task)
+    task.deleted_at = datetime.now(UTC)
+    session.add(task)
     await session.commit()
 
 

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -304,7 +304,9 @@ async def delete_label(session: AsyncSession, user_id: int, label_id: str) -> No
     if task_count or template_count:
         raise ConflictError("label is in use by tasks or templates and cannot be deleted")
 
-    label.deleted_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    label.deleted_at = now
+    label.client_updated_at = now
     session.add(label)
     await session.commit()
 
@@ -326,7 +328,7 @@ async def _validate_task_gantt_reference(
         return
     gantt_task = await session.get(GanttTask, gantt_task_id)
     if gantt_task is None or gantt_task.user_id != user_id or gantt_task.deleted_at is not None:
-        raise ValidationError("gantt task not found")
+        raise NotFoundError("gantt task not found")
 
 
 async def create_task(session: AsyncSession, user_id: int, payload: TaskCreate) -> TimeTrackingTask:
@@ -425,7 +427,9 @@ async def update_task(
 
 async def delete_task(session: AsyncSession, user_id: int, task_id: str) -> None:
     task = await get_task(session, user_id, task_id)
-    task.deleted_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    task.deleted_at = now
+    task.client_updated_at = now
     session.add(task)
     await session.commit()
 
@@ -488,7 +492,9 @@ async def update_template(
 
 async def delete_template(session: AsyncSession, user_id: int, template_id: str) -> None:
     template = await get_template(session, user_id, template_id)
-    template.deleted_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    template.deleted_at = now
+    template.client_updated_at = now
     session.add(template)
     await session.commit()
 
@@ -514,6 +520,7 @@ async def create_or_update_work_location(
         for field, value in payload.model_dump().items():
             setattr(location, field, value)
         location.deleted_at = None
+        location.client_updated_at = datetime.now(UTC)
 
     session.add(location)
     await session.commit()
@@ -575,7 +582,9 @@ async def update_work_location(
 
 async def delete_work_location(session: AsyncSession, user_id: int, value_date: date) -> None:
     location = await get_work_location(session, user_id, value_date)
-    location.deleted_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    location.deleted_at = now
+    location.client_updated_at = now
     session.add(location)
     await session.commit()
 
@@ -634,7 +643,9 @@ async def update_gantt_task(
 
 async def delete_gantt_task(session: AsyncSession, user_id: int, task_id: str) -> None:
     task = await get_gantt_task(session, user_id, task_id)
-    task.deleted_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    task.deleted_at = now
+    task.client_updated_at = now
     session.add(task)
     await session.commit()
 

--- a/backend/tests/test_db_api_endpoints.py
+++ b/backend/tests/test_db_api_endpoints.py
@@ -418,11 +418,11 @@ async def test_db_user_export_endpoint(
     assert "oidc_subject" not in body["user"]
     assert body["preferences"] == {"theme": "dark", "notifications": "off"}
     assert body["time_tracking_labels"][0]["id"] == "label-export"
-    assert body["time_tracking_tasks"][0]["deleted_at"] is not None
+    assert body["time_tracking_tasks"] == []
     assert body["time_tracking_templates"][0]["id"] == "template-export"
-    assert body["work_locations"][0]["deleted_at"] is not None
+    assert body["work_locations"] == []
     assert body["gantt_tasks"][0]["id"] == "gantt-export"
-    assert body["time_off_entries"][0]["deleted_at"] is not None
+    assert body["time_off_entries"] == []
 
     admin_export = client.get(f"/api/users/{owner_id}/export", headers=_auth_headers(other_id, is_admin=True))
     assert admin_export.status_code == 200

--- a/backend/tests/test_db_models_service.py
+++ b/backend/tests/test_db_models_service.py
@@ -41,15 +41,24 @@ from app.services.db_service import (
     create_task,
     create_template,
     create_user,
+    delete_gantt_task,
     delete_label,
+    delete_task,
+    delete_template,
     delete_user,
+    delete_work_location,
+    get_gantt_task,
     get_label,
     get_running_task,
     get_task,
     get_template,
+    get_work_location,
+    list_gantt_tasks,
     list_labels_for_user,
     list_tasks,
+    list_templates_for_user,
     list_users,
+    list_work_locations,
     update_gantt_task,
     update_task,
     update_user,
@@ -228,7 +237,7 @@ async def test_delete_label_succeeds_when_unused(db_session: AsyncSession) -> No
     await delete_label(db_session, user.id, label.id)
 
     labels = await list_labels_for_user(db_session, user.id)
-    assert not any(l.id == label.id for l in labels)
+    assert not any(item.id == label.id for item in labels)
 
 
 async def test_work_location_upsert(db_session: AsyncSession) -> None:
@@ -451,3 +460,83 @@ async def test_get_template_is_scoped_to_user(db_session: AsyncSession) -> None:
 
     with pytest.raises(NotFoundError):
         await get_template(db_session, other.id, template.id)
+
+
+async def test_soft_deleted_entities_are_tombstoned_and_hidden(db_session: AsyncSession) -> None:
+    user = await create_user(db_session, UserCreate(username="soft-delete", display_name="Soft Delete"))
+    label = await create_label(db_session, user.id, LabelCreate(name="Unused", color="#123456"))
+    task = await create_task(
+        db_session,
+        user.id,
+        TaskCreate(
+            text="Completed",
+            start_time=datetime(2026, 6, 1, 9, 0),
+            stop_time=datetime(2026, 6, 1, 10, 0),
+            includes_break=False,
+        ),
+    )
+    template = await create_template(
+        db_session,
+        user.id,
+        TemplateCreate(text="Template", start_time=time(9, 0), stop_time=time(10, 0)),
+    )
+    location = await create_or_update_work_location(
+        db_session,
+        user.id,
+        WorkLocationCreate(date=date(2026, 6, 1), country_code="NL", label="Home"),
+    )
+    gantt_task = await create_gantt_task(
+        db_session,
+        user.id,
+        GanttTaskCreate(
+            name="Milestone",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 6, 2),
+            progress=0,
+        ),
+    )
+
+    await delete_label(db_session, user.id, label.id)
+    await delete_task(db_session, user.id, task.id)
+    await delete_template(db_session, user.id, template.id)
+    await delete_work_location(db_session, user.id, location.date)
+    await delete_gantt_task(db_session, user.id, gantt_task.id)
+
+    for model, entity_id in (
+        (TimeTrackingLabel, label.id),
+        (TimeTrackingTask, task.id),
+        (TimeTrackingTemplate, template.id),
+        (WorkLocation, location.id),
+        (GanttTask, gantt_task.id),
+    ):
+        tombstone = await db_session.get(model, entity_id)
+        assert tombstone is not None
+        assert tombstone.deleted_at is not None
+
+    with pytest.raises(NotFoundError):
+        await get_label(db_session, user.id, label.id)
+    with pytest.raises(NotFoundError):
+        await get_task(db_session, user.id, task.id)
+    with pytest.raises(NotFoundError):
+        await get_template(db_session, user.id, template.id)
+    with pytest.raises(NotFoundError):
+        await get_work_location(db_session, user.id, location.date)
+    with pytest.raises(NotFoundError):
+        await get_gantt_task(db_session, user.id, gantt_task.id)
+
+    assert await get_running_task(db_session, user.id) is None
+    assert await list_labels_for_user(db_session, user.id) == []
+    assert await list_tasks(db_session, user_id=user.id) == []
+    assert await list_templates_for_user(db_session, user.id) == []
+    assert await list_work_locations(db_session, user_id=user.id) == []
+    assert await list_gantt_tasks(db_session, user_id=user.id) == []
+
+    restored = await create_or_update_work_location(
+        db_session,
+        user.id,
+        WorkLocationCreate(date=location.date, country_code="BE", label="Office"),
+    )
+    assert restored.id == location.id
+    assert restored.deleted_at is None
+    assert restored.country_code == "BE"
+    assert [item.id for item in await list_work_locations(db_session, user_id=user.id)] == [location.id]


### PR DESCRIPTION
### Motivation

- Ensure deletion is soft (tombstoned) so deletion history is preserved and deletions propagate to clients via sync instead of removing rows from the DB.
- Make reads and exports consistently exclude tombstoned rows so deleted items are hidden to ordinary users and sync/export flows behave predictably.
- Support restoring a previously-deleted work-location on upsert to satisfy client sync semantics and avoid uniqueness constraint conflicts.

### Description

- Replace hard deletes with tombstones by setting `deleted_at` (instead of `session.delete`) for labels, time-tracking tasks, templates, work locations, and Gantt tasks.
- Filter service read/list/export paths to exclude tombstoned rows (`deleted_at IS NULL`) and ensure `get_*` helpers raise `NotFoundError` for deleted items.
- Change label-deletion logic to only consider active (non-deleted) tasks/templates as blockers, and make work-location upsert clear `deleted_at` to restore existing rows.
- Add regression tests covering tombstone persistence, hidden deleted entities, work-location restoration via upsert, and update the user-export test to assert deleted rows are omitted.

### Testing

- Ran linters and static checks: `ruff` and the type checker completed successfully.
- Verified Python modules compile with `python -m compileall` successfully for the modified files and tests.
- Attempted to run the PostgreSQL-backed pytest suite but it could not complete in this environment because Docker is not available and no Postgres server is listening on `localhost:5432`, so DB-backed tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f22846a84832ea5186886ae2bbe73)