### PR TITLE
chore(android): SDK bump, version catalog, minification, dependabot limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       timezone: "Etc/UTC"
     assignees:
       - "tjorim"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -70,6 +71,7 @@ updates:
       timezone: "Etc/UTC"
     assignees:
       - "tjorim"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "deps(backend)"
       include: "scope"
@@ -89,6 +91,7 @@ updates:
       timezone: "Etc/UTC"
     assignees:
       - "tjorim"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "deps(android)"
       include: "scope"
@@ -106,6 +109,7 @@ updates:
       timezone: "Etc/UTC"
     assignees:
       - "tjorim"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "deps(docker)"
       include: "scope"
@@ -123,6 +127,7 @@ updates:
       timezone: "Etc/UTC"
     assignees:
       - "tjorim"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "deps(compose)"
       include: "scope"
@@ -140,6 +145,7 @@ updates:
       timezone: "Etc/UTC"
     assignees:
       - "tjorim"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.plugin.compose")
-    id("org.jetbrains.kotlin.plugin.serialization")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 fun quoted(value: String) = "\"$value\""
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId = "com.worktime.android"
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 37
         // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
         versionCode = 1000
         versionName = "0.1.0"
@@ -62,7 +62,8 @@ android {
             versionNameSuffix = "-debug"
         }
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
@@ -100,27 +101,27 @@ kotlin {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.19.0")
-    implementation("androidx.activity:activity-compose:1.13.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.10.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
-    implementation("androidx.navigation:navigation-compose:2.9.8")
-    implementation("androidx.compose.ui:ui:1.11.2")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.11.2")
-    implementation("androidx.compose.material3:material3:1.4.0")
-    implementation("androidx.datastore:datastore-preferences:1.2.1")
-    implementation("androidx.security:security-crypto:1.1.0")
-    implementation("com.google.android.material:material:1.14.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
-    implementation("com.squareup.retrofit2:retrofit:3.0.0")
-    implementation("com.squareup.okhttp3:okhttp:5.3.2")
-    implementation("com.squareup.okhttp3:logging-interceptor:5.3.2")
-    implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
-    implementation("net.openid:appauth:0.11.1")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.security.crypto)
+    implementation(libs.material)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.retrofit)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.retrofit.kotlinx.serialization.converter)
+    implementation(libs.appauth)
 
-    debugImplementation("androidx.compose.ui:ui-tooling:1.11.2")
+    debugImplementation(libs.compose.ui.tooling)
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "9.2.1" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.21" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,0 +1,48 @@
+[versions]
+agp = "9.2.1"
+kotlin = "2.3.21"
+
+androidx-core-ktx = "1.19.0"
+androidx-activity = "1.13.0"
+androidx-lifecycle = "2.10.0"
+androidx-navigation = "2.9.8"
+compose-ui = "1.11.2"
+compose-material3 = "1.4.0"
+androidx-datastore = "1.2.1"
+androidx-security-crypto = "1.1.0"
+material = "1.14.0"
+kotlinx-serialization-json = "1.11.0"
+kotlinx-coroutines = "1.11.0"
+retrofit = "3.0.0"
+okhttp = "5.3.2"
+retrofit-kotlinx-serialization-converter = "1.0.0"
+appauth = "0.11.1"
+junit = "4.13.2"
+
+[libraries]
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
+compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+retrofit-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit-kotlinx-serialization-converter" }
+appauth = { module = "net.openid:appauth", version.ref = "appauth" }
+junit = { module = "junit:junit", version.ref = "junit" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

- Bump `targetSdk` from 35 to 37 — `compileSdk` was already 37; aligns with champagnefestival/daynest and satisfies `androidx.core:core-ktx:1.19.0` requirement (closes #778)
- Migrate all Android dependencies and plugins to `android/gradle/libs.versions.toml` version catalog; shared `kotlin` version ref causes Dependabot to group `kotlin.plugin.compose` and `kotlin.plugin.serialization` into a single PR (closes #779)
- Enable `isMinifyEnabled = true` and `isShrinkResources = true` on release builds; existing `proguard-rules.pro` is unchanged — verify rules before shipping (closes #780)
- Add `open-pull-requests-limit: 20` to all six Dependabot ecosystems (npm, uv, gradle, docker, docker-compose, github-actions) to align with champagnefestival (closes #781)

## Test plan

- [ ] Verify `./gradlew assembleDevDebug` succeeds in `android/`
- [ ] Verify `./gradlew assembleDevRelease` succeeds and produces a minified APK
- [ ] Confirm `libs.*` accessors resolve correctly (no unresolved reference errors)
- [ ] Check Dependabot config is valid (GitHub will surface any YAML errors on next run)