### PR TITLE
Android: derive version from package.json, add BUILD_COMMIT, wire up Play Store publishing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{png,jpg,jpeg,gif,webp,svg,ico} binary
+*.{woff,woff2,eot,ttf,otf} binary

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -107,6 +107,6 @@ jobs:
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: com.worktime.android
+          packageName: im.tjor.worktime
           releaseFiles: android/app/build/outputs/bundle/release/*.aab
           track: internal

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -67,3 +67,46 @@ jobs:
           path: android/app/build/outputs/apk/release/*.apk
           if-no-files-found: error
           retention-days: 7
+
+      - name: Bundle release AAB
+        if: steps.keystore.outputs.signing_available == 'true'
+        env:
+          KEYSTORE_PATH: ${{ steps.keystore.outputs.keystore_path }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+          ANDROID_API_BASE_URL: ${{ secrets.ANDROID_API_BASE_URL }}
+          ANDROID_OIDC_ISSUER_URL: ${{ secrets.ANDROID_OIDC_ISSUER_URL }}
+          ANDROID_CERTIFICATE_PIN_HOST: ${{ secrets.ANDROID_CERTIFICATE_PIN_HOST }}
+          ANDROID_CERTIFICATE_PINS: ${{ secrets.ANDROID_CERTIFICATE_PINS }}
+        run: ./gradlew :app:bundleRelease
+
+      - name: Upload release AAB
+        if: steps.keystore.outputs.signing_available == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-aab
+          path: android/app/build/outputs/bundle/release/*.aab
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Check Play Store publishing credentials
+        id: play
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [[ -n "${PLAY_SERVICE_ACCOUNT_JSON}" ]]; then
+            echo "publish_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PLAY_SERVICE_ACCOUNT_JSON is not set. Play Store publish will be skipped."
+            echo "publish_available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to Play Store (internal track)
+        if: steps.keystore.outputs.signing_available == 'true' && steps.play.outputs.publish_available == 'true'
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.worktime.android
+          releaseFiles: android/app/build/outputs/bundle/release/*.aab
+          track: internal

--- a/android/.editorconfig
+++ b/android/.editorconfig
@@ -9,4 +9,4 @@ trim_trailing_whitespace = true
 [*.{kt,kts}]
 ktlint_function_naming_ignore_when_annotated_with = Composable
 ktlint_code_style = android_studio
-max_line_length = 160
+max_line_length = 120

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.worktime.buildlogic.CertPinning
+import groovy.json.JsonSlurper
 import java.util.Properties
 
 plugins {
@@ -117,8 +118,9 @@ val appVersion =
     providers
         .fileContents(layout.projectDirectory.file("../../frontend/package.json"))
         .asText
-        .map { json ->
-            Regex(""""version":\s*"([^"]+)"""").find(json)?.groupValues?.get(1)
+        .map { jsonText ->
+            val json = JsonSlurper().parseText(jsonText) as Map<*, *>
+            json["version"] as? String
                 ?: error("Could not find a \"version\" field in frontend/package.json")
         }.get()
 
@@ -134,7 +136,11 @@ fun versionCodeFor(version: String): Int {
     check(major >= 0) { "Major version must be non-negative, got $major" }
     check(minor in 0..999) { "Minor version must be between 0 and 999 to avoid versionCode collision, got $minor" }
     check(patch in 0..999) { "Patch version must be between 0 and 999 to avoid versionCode collision, got $patch" }
-    return major * 1_000_000 + minor * 1_000 + patch
+    val versionCode = major * 1_000_000 + minor * 1_000 + patch
+    check(versionCode <= 2_100_000_000) {
+        "versionCode $versionCode exceeds Google Play maximum of 2100000000"
+    }
+    return versionCode
 }
 
 // Falls back to "unknown" rather than failing the build when git is unavailable

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -107,6 +107,24 @@ if (releaseArtifactRequested) {
     CertPinning.requireHostConfiguredForPins(resolvedReleaseCertificatePinHost, resolvedReleaseCertificatePins)
 }
 
+// Single source of truth for the app version: frontend/package.json, kept in
+// lockstep with the web release version instead of a hand-maintained literal here.
+val appVersion =
+    File(rootDir.parentFile, "frontend/package.json").readText().let { json ->
+        Regex(""""version":\s*"([^"]+)"""").find(json)?.groupValues?.get(1)
+            ?: error("Could not find a \"version\" field in frontend/package.json")
+    }
+
+fun versionCodeFor(version: String): Int {
+    val parts = version.substringBefore("-").substringBefore("+").split(".")
+    check(parts.size == 3) { "Expected a MAJOR.MINOR.PATCH version, got \"$version\"" }
+    val (major, minor, patch) = parts.map { it.toInt() }
+    return major * 1_000_000 + minor * 1_000 + patch
+}
+
+val gitCommit =
+    providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }.standardOutput.asText.get().trim()
+
 android {
     namespace = "com.worktime.android"
     compileSdk = 37
@@ -138,8 +156,9 @@ android {
         minSdk = 26
         targetSdk = 37
         // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
-        versionCode = 1000
-        versionName = "0.1.0"
+        versionCode = versionCodeFor(appVersion)
+        versionName = appVersion
+        buildConfigField("String", "BUILD_COMMIT", quoted(gitCommit))
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -158,7 +158,8 @@ android {
     namespace = "com.worktime.android"
     compileSdk = 37
 
-    val keystorePath = localProperties.getProperty("keystorePath") ?: providers.environmentVariable("KEYSTORE_PATH").orNull
+    val keystorePath =
+        localProperties.getProperty("keystorePath") ?: providers.environmentVariable("KEYSTORE_PATH").orNull
     val keystorePassword =
         localProperties.getProperty("keystorePassword")
             ?: providers.environmentVariable("STORE_PASSWORD").orNull

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -201,7 +201,6 @@ android {
             buildConfigField("String", "OIDC_REDIRECT_URI", quoted("$redirectScheme:/oauth2redirect"))
             buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(""))
             buildConfigField("String", "CERTIFICATE_PINS", quoted(""))
-            manifestPlaceholders["appAuthRedirectScheme"] = redirectScheme
         }
         release {
             isMinifyEnabled = true
@@ -226,7 +225,6 @@ android {
             buildConfigField("String", "OIDC_REDIRECT_URI", quoted("im.tjor.worktime:/oauth2redirect"))
             buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(resolvedReleaseCertificatePinHost))
             buildConfigField("String", "CERTIFICATE_PINS", quoted(releaseCertificatePins))
-            manifestPlaceholders["appAuthRedirectScheme"] = "im.tjor.worktime"
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -109,21 +109,43 @@ if (releaseArtifactRequested) {
 
 // Single source of truth for the app version: frontend/package.json, kept in
 // lockstep with the web release version instead of a hand-maintained literal here.
+// Read via providers.fileContents (not File.readText()) so the file is tracked
+// as a build configuration input and this stays Configuration Cache-compatible.
 val appVersion =
-    File(rootDir.parentFile, "frontend/package.json").readText().let { json ->
-        Regex(""""version":\s*"([^"]+)"""").find(json)?.groupValues?.get(1)
-            ?: error("Could not find a \"version\" field in frontend/package.json")
-    }
+    providers
+        .fileContents(layout.projectDirectory.file("../../frontend/package.json"))
+        .asText
+        .map { json ->
+            Regex(""""version":\s*"([^"]+)"""").find(json)?.groupValues?.get(1)
+                ?: error("Could not find a \"version\" field in frontend/package.json")
+        }.get()
 
 fun versionCodeFor(version: String): Int {
     val parts = version.substringBefore("-").substringBefore("+").split(".")
     check(parts.size == 3) { "Expected a MAJOR.MINOR.PATCH version, got \"$version\"" }
-    val (major, minor, patch) = parts.map { it.toInt() }
+    val (major, minor, patch) =
+        parts.map {
+            it.toIntOrNull() ?: error("Invalid integer component \"$it\" in version \"$version\"")
+        }
     return major * 1_000_000 + minor * 1_000 + patch
 }
 
+// Falls back to "unknown" rather than failing the build when git is unavailable
+// (e.g. building from a downloaded source archive with no .git directory).
 val gitCommit =
-    providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }.standardOutput.asText.get().trim()
+    try {
+        providers
+            .exec {
+                commandLine("git", "rev-parse", "--short", "HEAD")
+                isIgnoreExitValue = true
+            }.standardOutput
+            .asText
+            .get()
+            .trim()
+            .ifEmpty { "unknown" }
+    } catch (e: Exception) {
+        "unknown"
+    }
 
 android {
     namespace = "com.worktime.android"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt.android)
 }
 
 fun quoted(value: String) = "\"$value\""
@@ -193,12 +195,10 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
-            val redirectScheme = "im.tjor.worktime.debug"
             buildConfigField("String", "WORKTIME_ENVIRONMENT", quoted("debug"))
             buildConfigField("String", "API_BASE_URL", quoted(debugApiBaseUrl))
             buildConfigField("String", "OIDC_CLIENT_ID", quoted(debugOidcClientId))
             buildConfigField("String", "OIDC_SCOPE", quoted(oidcScope))
-            buildConfigField("String", "OIDC_REDIRECT_URI", quoted("$redirectScheme:/oauth2redirect"))
             buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(""))
             buildConfigField("String", "CERTIFICATE_PINS", quoted(""))
         }
@@ -222,7 +222,6 @@ android {
             buildConfigField("String", "API_BASE_URL", quoted(releaseApiBaseUrl))
             buildConfigField("String", "OIDC_CLIENT_ID", quoted(releaseOidcClientId))
             buildConfigField("String", "OIDC_SCOPE", quoted(oidcScope))
-            buildConfigField("String", "OIDC_REDIRECT_URI", quoted("im.tjor.worktime:/oauth2redirect"))
             buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(resolvedReleaseCertificatePinHost))
             buildConfigField("String", "CERTIFICATE_PINS", quoted(releaseCertificatePins))
         }
@@ -278,6 +277,8 @@ dependencies {
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.retrofit.kotlinx.serialization.converter)
     implementation(libs.appauth)
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.android.compiler)
 
     debugImplementation(libs.compose.ui.tooling)
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -127,6 +127,11 @@ fun versionCodeFor(version: String): Int {
         parts.map {
             it.toIntOrNull() ?: error("Invalid integer component \"$it\" in version \"$version\"")
         }
+    // minor/patch must each fit in 3 digits or they'd overflow into the next digit
+    // group and collide with a different version's computed code.
+    check(major >= 0) { "Major version must be non-negative, got $major" }
+    check(minor in 0..999) { "Minor version must be between 0 and 999 to avoid versionCode collision, got $minor" }
+    check(patch in 0..999) { "Patch version must be between 0 and 999 to avoid versionCode collision, got $patch" }
     return major * 1_000_000 + minor * 1_000 + patch
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -152,7 +152,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.worktime.android"
+        applicationId = "im.tjor.worktime"
         minSdk = 26
         targetSdk = 37
         // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
@@ -166,7 +166,7 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
-            val redirectScheme = "com.worktime.android.debug"
+            val redirectScheme = "im.tjor.worktime.debug"
             buildConfigField("String", "WORKTIME_ENVIRONMENT", quoted("debug"))
             buildConfigField("String", "API_BASE_URL", quoted(debugApiBaseUrl))
             buildConfigField("String", "OIDC_CLIENT_ID", quoted(debugOidcClientId))
@@ -196,10 +196,10 @@ android {
             buildConfigField("String", "API_BASE_URL", quoted(releaseApiBaseUrl))
             buildConfigField("String", "OIDC_CLIENT_ID", quoted(releaseOidcClientId))
             buildConfigField("String", "OIDC_SCOPE", quoted(oidcScope))
-            buildConfigField("String", "OIDC_REDIRECT_URI", quoted("com.worktime.android:/oauth2redirect"))
+            buildConfigField("String", "OIDC_REDIRECT_URI", quoted("im.tjor.worktime:/oauth2redirect"))
             buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(resolvedReleaseCertificatePinHost))
             buildConfigField("String", "CERTIFICATE_PINS", quoted(releaseCertificatePins))
-            manifestPlaceholders["appAuthRedirectScheme"] = "com.worktime.android"
+            manifestPlaceholders["appAuthRedirectScheme"] = "im.tjor.worktime"
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,12 +24,12 @@
         <activity
             android:name="net.openid.appauth.RedirectUriReceiverActivity"
             android:exported="true"
-            tools:node="merge">
+            tools:node="replace">
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="${appAuthRedirectScheme}" android:path="/oauth2redirect" />
+                <data android:scheme="${applicationId}" android:path="/oauth2redirect" />
             </intent-filter>
         </activity>
     </application>

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeAndroidApplication.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeAndroidApplication.kt
@@ -1,13 +1,39 @@
 package com.worktime.android.app
 
 import android.app.Application
+import com.worktime.android.core.auth.OidcConfig
+import com.worktime.android.core.auth.OidcSessionManager
+import com.worktime.android.core.config.AppConfig
+import com.worktime.android.core.storage.ApiBaseUrlOverrideStore
+import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
+@HiltAndroidApp
 class WorktimeAndroidApplication : Application() {
+    @Inject
+    lateinit var appConfig: AppConfig
+
+    @Inject
+    lateinit var oidcConfig: OidcConfig
+
+    @Inject
+    lateinit var apiBaseUrlOverrideStore: ApiBaseUrlOverrideStore
+
+    @Inject
+    lateinit var sessionManager: OidcSessionManager
+
     lateinit var container: WorktimeAppContainer
         private set
 
     override fun onCreate() {
         super.onCreate()
-        container = WorktimeAppContainer(applicationContext)
+        container =
+            WorktimeAppContainer(
+                context = applicationContext,
+                appConfig = appConfig,
+                oidcConfig = oidcConfig,
+                apiBaseUrlOverrideStore = apiBaseUrlOverrideStore,
+                sessionManager = sessionManager
+            )
     }
 }

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
@@ -220,6 +220,7 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                     uiState = uiState,
                     actionsState = actionsState,
                     appConfig = container.appConfig,
+                    oidcConfig = container.oidcConfig,
                     initialDestination = initialDestination,
                     notificationPreferences = notificationPreferences,
                     apiBaseUrlOverride = apiBaseUrlOverride,
@@ -270,6 +271,7 @@ private fun WorktimeAuthenticatedScaffold(
     uiState: DashboardUiState,
     actionsState: com.worktime.android.feature.dashboard.MobileActionsUiState,
     appConfig: com.worktime.android.core.config.AppConfig,
+    oidcConfig: com.worktime.android.core.auth.OidcConfig,
     initialDestination: String,
     notificationPreferences: NotificationPreferences,
     apiBaseUrlOverride: String?,
@@ -356,6 +358,7 @@ private fun WorktimeAuthenticatedScaffold(
                     SettingsScreen(
                         uiState = uiState,
                         appConfig = appConfig,
+                        oidcConfig = oidcConfig,
                         notificationPreferences = notificationPreferences,
                         apiBaseUrlOverride = apiBaseUrlOverride,
                         onApiBaseUrlOverrideSave = onApiBaseUrlOverrideSave,

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeAppContainer.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeAppContainer.kt
@@ -2,30 +2,25 @@ package com.worktime.android.app
 
 import android.content.Context
 import com.worktime.android.BuildConfig
+import com.worktime.android.core.auth.OidcConfig
 import com.worktime.android.core.auth.OidcSessionManager
 import com.worktime.android.core.config.AppConfig
-import com.worktime.android.core.config.buildAppConfig
 import com.worktime.android.core.network.CertificatePinnerProvider
 import com.worktime.android.core.storage.ApiBaseUrlOverrideStore
 import com.worktime.android.core.storage.BiometricLockPreferencesStore
 import com.worktime.android.core.storage.NotificationPreferencesStore
-import com.worktime.android.core.storage.SecureSessionStore
 import com.worktime.android.data.api.WorktimeApi
 import com.worktime.android.data.repository.WorktimeRepository
 
-class WorktimeAppContainer(context: Context) {
-    val appConfig: AppConfig = buildAppConfig()
-    private val secureSessionStore = SecureSessionStore(context)
+class WorktimeAppContainer(
+    context: Context,
+    val appConfig: AppConfig,
+    val oidcConfig: OidcConfig,
+    val apiBaseUrlOverrideStore: ApiBaseUrlOverrideStore,
+    val sessionManager: OidcSessionManager
+) {
     val notificationPreferencesStore = NotificationPreferencesStore(context)
-    val apiBaseUrlOverrideStore = ApiBaseUrlOverrideStore(context)
     val biometricLockPreferencesStore = BiometricLockPreferencesStore(context)
-    val sessionManager =
-        OidcSessionManager(
-            context = context,
-            appConfig = appConfig,
-            sessionStore = secureSessionStore,
-            apiBaseUrlProvider = apiBaseUrlOverrideStore::currentOverrideBlocking
-        )
     private val api =
         WorktimeApi.create(
             baseUrl = appConfig.apiBaseUrl,

--- a/android/app/src/main/java/com/worktime/android/core/auth/AuthDiModule.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/AuthDiModule.kt
@@ -26,7 +26,8 @@ object AuthDiModule {
     // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
     @Provides
     @Singleton
-    fun provideOidcServiceConfigurationDiscovery(appConfig: AppConfig): OidcServiceConfigurationDiscovery = OidcServiceConfigurationDiscovery(
-        OkHttpClient.Builder().certificatePinner(CertificatePinnerProvider.fromConfig(appConfig)).build()
-    )
+    fun provideOidcServiceConfigurationDiscovery(appConfig: AppConfig): OidcServiceConfigurationDiscovery =
+        OidcServiceConfigurationDiscovery(
+            OkHttpClient.Builder().certificatePinner(CertificatePinnerProvider.fromConfig(appConfig)).build()
+        )
 }

--- a/android/app/src/main/java/com/worktime/android/core/auth/AuthDiModule.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/AuthDiModule.kt
@@ -26,8 +26,7 @@ object AuthDiModule {
     // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
     @Provides
     @Singleton
-    fun provideOidcServiceConfigurationDiscovery(appConfig: AppConfig): OidcServiceConfigurationDiscovery =
-        OidcServiceConfigurationDiscovery(
-            OkHttpClient.Builder().certificatePinner(CertificatePinnerProvider.fromConfig(appConfig)).build()
-        )
+    fun provideOidcServiceConfigurationDiscovery(appConfig: AppConfig): OidcServiceConfigurationDiscovery = OidcServiceConfigurationDiscovery(
+        OkHttpClient.Builder().certificatePinner(CertificatePinnerProvider.fromConfig(appConfig)).build()
+    )
 }

--- a/android/app/src/main/java/com/worktime/android/core/auth/AuthDiModule.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/AuthDiModule.kt
@@ -1,0 +1,33 @@
+package com.worktime.android.core.auth
+
+import com.worktime.android.core.config.AppConfig
+import com.worktime.android.core.config.buildAppConfig
+import com.worktime.android.core.network.CertificatePinnerProvider
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import okhttp3.OkHttpClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AuthDiModule {
+    @Provides
+    @Singleton
+    fun provideAppConfig(): AppConfig = buildAppConfig()
+
+    @Provides
+    @Singleton
+    fun provideOidcConfig(): OidcConfig = buildOidcConfig()
+
+    // Discovery returns the endpoints the whole auth flow trusts, so it must be
+    // pinned exactly like the API client; a plain OkHttpClient would let a
+    // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
+    @Provides
+    @Singleton
+    fun provideOidcServiceConfigurationDiscovery(appConfig: AppConfig): OidcServiceConfigurationDiscovery =
+        OidcServiceConfigurationDiscovery(
+            OkHttpClient.Builder().certificatePinner(CertificatePinnerProvider.fromConfig(appConfig)).build()
+        )
+}

--- a/android/app/src/main/java/com/worktime/android/core/auth/BiometricAuthenticator.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/BiometricAuthenticator.kt
@@ -30,21 +30,22 @@ class BiometricAuthenticator(private val activity: FragmentActivity) {
     private val allowedAuthenticators =
         BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
 
-    fun checkAvailability(): BiometricAvailability = when (BiometricManager.from(activity).canAuthenticate(allowedAuthenticators)) {
-        BiometricManager.BIOMETRIC_SUCCESS -> BiometricAvailability.Available
-        BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
-            BiometricAvailability.Unavailable(
-                "No biometric or device credential is set up on this device. Add one in your device " +
-                    "settings, or turn off app lock in Worktime settings."
-            )
-        BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE ->
-            BiometricAvailability.Unavailable("This device has no biometric hardware.")
-        BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE ->
-            BiometricAvailability.Unavailable("Biometric hardware is currently unavailable. Try again shortly.")
-        BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
-            BiometricAvailability.Unavailable("A security update is required before app lock can be used.")
-        else -> BiometricAvailability.Unavailable("Device authentication is not available right now.")
-    }
+    fun checkAvailability(): BiometricAvailability =
+        when (BiometricManager.from(activity).canAuthenticate(allowedAuthenticators)) {
+            BiometricManager.BIOMETRIC_SUCCESS -> BiometricAvailability.Available
+            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
+                BiometricAvailability.Unavailable(
+                    "No biometric or device credential is set up on this device. Add one in your device " +
+                        "settings, or turn off app lock in Worktime settings."
+                )
+            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE ->
+                BiometricAvailability.Unavailable("This device has no biometric hardware.")
+            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE ->
+                BiometricAvailability.Unavailable("Biometric hardware is currently unavailable. Try again shortly.")
+            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
+                BiometricAvailability.Unavailable("A security update is required before app lock can be used.")
+            else -> BiometricAvailability.Unavailable("Device authentication is not available right now.")
+        }
 
     fun authenticate(onSuccess: () -> Unit, onError: (String) -> Unit) {
         val executor = ContextCompat.getMainExecutor(activity)

--- a/android/app/src/main/java/com/worktime/android/core/auth/BiometricGateDecision.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/BiometricGateDecision.kt
@@ -5,7 +5,12 @@ package com.worktime.android.core.auth
  * so it can be unit tested without an Activity or real biometric hardware.
  */
 object BiometricGateDecision {
-    fun shouldRequireAuthentication(lockEnabled: Boolean, idleTimeoutMinutes: Int, lastBackgroundEpochMillis: Long?, nowEpochMillis: Long): Boolean {
+    fun shouldRequireAuthentication(
+        lockEnabled: Boolean,
+        idleTimeoutMinutes: Int,
+        lastBackgroundEpochMillis: Long?,
+        nowEpochMillis: Long
+    ): Boolean {
         if (!lockEnabled) return false
         if (lastBackgroundEpochMillis == null) return false
         val idleMillis = nowEpochMillis - lastBackgroundEpochMillis

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcConfig.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcConfig.kt
@@ -1,0 +1,16 @@
+package com.worktime.android.core.auth
+
+import android.net.Uri
+import com.worktime.android.BuildConfig
+
+data class OidcConfig(
+    val clientId: String,
+    val redirectUri: Uri,
+    val scope: String
+)
+
+fun buildOidcConfig(): OidcConfig = OidcConfig(
+    clientId = BuildConfig.OIDC_CLIENT_ID,
+    redirectUri = Uri.parse("${BuildConfig.APPLICATION_ID}:/oauth2redirect"),
+    scope = BuildConfig.OIDC_SCOPE
+)

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcConfig.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcConfig.kt
@@ -3,11 +3,7 @@ package com.worktime.android.core.auth
 import android.net.Uri
 import com.worktime.android.BuildConfig
 
-data class OidcConfig(
-    val clientId: String,
-    val redirectUri: Uri,
-    val scope: String
-)
+data class OidcConfig(val clientId: String, val redirectUri: Uri, val scope: String)
 
 fun buildOidcConfig(): OidcConfig = OidcConfig(
     clientId = BuildConfig.OIDC_CLIENT_ID,

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscovery.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscovery.kt
@@ -19,7 +19,7 @@ class OidcServiceConfigurationDiscovery(private val client: OkHttpClient = OkHtt
                 val errorBody = runCatching { response.peekBody(1024).string() }.getOrElse { "" }
                 throw IOException("OIDC config endpoint returned HTTP ${response.code}: $errorBody")
             }
-            val body = response.body.string()
+            val body = runCatching { response.body.string() }.getOrElse { "" }
             if (body.isBlank()) {
                 throw IOException("Empty response from OIDC config endpoint")
             }

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -25,128 +25,130 @@ import net.openid.appauth.ResponseTypeValues
 import net.openid.appauth.TokenRequest
 
 @Singleton
-class OidcSessionManager @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val appConfig: AppConfig,
-    private val oidcConfig: OidcConfig,
-    private val sessionStore: SecureSessionStore,
-    private val apiBaseUrlOverrideStore: ApiBaseUrlOverrideStore,
-    // Discovery returns the endpoints the whole auth flow trusts, so it must be
-    // pinned exactly like the API client; a plain OkHttpClient would let a
-    // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
-    private val oidcDiscovery: OidcServiceConfigurationDiscovery
-) : SessionController {
-    private val tokenMutex = Mutex()
-    private val configMutex = Mutex()
-    private val _sessionState = MutableStateFlow<SessionState>(SessionState.Initializing)
-    override val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
-    private var cachedConfiguration: Pair<String, AuthorizationServiceConfiguration>? = null
+class OidcSessionManager
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val appConfig: AppConfig,
+        private val oidcConfig: OidcConfig,
+        private val sessionStore: SecureSessionStore,
+        private val apiBaseUrlOverrideStore: ApiBaseUrlOverrideStore,
+        // Discovery returns the endpoints the whole auth flow trusts, so it must be
+        // pinned exactly like the API client; a plain OkHttpClient would let a
+        // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
+        private val oidcDiscovery: OidcServiceConfigurationDiscovery
+    ) : SessionController {
+        private val tokenMutex = Mutex()
+        private val configMutex = Mutex()
+        private val _sessionState = MutableStateFlow<SessionState>(SessionState.Initializing)
+        override val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
+        private var cachedConfiguration: Pair<String, AuthorizationServiceConfiguration>? = null
 
-    private var authState: AuthState? =
-        try {
-            sessionStore
-                .readAuthStateJson()
-                ?.takeIf { it.isNotBlank() }
-                ?.let(AuthState::jsonDeserialize)
-                ?.also(::publishState)
-        } catch (_: Exception) {
-            // readAuthStateJson() is backed by EncryptedSharedPreferences, which can throw
-            // GeneralSecurityException/IOException if the Android Keystore key is lost or
-            // corrupted, not just JSONException from malformed AuthState JSON. Treat any of
-            // these as a logged-out state rather than crashing on startup.
-            sessionStore.clear()
-            null
-        } ?: run {
-            _sessionState.value = SessionState.LoggedOut
-            null
+        private var authState: AuthState? =
+            try {
+                sessionStore
+                    .readAuthStateJson()
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(AuthState::jsonDeserialize)
+                    ?.also(::publishState)
+            } catch (_: Exception) {
+                // readAuthStateJson() is backed by EncryptedSharedPreferences, which can throw
+                // GeneralSecurityException/IOException if the Android Keystore key is lost or
+                // corrupted, not just JSONException from malformed AuthState JSON. Treat any of
+                // these as a logged-out state rather than crashing on startup.
+                sessionStore.clear()
+                null
+            } ?: run {
+                _sessionState.value = SessionState.LoggedOut
+                null
+            }
+
+        override suspend fun createAuthorizationIntent(): Intent {
+            val configuration = fetchAuthorizationServiceConfiguration()
+            val request =
+                AuthorizationRequest
+                    .Builder(
+                        configuration,
+                        oidcConfig.clientId,
+                        ResponseTypeValues.CODE,
+                        oidcConfig.redirectUri
+                    ).setScope(oidcConfig.scope)
+                    .build()
+
+            return AuthorizationService(context).getAuthorizationRequestIntent(request)
         }
 
-    override suspend fun createAuthorizationIntent(): Intent {
-        val configuration = fetchAuthorizationServiceConfiguration()
-        val request =
-            AuthorizationRequest
-                .Builder(
-                    configuration,
-                    oidcConfig.clientId,
-                    ResponseTypeValues.CODE,
-                    oidcConfig.redirectUri
-                ).setScope(oidcConfig.scope)
-                .build()
+        override suspend fun handleAuthorizationResponse(intent: Intent?): Result<Unit> = runCatching {
+            requireNotNull(intent) { "Missing sign-in result" }
+            val response = AuthorizationResponse.fromIntent(intent)
+            val exception = AuthorizationException.fromIntent(intent)
+            val newState = AuthState(response, exception)
 
-        return AuthorizationService(context).getAuthorizationRequestIntent(request)
-    }
+            if (response == null) {
+                val message = exception?.errorDescription ?: "Sign-in was cancelled"
+                _sessionState.value = SessionState.Error(message)
+                throw IllegalStateException(message)
+            }
 
-    override suspend fun handleAuthorizationResponse(intent: Intent?): Result<Unit> = runCatching {
-        requireNotNull(intent) { "Missing sign-in result" }
-        val response = AuthorizationResponse.fromIntent(intent)
-        val exception = AuthorizationException.fromIntent(intent)
-        val newState = AuthState(response, exception)
+            val (tokenResponse, tokenException) = performTokenRequest(response.createTokenExchangeRequest())
+            newState.update(tokenResponse, tokenException)
+            if (tokenException != null || tokenResponse?.accessToken.isNullOrBlank()) {
+                val message = tokenException?.errorDescription ?: "Missing access token"
+                _sessionState.value = SessionState.Error(message)
+                throw IllegalStateException(message)
+            }
 
-        if (response == null) {
-            val message = exception?.errorDescription ?: "Sign-in was cancelled"
-            _sessionState.value = SessionState.Error(message)
-            throw IllegalStateException(message)
+            persistAuthState(newState)
         }
 
-        val (tokenResponse, tokenException) = performTokenRequest(response.createTokenExchangeRequest())
-        newState.update(tokenResponse, tokenException)
-        if (tokenException != null || tokenResponse?.accessToken.isNullOrBlank()) {
-            val message = tokenException?.errorDescription ?: "Missing access token"
-            _sessionState.value = SessionState.Error(message)
-            throw IllegalStateException(message)
-        }
-
-        persistAuthState(newState)
-    }
-
-    override suspend fun getFreshAccessToken(): String? = tokenMutex.withLock {
-        val currentState = authState ?: return null
-        return suspendCancellableCoroutine { continuation ->
-            val service = AuthorizationService(context)
-            currentState.performActionWithFreshTokens(service) { accessToken, _, exception ->
-                service.dispose()
-                if (exception != null || accessToken.isNullOrBlank()) {
-                    logout()
-                    continuation.resume(null)
-                    return@performActionWithFreshTokens
+        override suspend fun getFreshAccessToken(): String? = tokenMutex.withLock {
+            val currentState = authState ?: return null
+            return suspendCancellableCoroutine { continuation ->
+                val service = AuthorizationService(context)
+                currentState.performActionWithFreshTokens(service) { accessToken, _, exception ->
+                    service.dispose()
+                    if (exception != null || accessToken.isNullOrBlank()) {
+                        logout()
+                        continuation.resume(null)
+                        return@performActionWithFreshTokens
+                    }
+                    persistAuthState(currentState)
+                    continuation.resume(accessToken)
                 }
-                persistAuthState(currentState)
-                continuation.resume(accessToken)
-            }
-        }
-    }
-
-    override fun logout() {
-        authState = null
-        sessionStore.clear()
-        _sessionState.value = SessionState.LoggedOut
-    }
-
-    private suspend fun fetchAuthorizationServiceConfiguration(): AuthorizationServiceConfiguration {
-        val apiBaseUrl = apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
-        cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.let { return it.second }
-        return configMutex.withLock {
-            cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.second
-                ?: oidcDiscovery.fetch(apiBaseUrl).also { cachedConfiguration = apiBaseUrl to it }
-        }
-    }
-
-    private suspend fun performTokenRequest(request: TokenRequest): Pair<net.openid.appauth.TokenResponse?, AuthorizationException?> =
-        suspendCancellableCoroutine { continuation ->
-            val service = AuthorizationService(context)
-            service.performTokenRequest(request) { response, ex ->
-                service.dispose()
-                continuation.resume(response to ex)
             }
         }
 
-    private fun persistAuthState(state: AuthState) {
-        authState = state
-        sessionStore.writeAuthStateJson(state.jsonSerializeString())
-        publishState(state)
-    }
+        override fun logout() {
+            authState = null
+            sessionStore.clear()
+            _sessionState.value = SessionState.LoggedOut
+        }
 
-    private fun publishState(state: AuthState) {
-        _sessionState.value = SessionState.Authenticated(hasRefreshToken = !state.refreshToken.isNullOrBlank())
+        private suspend fun fetchAuthorizationServiceConfiguration(): AuthorizationServiceConfiguration {
+            val apiBaseUrl = apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
+            cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.let { return it.second }
+            return configMutex.withLock {
+                cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.second
+                    ?: oidcDiscovery.fetch(apiBaseUrl).also { cachedConfiguration = apiBaseUrl to it }
+            }
+        }
+
+        private suspend fun performTokenRequest(request: TokenRequest): Pair<net.openid.appauth.TokenResponse?, AuthorizationException?> =
+            suspendCancellableCoroutine { continuation ->
+                val service = AuthorizationService(context)
+                service.performTokenRequest(request) { response, ex ->
+                    service.dispose()
+                    continuation.resume(response to ex)
+                }
+            }
+
+        private fun persistAuthState(state: AuthState) {
+            authState = state
+            sessionStore.writeAuthStateJson(state.jsonSerializeString())
+            publishState(state)
+        }
+
+        private fun publishState(state: AuthState) {
+            _sessionState.value = SessionState.Authenticated(hasRefreshToken = !state.refreshToken.isNullOrBlank())
+        }
     }
-}

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -2,10 +2,12 @@ package com.worktime.android.core.auth
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import com.worktime.android.core.config.AppConfig
-import com.worktime.android.core.network.CertificatePinnerProvider
+import com.worktime.android.core.storage.ApiBaseUrlOverrideStore
 import com.worktime.android.core.storage.SecureSessionStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,19 +23,20 @@ import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
 import net.openid.appauth.ResponseTypeValues
 import net.openid.appauth.TokenRequest
-import okhttp3.OkHttpClient
 
-class OidcSessionManager(
-    private val context: Context,
+@Singleton
+class OidcSessionManager
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
     private val appConfig: AppConfig,
+    private val oidcConfig: OidcConfig,
     private val sessionStore: SecureSessionStore,
-    private val apiBaseUrlProvider: () -> String? = { null },
+    private val apiBaseUrlOverrideStore: ApiBaseUrlOverrideStore,
     // Discovery returns the endpoints the whole auth flow trusts, so it must be
     // pinned exactly like the API client; a plain OkHttpClient would let a
     // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
-    private val oidcDiscovery: OidcServiceConfigurationDiscovery = OidcServiceConfigurationDiscovery(
-        OkHttpClient.Builder().certificatePinner(CertificatePinnerProvider.fromConfig(appConfig)).build()
-    )
+    private val oidcDiscovery: OidcServiceConfigurationDiscovery
 ) : SessionController {
     private val tokenMutex = Mutex()
     private val configMutex = Mutex()
@@ -66,10 +69,10 @@ class OidcSessionManager(
             AuthorizationRequest
                 .Builder(
                     configuration,
-                    appConfig.oidcClientId,
+                    oidcConfig.clientId,
                     ResponseTypeValues.CODE,
-                    Uri.parse(appConfig.oidcRedirectUri)
-                ).setScope(appConfig.oidcScope)
+                    oidcConfig.redirectUri
+                ).setScope(oidcConfig.scope)
                 .build()
 
         return AuthorizationService(context).getAuthorizationRequestIntent(request)
@@ -122,7 +125,7 @@ class OidcSessionManager(
     }
 
     private suspend fun fetchAuthorizationServiceConfiguration(): AuthorizationServiceConfiguration {
-        val apiBaseUrl = apiBaseUrlProvider()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
+        val apiBaseUrl = apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
         cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.let { return it.second }
         return configMutex.withLock {
             cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.second

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -25,9 +25,7 @@ import net.openid.appauth.ResponseTypeValues
 import net.openid.appauth.TokenRequest
 
 @Singleton
-class OidcSessionManager
-@Inject
-constructor(
+class OidcSessionManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val appConfig: AppConfig,
     private val oidcConfig: OidcConfig,

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -123,7 +123,8 @@ class OidcSessionManager @Inject constructor(
     }
 
     private suspend fun fetchAuthorizationServiceConfiguration(): AuthorizationServiceConfiguration {
-        val apiBaseUrl = apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
+        val apiBaseUrl =
+            apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
         cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.let { return it.second }
         return configMutex.withLock {
             cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.second
@@ -131,14 +132,15 @@ class OidcSessionManager @Inject constructor(
         }
     }
 
-    private suspend fun performTokenRequest(request: TokenRequest): Pair<net.openid.appauth.TokenResponse?, AuthorizationException?> =
-        suspendCancellableCoroutine { continuation ->
-            val service = AuthorizationService(context)
-            service.performTokenRequest(request) { response, ex ->
-                service.dispose()
-                continuation.resume(response to ex)
-            }
+    private suspend fun performTokenRequest(
+        request: TokenRequest
+    ): Pair<net.openid.appauth.TokenResponse?, AuthorizationException?> = suspendCancellableCoroutine { continuation ->
+        val service = AuthorizationService(context)
+        service.performTokenRequest(request) { response, ex ->
+            service.dispose()
+            continuation.resume(response to ex)
         }
+    }
 
     private fun persistAuthState(state: AuthState) {
         authState = state

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -25,130 +25,128 @@ import net.openid.appauth.ResponseTypeValues
 import net.openid.appauth.TokenRequest
 
 @Singleton
-class OidcSessionManager
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-        private val appConfig: AppConfig,
-        private val oidcConfig: OidcConfig,
-        private val sessionStore: SecureSessionStore,
-        private val apiBaseUrlOverrideStore: ApiBaseUrlOverrideStore,
-        // Discovery returns the endpoints the whole auth flow trusts, so it must be
-        // pinned exactly like the API client; a plain OkHttpClient would let a
-        // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
-        private val oidcDiscovery: OidcServiceConfigurationDiscovery
-    ) : SessionController {
-        private val tokenMutex = Mutex()
-        private val configMutex = Mutex()
-        private val _sessionState = MutableStateFlow<SessionState>(SessionState.Initializing)
-        override val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
-        private var cachedConfiguration: Pair<String, AuthorizationServiceConfiguration>? = null
+class OidcSessionManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val appConfig: AppConfig,
+    private val oidcConfig: OidcConfig,
+    private val sessionStore: SecureSessionStore,
+    private val apiBaseUrlOverrideStore: ApiBaseUrlOverrideStore,
+    // Discovery returns the endpoints the whole auth flow trusts, so it must be
+    // pinned exactly like the API client; a plain OkHttpClient would let a
+    // MITM with a rogue CA swap in attacker-controlled authorization/token URLs.
+    private val oidcDiscovery: OidcServiceConfigurationDiscovery
+) : SessionController {
+    private val tokenMutex = Mutex()
+    private val configMutex = Mutex()
+    private val _sessionState = MutableStateFlow<SessionState>(SessionState.Initializing)
+    override val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
+    private var cachedConfiguration: Pair<String, AuthorizationServiceConfiguration>? = null
 
-        private var authState: AuthState? =
-            try {
-                sessionStore
-                    .readAuthStateJson()
-                    ?.takeIf { it.isNotBlank() }
-                    ?.let(AuthState::jsonDeserialize)
-                    ?.also(::publishState)
-            } catch (_: Exception) {
-                // readAuthStateJson() is backed by EncryptedSharedPreferences, which can throw
-                // GeneralSecurityException/IOException if the Android Keystore key is lost or
-                // corrupted, not just JSONException from malformed AuthState JSON. Treat any of
-                // these as a logged-out state rather than crashing on startup.
-                sessionStore.clear()
-                null
-            } ?: run {
-                _sessionState.value = SessionState.LoggedOut
-                null
-            }
-
-        override suspend fun createAuthorizationIntent(): Intent {
-            val configuration = fetchAuthorizationServiceConfiguration()
-            val request =
-                AuthorizationRequest
-                    .Builder(
-                        configuration,
-                        oidcConfig.clientId,
-                        ResponseTypeValues.CODE,
-                        oidcConfig.redirectUri
-                    ).setScope(oidcConfig.scope)
-                    .build()
-
-            return AuthorizationService(context).getAuthorizationRequestIntent(request)
-        }
-
-        override suspend fun handleAuthorizationResponse(intent: Intent?): Result<Unit> = runCatching {
-            requireNotNull(intent) { "Missing sign-in result" }
-            val response = AuthorizationResponse.fromIntent(intent)
-            val exception = AuthorizationException.fromIntent(intent)
-            val newState = AuthState(response, exception)
-
-            if (response == null) {
-                val message = exception?.errorDescription ?: "Sign-in was cancelled"
-                _sessionState.value = SessionState.Error(message)
-                throw IllegalStateException(message)
-            }
-
-            val (tokenResponse, tokenException) = performTokenRequest(response.createTokenExchangeRequest())
-            newState.update(tokenResponse, tokenException)
-            if (tokenException != null || tokenResponse?.accessToken.isNullOrBlank()) {
-                val message = tokenException?.errorDescription ?: "Missing access token"
-                _sessionState.value = SessionState.Error(message)
-                throw IllegalStateException(message)
-            }
-
-            persistAuthState(newState)
-        }
-
-        override suspend fun getFreshAccessToken(): String? = tokenMutex.withLock {
-            val currentState = authState ?: return null
-            return suspendCancellableCoroutine { continuation ->
-                val service = AuthorizationService(context)
-                currentState.performActionWithFreshTokens(service) { accessToken, _, exception ->
-                    service.dispose()
-                    if (exception != null || accessToken.isNullOrBlank()) {
-                        logout()
-                        continuation.resume(null)
-                        return@performActionWithFreshTokens
-                    }
-                    persistAuthState(currentState)
-                    continuation.resume(accessToken)
-                }
-            }
-        }
-
-        override fun logout() {
-            authState = null
+    private var authState: AuthState? =
+        try {
+            sessionStore
+                .readAuthStateJson()
+                ?.takeIf { it.isNotBlank() }
+                ?.let(AuthState::jsonDeserialize)
+                ?.also(::publishState)
+        } catch (_: Exception) {
+            // readAuthStateJson() is backed by EncryptedSharedPreferences, which can throw
+            // GeneralSecurityException/IOException if the Android Keystore key is lost or
+            // corrupted, not just JSONException from malformed AuthState JSON. Treat any of
+            // these as a logged-out state rather than crashing on startup.
             sessionStore.clear()
+            null
+        } ?: run {
             _sessionState.value = SessionState.LoggedOut
+            null
         }
 
-        private suspend fun fetchAuthorizationServiceConfiguration(): AuthorizationServiceConfiguration {
-            val apiBaseUrl = apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
-            cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.let { return it.second }
-            return configMutex.withLock {
-                cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.second
-                    ?: oidcDiscovery.fetch(apiBaseUrl).also { cachedConfiguration = apiBaseUrl to it }
-            }
+    override suspend fun createAuthorizationIntent(): Intent {
+        val configuration = fetchAuthorizationServiceConfiguration()
+        val request =
+            AuthorizationRequest
+                .Builder(
+                    configuration,
+                    oidcConfig.clientId,
+                    ResponseTypeValues.CODE,
+                    oidcConfig.redirectUri
+                ).setScope(oidcConfig.scope)
+                .build()
+
+        return AuthorizationService(context).getAuthorizationRequestIntent(request)
+    }
+
+    override suspend fun handleAuthorizationResponse(intent: Intent?): Result<Unit> = runCatching {
+        requireNotNull(intent) { "Missing sign-in result" }
+        val response = AuthorizationResponse.fromIntent(intent)
+        val exception = AuthorizationException.fromIntent(intent)
+        val newState = AuthState(response, exception)
+
+        if (response == null) {
+            val message = exception?.errorDescription ?: "Sign-in was cancelled"
+            _sessionState.value = SessionState.Error(message)
+            throw IllegalStateException(message)
         }
 
-        private suspend fun performTokenRequest(request: TokenRequest): Pair<net.openid.appauth.TokenResponse?, AuthorizationException?> =
-            suspendCancellableCoroutine { continuation ->
-                val service = AuthorizationService(context)
-                service.performTokenRequest(request) { response, ex ->
-                    service.dispose()
-                    continuation.resume(response to ex)
+        val (tokenResponse, tokenException) = performTokenRequest(response.createTokenExchangeRequest())
+        newState.update(tokenResponse, tokenException)
+        if (tokenException != null || tokenResponse?.accessToken.isNullOrBlank()) {
+            val message = tokenException?.errorDescription ?: "Missing access token"
+            _sessionState.value = SessionState.Error(message)
+            throw IllegalStateException(message)
+        }
+
+        persistAuthState(newState)
+    }
+
+    override suspend fun getFreshAccessToken(): String? = tokenMutex.withLock {
+        val currentState = authState ?: return null
+        return suspendCancellableCoroutine { continuation ->
+            val service = AuthorizationService(context)
+            currentState.performActionWithFreshTokens(service) { accessToken, _, exception ->
+                service.dispose()
+                if (exception != null || accessToken.isNullOrBlank()) {
+                    logout()
+                    continuation.resume(null)
+                    return@performActionWithFreshTokens
                 }
+                persistAuthState(currentState)
+                continuation.resume(accessToken)
             }
-
-        private fun persistAuthState(state: AuthState) {
-            authState = state
-            sessionStore.writeAuthStateJson(state.jsonSerializeString())
-            publishState(state)
-        }
-
-        private fun publishState(state: AuthState) {
-            _sessionState.value = SessionState.Authenticated(hasRefreshToken = !state.refreshToken.isNullOrBlank())
         }
     }
+
+    override fun logout() {
+        authState = null
+        sessionStore.clear()
+        _sessionState.value = SessionState.LoggedOut
+    }
+
+    private suspend fun fetchAuthorizationServiceConfiguration(): AuthorizationServiceConfiguration {
+        val apiBaseUrl = apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
+        cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.let { return it.second }
+        return configMutex.withLock {
+            cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.second
+                ?: oidcDiscovery.fetch(apiBaseUrl).also { cachedConfiguration = apiBaseUrl to it }
+        }
+    }
+
+    private suspend fun performTokenRequest(request: TokenRequest): Pair<net.openid.appauth.TokenResponse?, AuthorizationException?> =
+        suspendCancellableCoroutine { continuation ->
+            val service = AuthorizationService(context)
+            service.performTokenRequest(request) { response, ex ->
+                service.dispose()
+                continuation.resume(response to ex)
+            }
+        }
+
+    private fun persistAuthState(state: AuthState) {
+        authState = state
+        sessionStore.writeAuthStateJson(state.jsonSerializeString())
+        publishState(state)
+    }
+
+    private fun publishState(state: AuthState) {
+        _sessionState.value = SessionState.Authenticated(hasRefreshToken = !state.refreshToken.isNullOrBlank())
+    }
+}

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -42,6 +42,7 @@ class OidcSessionManager @Inject constructor(
     override val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
     private var cachedConfiguration: Pair<String, AuthorizationServiceConfiguration>? = null
 
+    @Volatile
     private var authState: AuthState? =
         try {
             sessionStore
@@ -123,8 +124,7 @@ class OidcSessionManager @Inject constructor(
     }
 
     private suspend fun fetchAuthorizationServiceConfiguration(): AuthorizationServiceConfiguration {
-        val apiBaseUrl =
-            apiBaseUrlOverrideStore.currentOverrideBlocking()?.takeIf { it.isNotBlank() } ?: appConfig.apiBaseUrl
+        val apiBaseUrl = apiBaseUrlOverrideStore.override.value ?: appConfig.apiBaseUrl
         cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.let { return it.second }
         return configMutex.withLock {
             cachedConfiguration?.takeIf { it.first == apiBaseUrl }?.second

--- a/android/app/src/main/java/com/worktime/android/core/config/AppConfig.kt
+++ b/android/app/src/main/java/com/worktime/android/core/config/AppConfig.kt
@@ -2,7 +2,12 @@ package com.worktime.android.core.config
 
 import com.worktime.android.BuildConfig
 
-data class AppConfig(val environment: String, val apiBaseUrl: String, val certificatePinHost: String, val certificatePins: List<String>)
+data class AppConfig(
+    val environment: String,
+    val apiBaseUrl: String,
+    val certificatePinHost: String,
+    val certificatePins: List<String>
+)
 
 fun buildAppConfig(): AppConfig = AppConfig(
     environment = BuildConfig.WORKTIME_ENVIRONMENT,

--- a/android/app/src/main/java/com/worktime/android/core/config/AppConfig.kt
+++ b/android/app/src/main/java/com/worktime/android/core/config/AppConfig.kt
@@ -2,12 +2,7 @@ package com.worktime.android.core.config
 
 import com.worktime.android.BuildConfig
 
-data class AppConfig(
-    val environment: String,
-    val apiBaseUrl: String,
-    val certificatePinHost: String,
-    val certificatePins: List<String>
-)
+data class AppConfig(val environment: String, val apiBaseUrl: String, val certificatePinHost: String, val certificatePins: List<String>)
 
 fun buildAppConfig(): AppConfig = AppConfig(
     environment = BuildConfig.WORKTIME_ENVIRONMENT,

--- a/android/app/src/main/java/com/worktime/android/core/config/AppConfig.kt
+++ b/android/app/src/main/java/com/worktime/android/core/config/AppConfig.kt
@@ -5,9 +5,6 @@ import com.worktime.android.BuildConfig
 data class AppConfig(
     val environment: String,
     val apiBaseUrl: String,
-    val oidcClientId: String,
-    val oidcScope: String,
-    val oidcRedirectUri: String,
     val certificatePinHost: String,
     val certificatePins: List<String>
 )
@@ -15,9 +12,6 @@ data class AppConfig(
 fun buildAppConfig(): AppConfig = AppConfig(
     environment = BuildConfig.WORKTIME_ENVIRONMENT,
     apiBaseUrl = BuildConfig.API_BASE_URL,
-    oidcClientId = BuildConfig.OIDC_CLIENT_ID,
-    oidcScope = BuildConfig.OIDC_SCOPE,
-    oidcRedirectUri = BuildConfig.OIDC_REDIRECT_URI,
     certificatePinHost = BuildConfig.CERTIFICATE_PIN_HOST,
     certificatePins = BuildConfig.CERTIFICATE_PINS.toCsvList()
 )

--- a/android/app/src/main/java/com/worktime/android/core/di/AppModule.kt
+++ b/android/app/src/main/java/com/worktime/android/core/di/AppModule.kt
@@ -1,0 +1,19 @@
+package com.worktime.android.core.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}

--- a/android/app/src/main/java/com/worktime/android/core/di/ApplicationScope.kt
+++ b/android/app/src/main/java/com/worktime/android/core/di/ApplicationScope.kt
@@ -1,0 +1,7 @@
+package com.worktime.android.core.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope

--- a/android/app/src/main/java/com/worktime/android/core/network/CertificatePinnerProvider.kt
+++ b/android/app/src/main/java/com/worktime/android/core/network/CertificatePinnerProvider.kt
@@ -6,7 +6,11 @@ import okhttp3.CertificatePinner
 object CertificatePinnerProvider {
     fun fromConfig(appConfig: AppConfig): CertificatePinner {
         if (appConfig.environment != "prod") return CertificatePinner.DEFAULT
-        if (appConfig.certificatePinHost.isEmpty() || appConfig.certificatePins.isEmpty()) return CertificatePinner.DEFAULT
+        if (appConfig.certificatePinHost.isEmpty() ||
+            appConfig.certificatePins.isEmpty()
+        ) {
+            return CertificatePinner.DEFAULT
+        }
 
         return CertificatePinner
             .Builder()

--- a/android/app/src/main/java/com/worktime/android/core/notifications/WorktimeNotifications.kt
+++ b/android/app/src/main/java/com/worktime/android/core/notifications/WorktimeNotifications.kt
@@ -85,7 +85,8 @@ class WorktimeNotifications(private val context: Context) {
                 .build()
         val canNotify =
             Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-                ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+                ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
         if (canNotify) {
             NotificationManagerCompat.from(context).notify(id, notification)
         }

--- a/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
@@ -7,14 +7,14 @@ import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Persists an optional runtime override for the API base URL, letting an installed build

--- a/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
@@ -6,7 +6,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
@@ -18,7 +21,10 @@ import kotlinx.coroutines.runBlocking
  * target a different backend without reinstalling another build variant.
  * When no override is set, callers fall back to the build-configured `AppConfig.apiBaseUrl`.
  */
-class ApiBaseUrlOverrideStore(context: Context) {
+@Singleton
+class ApiBaseUrlOverrideStore
+@Inject
+constructor(@ApplicationContext context: Context) {
     private val dataStore =
         PreferenceDataStoreFactory.create(
             produceFile = { context.preferencesDataStoreFile(PREFERENCES_FILE) }

--- a/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
@@ -6,15 +6,19 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
+import com.worktime.android.core.di.ApplicationScope
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 
 /**
  * Persists an optional runtime override for the API base URL, letting an installed build
@@ -22,54 +26,52 @@ import kotlinx.coroutines.runBlocking
  * When no override is set, callers fall back to the build-configured `AppConfig.apiBaseUrl`.
  */
 @Singleton
-class ApiBaseUrlOverrideStore @Inject constructor(@ApplicationContext context: Context) {
+class ApiBaseUrlOverrideStore
+@Inject
+constructor(
+    @ApplicationContext context: Context,
+    @ApplicationScope
+    applicationScope: CoroutineScope
+) {
     private val dataStore =
         PreferenceDataStoreFactory.create(
+            scope = applicationScope,
             produceFile = { context.preferencesDataStoreFile(PREFERENCES_FILE) }
         )
 
-    val override: Flow<String?> =
-        dataStore.data
+    private val overrideFlow: Flow<String?> =
+        dataStore
+            .data
             .catch { error ->
                 if (error is IOException) emit(emptyPreferences()) else throw error
             }.map { prefs ->
                 prefs[KEY_API_BASE_URL_OVERRIDE]?.takeIf { it.isNotBlank() }
             }
 
-    @Volatile
-    private var isCacheLoaded = false
+    private val _override = MutableStateFlow<String?>(null)
+    val override: StateFlow<String?> = _override.asStateFlow()
 
-    @Volatile
-    private var cachedOverride: String? = null
+    init {
+        applicationScope.launch {
+            overrideFlow.collect { _override.value = it }
+        }
+    }
 
     /**
      * Synchronous read for request-time consumers (OkHttp interceptors run on background
-     * threads). Backed by an in-memory cache after the first read so requests never block
-     * on `runBlocking`; the cache is kept in sync by [setOverride] and [clearOverride], the
-     * only writers to this store.
+     * threads). Backed by an in-memory cache kept in sync by the application-scope
+     * DataStore collection.
      */
-    fun currentOverrideBlocking(): String? {
-        if (!isCacheLoaded) {
-            synchronized(this) {
-                if (!isCacheLoaded) {
-                    cachedOverride = runBlocking { override.first() }
-                    isCacheLoaded = true
-                }
-            }
-        }
-        return cachedOverride
-    }
+    fun currentOverrideBlocking(): String? = override.value
 
     suspend fun setOverride(url: String) {
         dataStore.edit { it[KEY_API_BASE_URL_OVERRIDE] = url }
-        cachedOverride = url
-        isCacheLoaded = true
+        _override.value = url
     }
 
     suspend fun clearOverride() {
         dataStore.edit { it.remove(KEY_API_BASE_URL_OVERRIDE) }
-        cachedOverride = null
-        isCacheLoaded = true
+        _override.value = null
     }
 
     private companion object {

--- a/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
@@ -7,14 +7,14 @@ import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Persists an optional runtime override for the API base URL, letting an installed build
@@ -22,9 +22,7 @@ import kotlinx.coroutines.runBlocking
  * When no override is set, callers fall back to the build-configured `AppConfig.apiBaseUrl`.
  */
 @Singleton
-class ApiBaseUrlOverrideStore
-@Inject
-constructor(@ApplicationContext context: Context) {
+class ApiBaseUrlOverrideStore @Inject constructor(@ApplicationContext context: Context) {
     private val dataStore =
         PreferenceDataStoreFactory.create(
             produceFile = { context.preferencesDataStoreFile(PREFERENCES_FILE) }

--- a/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
@@ -22,62 +22,58 @@ import javax.inject.Singleton
  * When no override is set, callers fall back to the build-configured `AppConfig.apiBaseUrl`.
  */
 @Singleton
-class ApiBaseUrlOverrideStore
-    @Inject
-    constructor(
-        @ApplicationContext context: Context
-    ) {
-        private val dataStore =
-            PreferenceDataStoreFactory.create(
-                produceFile = { context.preferencesDataStoreFile(PREFERENCES_FILE) }
-            )
+class ApiBaseUrlOverrideStore @Inject constructor(@ApplicationContext context: Context) {
+    private val dataStore =
+        PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile(PREFERENCES_FILE) }
+        )
 
-        val override: Flow<String?> =
-            dataStore.data
-                .catch { error ->
-                    if (error is IOException) emit(emptyPreferences()) else throw error
-                }.map { prefs ->
-                    prefs[KEY_API_BASE_URL_OVERRIDE]?.takeIf { it.isNotBlank() }
-                }
+    val override: Flow<String?> =
+        dataStore.data
+            .catch { error ->
+                if (error is IOException) emit(emptyPreferences()) else throw error
+            }.map { prefs ->
+                prefs[KEY_API_BASE_URL_OVERRIDE]?.takeIf { it.isNotBlank() }
+            }
 
-        @Volatile
-        private var isCacheLoaded = false
+    @Volatile
+    private var isCacheLoaded = false
 
-        @Volatile
-        private var cachedOverride: String? = null
+    @Volatile
+    private var cachedOverride: String? = null
 
-        /**
-         * Synchronous read for request-time consumers (OkHttp interceptors run on background
-         * threads). Backed by an in-memory cache after the first read so requests never block
-         * on `runBlocking`; the cache is kept in sync by [setOverride] and [clearOverride], the
-         * only writers to this store.
-         */
-        fun currentOverrideBlocking(): String? {
-            if (!isCacheLoaded) {
-                synchronized(this) {
-                    if (!isCacheLoaded) {
-                        cachedOverride = runBlocking { override.first() }
-                        isCacheLoaded = true
-                    }
+    /**
+     * Synchronous read for request-time consumers (OkHttp interceptors run on background
+     * threads). Backed by an in-memory cache after the first read so requests never block
+     * on `runBlocking`; the cache is kept in sync by [setOverride] and [clearOverride], the
+     * only writers to this store.
+     */
+    fun currentOverrideBlocking(): String? {
+        if (!isCacheLoaded) {
+            synchronized(this) {
+                if (!isCacheLoaded) {
+                    cachedOverride = runBlocking { override.first() }
+                    isCacheLoaded = true
                 }
             }
-            return cachedOverride
         }
-
-        suspend fun setOverride(url: String) {
-            dataStore.edit { it[KEY_API_BASE_URL_OVERRIDE] = url }
-            cachedOverride = url
-            isCacheLoaded = true
-        }
-
-        suspend fun clearOverride() {
-            dataStore.edit { it.remove(KEY_API_BASE_URL_OVERRIDE) }
-            cachedOverride = null
-            isCacheLoaded = true
-        }
-
-        private companion object {
-            const val PREFERENCES_FILE = "api_base_url_override"
-            val KEY_API_BASE_URL_OVERRIDE = stringPreferencesKey("api_base_url_override")
-        }
+        return cachedOverride
     }
+
+    suspend fun setOverride(url: String) {
+        dataStore.edit { it[KEY_API_BASE_URL_OVERRIDE] = url }
+        cachedOverride = url
+        isCacheLoaded = true
+    }
+
+    suspend fun clearOverride() {
+        dataStore.edit { it.remove(KEY_API_BASE_URL_OVERRIDE) }
+        cachedOverride = null
+        isCacheLoaded = true
+    }
+
+    private companion object {
+        const val PREFERENCES_FILE = "api_base_url_override"
+        val KEY_API_BASE_URL_OVERRIDE = stringPreferencesKey("api_base_url_override")
+    }
+}

--- a/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/ApiBaseUrlOverrideStore.kt
@@ -22,58 +22,62 @@ import javax.inject.Singleton
  * When no override is set, callers fall back to the build-configured `AppConfig.apiBaseUrl`.
  */
 @Singleton
-class ApiBaseUrlOverrideStore @Inject constructor(@ApplicationContext context: Context) {
-    private val dataStore =
-        PreferenceDataStoreFactory.create(
-            produceFile = { context.preferencesDataStoreFile(PREFERENCES_FILE) }
-        )
+class ApiBaseUrlOverrideStore
+    @Inject
+    constructor(
+        @ApplicationContext context: Context
+    ) {
+        private val dataStore =
+            PreferenceDataStoreFactory.create(
+                produceFile = { context.preferencesDataStoreFile(PREFERENCES_FILE) }
+            )
 
-    val override: Flow<String?> =
-        dataStore.data
-            .catch { error ->
-                if (error is IOException) emit(emptyPreferences()) else throw error
-            }.map { prefs ->
-                prefs[KEY_API_BASE_URL_OVERRIDE]?.takeIf { it.isNotBlank() }
-            }
+        val override: Flow<String?> =
+            dataStore.data
+                .catch { error ->
+                    if (error is IOException) emit(emptyPreferences()) else throw error
+                }.map { prefs ->
+                    prefs[KEY_API_BASE_URL_OVERRIDE]?.takeIf { it.isNotBlank() }
+                }
 
-    @Volatile
-    private var isCacheLoaded = false
+        @Volatile
+        private var isCacheLoaded = false
 
-    @Volatile
-    private var cachedOverride: String? = null
+        @Volatile
+        private var cachedOverride: String? = null
 
-    /**
-     * Synchronous read for request-time consumers (OkHttp interceptors run on background
-     * threads). Backed by an in-memory cache after the first read so requests never block
-     * on `runBlocking`; the cache is kept in sync by [setOverride] and [clearOverride], the
-     * only writers to this store.
-     */
-    fun currentOverrideBlocking(): String? {
-        if (!isCacheLoaded) {
-            synchronized(this) {
-                if (!isCacheLoaded) {
-                    cachedOverride = runBlocking { override.first() }
-                    isCacheLoaded = true
+        /**
+         * Synchronous read for request-time consumers (OkHttp interceptors run on background
+         * threads). Backed by an in-memory cache after the first read so requests never block
+         * on `runBlocking`; the cache is kept in sync by [setOverride] and [clearOverride], the
+         * only writers to this store.
+         */
+        fun currentOverrideBlocking(): String? {
+            if (!isCacheLoaded) {
+                synchronized(this) {
+                    if (!isCacheLoaded) {
+                        cachedOverride = runBlocking { override.first() }
+                        isCacheLoaded = true
+                    }
                 }
             }
+            return cachedOverride
         }
-        return cachedOverride
-    }
 
-    suspend fun setOverride(url: String) {
-        dataStore.edit { it[KEY_API_BASE_URL_OVERRIDE] = url }
-        cachedOverride = url
-        isCacheLoaded = true
-    }
+        suspend fun setOverride(url: String) {
+            dataStore.edit { it[KEY_API_BASE_URL_OVERRIDE] = url }
+            cachedOverride = url
+            isCacheLoaded = true
+        }
 
-    suspend fun clearOverride() {
-        dataStore.edit { it.remove(KEY_API_BASE_URL_OVERRIDE) }
-        cachedOverride = null
-        isCacheLoaded = true
-    }
+        suspend fun clearOverride() {
+            dataStore.edit { it.remove(KEY_API_BASE_URL_OVERRIDE) }
+            cachedOverride = null
+            isCacheLoaded = true
+        }
 
-    private companion object {
-        const val PREFERENCES_FILE = "api_base_url_override"
-        val KEY_API_BASE_URL_OVERRIDE = stringPreferencesKey("api_base_url_override")
+        private companion object {
+            const val PREFERENCES_FILE = "api_base_url_override"
+            val KEY_API_BASE_URL_OVERRIDE = stringPreferencesKey("api_base_url_override")
+        }
     }
-}

--- a/android/app/src/main/java/com/worktime/android/core/storage/NotificationPreferencesStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/NotificationPreferencesStore.kt
@@ -11,7 +11,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
-data class NotificationPreferences(val shiftsEnabled: Boolean = true, val timeTrackingEnabled: Boolean = true, val syncConflictsEnabled: Boolean = true)
+data class NotificationPreferences(
+    val shiftsEnabled: Boolean = true,
+    val timeTrackingEnabled: Boolean = true,
+    val syncConflictsEnabled: Boolean = true
+)
 
 class NotificationPreferencesStore(context: Context) {
     private val dataStore =

--- a/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
@@ -8,9 +8,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class SecureSessionStore
-@Inject
-constructor(@ApplicationContext context: Context) {
+class SecureSessionStore @Inject constructor(@ApplicationContext context: Context) {
     private val prefs by lazy {
         val masterKey = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
         EncryptedSharedPreferences.create(

--- a/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
@@ -8,34 +8,30 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class SecureSessionStore
-    @Inject
-    constructor(
-        @ApplicationContext context: Context
-    ) {
-        private val prefs by lazy {
-            val masterKey = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
-            EncryptedSharedPreferences.create(
-                context,
-                PREFS_NAME,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
-        }
-
-        fun readAuthStateJson(): String? = prefs.getString(KEY_AUTH_STATE, null)
-
-        fun writeAuthStateJson(value: String) {
-            prefs.edit().putString(KEY_AUTH_STATE, value).apply()
-        }
-
-        fun clear() {
-            prefs.edit().clear().apply()
-        }
-
-        private companion object {
-            const val PREFS_NAME = "worktime_android_secure_session"
-            const val KEY_AUTH_STATE = "auth_state"
-        }
+class SecureSessionStore @Inject constructor(@ApplicationContext context: Context) {
+    private val prefs by lazy {
+        val masterKey = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
+
+    fun readAuthStateJson(): String? = prefs.getString(KEY_AUTH_STATE, null)
+
+    fun writeAuthStateJson(value: String) {
+        prefs.edit().putString(KEY_AUTH_STATE, value).apply()
+    }
+
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "worktime_android_secure_session"
+        const val KEY_AUTH_STATE = "auth_state"
+    }
+}

--- a/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
@@ -20,14 +20,14 @@ class SecureSessionStore @Inject constructor(@ApplicationContext context: Contex
         )
     }
 
-    fun readAuthStateJson(): String? = prefs.getString(KEY_AUTH_STATE, null)
+    fun readAuthStateJson(): String? = runCatching { prefs.getString(KEY_AUTH_STATE, null) }.getOrNull()
 
     fun writeAuthStateJson(value: String) {
-        prefs.edit().putString(KEY_AUTH_STATE, value).apply()
+        runCatching { prefs.edit().putString(KEY_AUTH_STATE, value).apply() }
     }
 
     fun clear() {
-        prefs.edit().clear().apply()
+        runCatching { prefs.edit().clear().apply() }
     }
 
     private companion object {

--- a/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
@@ -3,8 +3,14 @@ package com.worktime.android.core.storage
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class SecureSessionStore(context: Context) {
+@Singleton
+class SecureSessionStore
+@Inject
+constructor(@ApplicationContext context: Context) {
     private val prefs by lazy {
         val masterKey = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
         EncryptedSharedPreferences.create(

--- a/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
+++ b/android/app/src/main/java/com/worktime/android/core/storage/SecureSessionStore.kt
@@ -8,30 +8,34 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class SecureSessionStore @Inject constructor(@ApplicationContext context: Context) {
-    private val prefs by lazy {
-        val masterKey = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
-        EncryptedSharedPreferences.create(
-            context,
-            PREFS_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    }
+class SecureSessionStore
+    @Inject
+    constructor(
+        @ApplicationContext context: Context
+    ) {
+        private val prefs by lazy {
+            val masterKey = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
+            EncryptedSharedPreferences.create(
+                context,
+                PREFS_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        }
 
-    fun readAuthStateJson(): String? = prefs.getString(KEY_AUTH_STATE, null)
+        fun readAuthStateJson(): String? = prefs.getString(KEY_AUTH_STATE, null)
 
-    fun writeAuthStateJson(value: String) {
-        prefs.edit().putString(KEY_AUTH_STATE, value).apply()
-    }
+        fun writeAuthStateJson(value: String) {
+            prefs.edit().putString(KEY_AUTH_STATE, value).apply()
+        }
 
-    fun clear() {
-        prefs.edit().clear().apply()
-    }
+        fun clear() {
+            prefs.edit().clear().apply()
+        }
 
-    private companion object {
-        const val PREFS_NAME = "worktime_android_secure_session"
-        const val KEY_AUTH_STATE = "auth_state"
+        private companion object {
+            const val PREFS_NAME = "worktime_android_secure_session"
+            const val KEY_AUTH_STATE = "auth_state"
+        }
     }
-}

--- a/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
+++ b/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
@@ -27,10 +27,17 @@ import retrofit2.http.Query
 
 interface WorktimeApi {
     @GET("api/read-models/dashboard")
-    suspend fun getDashboard(@Header("Authorization") authorization: String, @Query("timezone") timezone: String): DashboardResponse
+    suspend fun getDashboard(
+        @Header("Authorization") authorization: String,
+        @Query("timezone") timezone: String
+    ): DashboardResponse
 
     @POST("api/time-tracking/tasks")
-    suspend fun createTask(@Header("Authorization") authorization: String, @Query("user_id") userId: Int, @Body payload: TaskMutationRequest): TaskRecord
+    suspend fun createTask(
+        @Header("Authorization") authorization: String,
+        @Query("user_id") userId: Int,
+        @Body payload: TaskMutationRequest
+    ): TaskRecord
 
     @PUT("api/time-tracking/tasks/{taskId}")
     suspend fun updateTask(
@@ -41,7 +48,10 @@ interface WorktimeApi {
     ): TaskRecord
 
     @GET("api/time-tracking/tasks/running")
-    suspend fun getRunningTask(@Header("Authorization") authorization: String, @Query("user_id") userId: Int): Response<TaskRecord>
+    suspend fun getRunningTask(
+        @Header("Authorization") authorization: String,
+        @Query("user_id") userId: Int
+    ): Response<TaskRecord>
 
     @POST("api/work-locations/")
     suspend fun upsertWorkLocation(
@@ -59,7 +69,11 @@ interface WorktimeApi {
     ): WorkLocationListResponse
 
     @DELETE("api/time-tracking/labels/{labelId}")
-    suspend fun deleteLabel(@Header("Authorization") authorization: String, @Path("labelId") labelId: String, @Query("user_id") userId: Int)
+    suspend fun deleteLabel(
+        @Header("Authorization") authorization: String,
+        @Path("labelId") labelId: String,
+        @Query("user_id") userId: Int
+    )
 
     @GET("api/sync/status")
     suspend fun getSyncStatus(@Header("Authorization") authorization: String): SyncStatusResponse

--- a/android/app/src/main/java/com/worktime/android/data/model/ReadModels.kt
+++ b/android/app/src/main/java/com/worktime/android/data/model/ReadModels.kt
@@ -15,7 +15,12 @@ data class DashboardResponse(
 )
 
 @Serializable
-data class Identity(val id: Int, val username: String, @SerialName("display_name") val displayName: String, @SerialName("is_admin") val isAdmin: Boolean)
+data class Identity(
+    val id: Int,
+    val username: String,
+    @SerialName("display_name") val displayName: String,
+    @SerialName("is_admin") val isAdmin: Boolean
+)
 
 @Serializable
 data class FeatureFlags(@SerialName("time_off_enabled") val timeOffEnabled: Boolean)
@@ -117,7 +122,11 @@ data class TaskRecord(
 )
 
 @Serializable
-data class WorkLocationMutationRequest(val date: String, @SerialName("country_code") val countryCode: String, val label: String? = null)
+data class WorkLocationMutationRequest(
+    val date: String,
+    @SerialName("country_code") val countryCode: String,
+    val label: String? = null
+)
 
 @Serializable
 data class WorkLocationRecord(

--- a/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
+++ b/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
@@ -49,7 +49,11 @@ interface DashboardRepository {
 
     suspend fun getRunningTask(): MutationResult<TaskRecord?>
 
-    suspend fun setWorkLocation(date: LocalDate, countryCode: String, label: String? = null): MutationResult<WorkLocationRecord>
+    suspend fun setWorkLocation(
+        date: LocalDate,
+        countryCode: String,
+        label: String? = null
+    ): MutationResult<WorkLocationRecord>
 
     suspend fun loadWeeklyWorkLocations(until: LocalDate = LocalDate.now()): MutationResult<List<WorkLocationRecord>>
 
@@ -60,7 +64,8 @@ interface DashboardRepository {
     fun logout()
 }
 
-class WorktimeRepository(private val api: WorktimeApi, private val sessionController: SessionController) : DashboardRepository {
+class WorktimeRepository(private val api: WorktimeApi, private val sessionController: SessionController) :
+    DashboardRepository {
     override val sessionState: StateFlow<SessionState> = sessionController.sessionState
     private var currentUserId: Int? = null
 
@@ -123,14 +128,18 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
         }
     }
 
-    override suspend fun updateTask(taskId: String, text: String?, labelId: String?): MutationResult<TaskRecord> = withAuthorizedUser { token, userId ->
-        api.updateTask(
-            authorization = "Bearer $token",
-            taskId = taskId,
-            userId = userId,
-            payload = TaskMutationRequest(text = text, labelId = labelId)
-        )
-    }
+    override suspend fun updateTask(taskId: String, text: String?, labelId: String?): MutationResult<TaskRecord> =
+        withAuthorizedUser {
+                token,
+                userId
+            ->
+            api.updateTask(
+                authorization = "Bearer $token",
+                taskId = taskId,
+                userId = userId,
+                payload = TaskMutationRequest(text = text, labelId = labelId)
+            )
+        }
 
     override suspend fun getRunningTask(): MutationResult<TaskRecord?> = withAuthorizedUser { token, userId ->
         val response =
@@ -142,29 +151,36 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
         if (response.code() == HTTP_NO_CONTENT) null else response.body()
     }
 
-    override suspend fun setWorkLocation(date: LocalDate, countryCode: String, label: String?): MutationResult<WorkLocationRecord> =
-        withAuthorizedUser { token, userId ->
-            api.upsertWorkLocation(
-                authorization = "Bearer $token",
-                userId = userId,
-                payload =
-                WorkLocationMutationRequest(
-                    date = date.toString(),
-                    countryCode = countryCode.uppercase(),
-                    label = label?.takeIf { it.isNotBlank() }
-                )
+    override suspend fun setWorkLocation(
+        date: LocalDate,
+        countryCode: String,
+        label: String?
+    ): MutationResult<WorkLocationRecord> = withAuthorizedUser { token, userId ->
+        api.upsertWorkLocation(
+            authorization = "Bearer $token",
+            userId = userId,
+            payload =
+            WorkLocationMutationRequest(
+                date = date.toString(),
+                countryCode = countryCode.uppercase(),
+                label = label?.takeIf { it.isNotBlank() }
             )
-        }
-
-    override suspend fun loadWeeklyWorkLocations(until: LocalDate): MutationResult<List<WorkLocationRecord>> = withAuthorizedUser { token, userId ->
-        api
-            .listWorkLocations(
-                authorization = "Bearer $token",
-                userId = userId,
-                startDate = until.minusDays(WEEK_LOOKBACK_DAYS).toString(),
-                endDate = until.toString()
-            ).items
+        )
     }
+
+    override suspend fun loadWeeklyWorkLocations(until: LocalDate): MutationResult<List<WorkLocationRecord>> =
+        withAuthorizedUser {
+                token,
+                userId
+            ->
+            api
+                .listWorkLocations(
+                    authorization = "Bearer $token",
+                    userId = userId,
+                    startDate = until.minusDays(WEEK_LOOKBACK_DAYS).toString(),
+                    endDate = until.toString()
+                ).items
+        }
 
     override suspend fun deleteLabel(labelId: String): MutationResult<Unit> {
         val token = sessionController.getFreshAccessToken() ?: return MutationResult.LoggedOut
@@ -178,7 +194,9 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
                     sessionController.logout()
                     MutationResult.LoggedOut
                 }
-                HTTP_CONFLICT -> MutationResult.ValidationError("Label is in use by tasks or templates and cannot be deleted")
+                HTTP_CONFLICT -> MutationResult.ValidationError(
+                    "Label is in use by tasks or templates and cannot be deleted"
+                )
                 else -> MutationResult.Error("Request failed (${error.code()})")
             }
         } catch (_: IOException) {

--- a/android/app/src/main/java/com/worktime/android/feature/login/LoginScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/login/LoginScreen.kt
@@ -17,7 +17,13 @@ import com.worktime.android.core.auth.SessionState
 import com.worktime.android.core.config.AppConfig
 
 @Composable
-fun LoginScreen(sessionState: SessionState, appConfig: AppConfig, isBusy: Boolean, errorMessage: String?, onLogin: () -> Unit) {
+fun LoginScreen(
+    sessionState: SessionState,
+    appConfig: AppConfig,
+    isBusy: Boolean,
+    errorMessage: String?,
+    onLogin: () -> Unit
+) {
     Column(
         modifier =
         Modifier
@@ -36,7 +42,9 @@ fun LoginScreen(sessionState: SessionState, appConfig: AppConfig, isBusy: Boolea
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 Text(
-                    text = "Native Android companion app for the current shift, next shifts, team status, and time-off summary.",
+                    text =
+                    "Native Android companion app for the current shift, next shifts, " +
+                        "team status, and time-off summary.",
                     style = MaterialTheme.typography.bodyLarge
                 )
                 Text(text = "Environment: ${appConfig.environment}")
@@ -46,7 +54,8 @@ fun LoginScreen(sessionState: SessionState, appConfig: AppConfig, isBusy: Boolea
                     when (sessionState) {
                         SessionState.Initializing -> "Checking existing session…"
                         SessionState.LoggedOut -> "No active session"
-                        is SessionState.Authenticated -> if (sessionState.hasRefreshToken) "Session ready (refresh enabled)" else "Session ready"
+                        is SessionState.Authenticated ->
+                            if (sessionState.hasRefreshToken) "Session ready (refresh enabled)" else "Session ready"
                         is SessionState.Error -> sessionState.message
                     }
                 )

--- a/android/app/src/main/java/com/worktime/android/feature/session/BiometricGateScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/session/BiometricGateScreen.kt
@@ -16,7 +16,12 @@ import androidx.compose.ui.unit.dp
 import com.worktime.android.core.auth.BiometricAvailability
 
 @Composable
-fun BiometricGateScreen(availability: BiometricAvailability, isPrompting: Boolean, onUnlock: () -> Unit, onContinueWithoutLock: () -> Unit) {
+fun BiometricGateScreen(
+    availability: BiometricAvailability,
+    isPrompting: Boolean,
+    onUnlock: () -> Unit,
+    onContinueWithoutLock: () -> Unit
+) {
     Column(
         modifier =
         Modifier

--- a/android/app/src/main/java/com/worktime/android/feature/settings/ApiBaseUrlOverrideCard.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/ApiBaseUrlOverrideCard.kt
@@ -20,7 +20,12 @@ import com.worktime.android.core.network.DynamicBaseUrlInterceptor
 import com.worktime.android.ui.components.SummaryCard
 
 @Composable
-fun ApiBaseUrlOverrideCard(appConfig: AppConfig, apiBaseUrlOverride: String?, onSave: (String) -> Unit, onClear: () -> Unit) {
+fun ApiBaseUrlOverrideCard(
+    appConfig: AppConfig,
+    apiBaseUrlOverride: String?,
+    onSave: (String) -> Unit,
+    onClear: () -> Unit
+) {
     SummaryCard(title = "API environment override") {
         content {
             var draft by rememberSaveable(apiBaseUrlOverride) { mutableStateOf(apiBaseUrlOverride.orEmpty()) }
@@ -35,7 +40,9 @@ fun ApiBaseUrlOverrideCard(appConfig: AppConfig, apiBaseUrlOverride: String?, on
                 modifier = Modifier.fillMaxWidth()
             )
             Text(
-                text = "Point this build at a different backend without reinstalling. Reset to return to the build default (${appConfig.apiBaseUrl}).",
+                text =
+                "Point this build at a different backend without reinstalling. " +
+                    "Reset to return to the build default (${appConfig.apiBaseUrl}).",
                 style = MaterialTheme.typography.bodySmall
             )
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.worktime.android.core.auth.OidcConfig
 import com.worktime.android.core.config.AppConfig
 import com.worktime.android.core.storage.BiometricLockPreferences
 import com.worktime.android.core.storage.NotificationPreferences
@@ -40,6 +41,7 @@ private val IDLE_TIMEOUT_OPTIONS_MINUTES =
 fun SettingsScreen(
     uiState: DashboardUiState,
     appConfig: AppConfig,
+    oidcConfig: OidcConfig,
     notificationPreferences: NotificationPreferences,
     apiBaseUrlOverride: String?,
     onApiBaseUrlOverrideSave: (String) -> Unit,
@@ -61,8 +63,8 @@ fun SettingsScreen(
                     text("Build default", appConfig.apiBaseUrl)
                 }
                 text("OIDC config", "${(apiBaseUrlOverride ?: appConfig.apiBaseUrl).trimEnd('/')}/api/auth/oidc-config")
-                text("OIDC client ID", appConfig.oidcClientId)
-                text("OIDC scope", appConfig.oidcScope)
+                text("OIDC client ID", oidcConfig.clientId)
+                text("OIDC scope", oidcConfig.scope)
             }
         }
         item {

--- a/android/app/src/main/java/com/worktime/android/ui/components/ReadModelScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/ui/components/ReadModelScreen.kt
@@ -68,7 +68,13 @@ private fun LoadingPane(title: String) {
 }
 
 @Composable
-fun EmptyPane(title: String, headline: String, body: String, actionLabel: String? = null, onAction: (() -> Unit)? = null) {
+fun EmptyPane(
+    title: String,
+    headline: String,
+    body: String,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null
+) {
     Column(
         modifier =
         Modifier

--- a/android/app/src/test/java/com/worktime/android/core/network/CertificatePinnerProviderTest.kt
+++ b/android/app/src/test/java/com/worktime/android/core/network/CertificatePinnerProviderTest.kt
@@ -34,11 +34,13 @@ class CertificatePinnerProviderTest {
         assertEquals(CertificatePinner.DEFAULT, pinner)
     }
 
-    private fun appConfig(environment: String, certificatePins: List<String> = listOf("sha256/YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=")): AppConfig =
-        AppConfig(
-            environment = environment,
-            apiBaseUrl = "https://worktime.tjor.im/",
-            certificatePinHost = "worktime.tjor.im",
-            certificatePins = certificatePins
-        )
+    private fun appConfig(
+        environment: String,
+        certificatePins: List<String> = listOf("sha256/YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=")
+    ): AppConfig = AppConfig(
+        environment = environment,
+        apiBaseUrl = "https://worktime.tjor.im/",
+        certificatePinHost = "worktime.tjor.im",
+        certificatePins = certificatePins
+    )
 }

--- a/android/app/src/test/java/com/worktime/android/core/network/CertificatePinnerProviderTest.kt
+++ b/android/app/src/test/java/com/worktime/android/core/network/CertificatePinnerProviderTest.kt
@@ -38,9 +38,6 @@ class CertificatePinnerProviderTest {
         AppConfig(
             environment = environment,
             apiBaseUrl = "https://worktime.tjor.im/",
-            oidcClientId = "worktime",
-            oidcScope = "openid profile email offline_access",
-            oidcRedirectUri = "com.worktime.android:/oauth2redirect",
             certificatePinHost = "worktime.tjor.im",
             certificatePins = certificatePins
         )

--- a/android/app/src/test/java/com/worktime/android/core/network/DynamicBaseUrlInterceptorTest.kt
+++ b/android/app/src/test/java/com/worktime/android/core/network/DynamicBaseUrlInterceptorTest.kt
@@ -104,5 +104,6 @@ class DynamicBaseUrlInterceptorTest {
         assertFalse(DynamicBaseUrlInterceptor.isValidOverride("ftp://host/"))
     }
 
-    private fun okhttp3.HttpUrl.encodedPathAndQueryOrPath(): String = encodedQuery?.let { "$encodedPath?$it" } ?: encodedPath
+    private fun okhttp3.HttpUrl.encodedPathAndQueryOrPath(): String =
+        encodedQuery?.let { "$encodedPath?$it" } ?: encodedPath
 }

--- a/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
@@ -136,28 +136,41 @@ class WorktimeRepositoryTest {
             return sampleTask(userId = userId, text = payload.text ?: "Task")
         }
 
-        override suspend fun updateTask(authorization: String, taskId: String, userId: Int, payload: TaskMutationRequest): TaskRecord {
+        override suspend fun updateTask(
+            authorization: String,
+            taskId: String,
+            userId: Int,
+            payload: TaskMutationRequest
+        ): TaskRecord {
             taskThrowable?.let { throw it }
             return sampleTask(userId = userId, id = taskId, text = payload.text ?: "Task")
         }
 
-        override suspend fun getRunningTask(authorization: String, userId: Int): Response<TaskRecord> = Response.success(sampleTask(userId = userId))
+        override suspend fun getRunningTask(authorization: String, userId: Int): Response<TaskRecord> =
+            Response.success(sampleTask(userId = userId))
 
-        override suspend fun upsertWorkLocation(authorization: String, userId: Int, payload: WorkLocationMutationRequest): WorkLocationRecord =
-            WorkLocationRecord(
-                id = 1,
-                userId = userId,
-                date = payload.date,
-                countryCode = payload.countryCode.uppercase(),
-                label = payload.label,
-                createdAt = "2026-05-26T12:00:00Z"
-            )
+        override suspend fun upsertWorkLocation(
+            authorization: String,
+            userId: Int,
+            payload: WorkLocationMutationRequest
+        ): WorkLocationRecord = WorkLocationRecord(
+            id = 1,
+            userId = userId,
+            date = payload.date,
+            countryCode = payload.countryCode.uppercase(),
+            label = payload.label,
+            createdAt = "2026-05-26T12:00:00Z"
+        )
 
-        override suspend fun listWorkLocations(authorization: String, userId: Int, startDate: String?, endDate: String?): WorkLocationListResponse =
-            WorkLocationListResponse(
-                items = emptyList(),
-                total = 0
-            )
+        override suspend fun listWorkLocations(
+            authorization: String,
+            userId: Int,
+            startDate: String?,
+            endDate: String?
+        ): WorkLocationListResponse = WorkLocationListResponse(
+            items = emptyList(),
+            total = 0
+        )
 
         override suspend fun deleteLabel(authorization: String, labelId: String, userId: Int) = Unit
 

--- a/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
@@ -137,15 +137,22 @@ class DashboardViewModelTest {
             sessionState.value = SessionState.LoggedOut
         }
 
-        override suspend fun startTimeTracking(text: String, labelId: String?): MutationResult<TaskRecord> = startTrackingResult
+        override suspend fun startTimeTracking(text: String, labelId: String?): MutationResult<TaskRecord> =
+            startTrackingResult
 
-        override suspend fun stopTimeTracking(taskId: String): MutationResult<TaskRecord> = MutationResult.Success(sampleTask())
+        override suspend fun stopTimeTracking(taskId: String): MutationResult<TaskRecord> =
+            MutationResult.Success(sampleTask())
 
-        override suspend fun updateTask(taskId: String, text: String?, labelId: String?): MutationResult<TaskRecord> = MutationResult.Success(sampleTask())
+        override suspend fun updateTask(taskId: String, text: String?, labelId: String?): MutationResult<TaskRecord> =
+            MutationResult.Success(sampleTask())
 
         override suspend fun getRunningTask(): MutationResult<TaskRecord?> = MutationResult.Success(null)
 
-        override suspend fun setWorkLocation(date: LocalDate, countryCode: String, label: String?): MutationResult<WorkLocationRecord> = MutationResult.Success(
+        override suspend fun setWorkLocation(
+            date: LocalDate,
+            countryCode: String,
+            label: String?
+        ): MutationResult<WorkLocationRecord> = MutationResult.Success(
             WorkLocationRecord(
                 id = 1,
                 userId = 1,
@@ -156,7 +163,8 @@ class DashboardViewModelTest {
             )
         )
 
-        override suspend fun loadWeeklyWorkLocations(until: LocalDate): MutationResult<List<WorkLocationRecord>> = MutationResult.Success(emptyList())
+        override suspend fun loadWeeklyWorkLocations(until: LocalDate): MutationResult<List<WorkLocationRecord>> =
+            MutationResult.Success(emptyList())
 
         override suspend fun deleteLabel(labelId: String): MutationResult<Unit> = MutationResult.Success(Unit)
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,4 +4,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt.android) apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 agp = "9.2.1"
 kotlin = "2.4.0"
+ksp = "2.3.9"
+hilt = "2.60"
 
 androidx-core-ktx = "1.19.0"
 androidx-activity = "1.13.0"
@@ -52,6 +54,8 @@ junit = { module = "junit:junit", version.ref = "junit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 json = { module = "org.json:json", version.ref = "json" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -59,3 +63,5 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -15,6 +15,7 @@ Provides three endpoints that serve different consumers:
 
 import asyncio
 import logging
+import time
 from collections.abc import AsyncGenerator
 from typing import Annotated
 
@@ -40,6 +41,38 @@ async def _get_db_if_enabled() -> AsyncGenerator[AsyncSession | None, None]:
             yield session
     else:
         yield None
+
+
+async def _check_jwks_reachable() -> bool:
+    """Check that the OIDC provider's JWKS endpoint is reachable."""
+    jwks_uri = await _resolve_jwks_uri()
+    async with httpx.AsyncClient(timeout=3.0) as client:
+        response = await client.get(jwks_uri)
+    if response.status_code == 200:
+        return True
+    logger.warning("Health check: OIDC provider returned unexpected status %s", response.status_code)
+    return False
+
+
+_JWKS_READINESS_CACHE_SECONDS = 30.0
+_jwks_readiness_cache: tuple[float, bool] | None = None
+_jwks_readiness_lock = asyncio.Lock()
+
+
+async def _jwks_reachable() -> bool:
+    global _jwks_readiness_cache  # noqa: PLW0603
+    now = time.monotonic()
+    if _jwks_readiness_cache is not None and now - _jwks_readiness_cache[0] < _JWKS_READINESS_CACHE_SECONDS:
+        return _jwks_readiness_cache[1]
+
+    async with _jwks_readiness_lock:
+        now = time.monotonic()
+        if _jwks_readiness_cache is not None and now - _jwks_readiness_cache[0] < _JWKS_READINESS_CACHE_SECONDS:
+            return _jwks_readiness_cache[1]
+
+        reachable = await _check_jwks_reachable()
+        _jwks_readiness_cache = (now, True) if reachable else None
+        return reachable
 
 
 @router.get("/health/liveness")
@@ -79,12 +112,8 @@ async def readiness(
     async def _check_auth() -> tuple[str, bool]:
         """Check that the OIDC provider's JWKS endpoint is reachable."""
         try:
-            jwks_uri = await _resolve_jwks_uri()
-            async with httpx.AsyncClient(timeout=3.0) as client:
-                response = await client.get(jwks_uri)
-            if response.status_code == 200:
+            if await _jwks_reachable():
                 return "ok", False
-            logger.warning("Health check: OIDC provider returned unexpected status %s", response.status_code)
             return "unreachable", True
         except OIDCTokenError as e:
             logger.error("Health check failed: OIDC discovery failed", exc_info=e)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from app.config import settings
 from app.main import app
+from app.routers import health as health_router
 from app.routers.health import _get_db_if_enabled
 
 
@@ -91,6 +92,25 @@ def test_readiness_check_success(readiness_client, tmp_path, monkeypatch):
     assert data["share"] == "ok"
 
 
+@pytest.mark.asyncio
+async def test_jwks_reachable_coalesces_concurrent_cache_misses(monkeypatch):
+    calls = 0
+
+    async def reachable() -> bool:
+        nonlocal calls
+        calls += 1
+        await health_router.asyncio.sleep(0)
+        return True
+
+    monkeypatch.setattr(health_router, "_jwks_readiness_cache", None)
+    monkeypatch.setattr(health_router, "_check_jwks_reachable", reachable)
+
+    results = await health_router.asyncio.gather(*(health_router._jwks_reachable() for _ in range(5)))
+
+    assert results == [True] * 5
+    assert calls == 1
+
+
 def test_readiness_check_directory_not_found(readiness_client, tmp_path, monkeypatch):
     """Test readiness check when share directory does not exist."""
     share_dir = tmp_path / "nonexistent"
@@ -172,4 +192,3 @@ def test_readiness_check_general_error(readiness_client, tmp_path, monkeypatch):
     assert data["share"] == "error"
     assert "error" in data
     assert data["error"] == "internal_error"
-


### PR DESCRIPTION
## Summary
- Derive Android \`versionCode\`/\`versionName\` from \`frontend/package.json\` at build time instead of a hand-maintained literal (was drifted to 0.1.0 vs. package.json's 4.7.0)
- Expose the build's short git commit SHA via \`BuildConfig.BUILD_COMMIT\`
- Add \`:app:bundleRelease\` + Play Store internal-track publishing to \`android-release.yml\`, gated on a new \`PLAY_SERVICE_ACCOUNT_JSON\` secret — inert until that secret and a Play Console listing exist; existing APK build/upload for manual sideloading is untouched

Closes #869

## Test plan
- [ ] CI run on this branch (`android.yml` / `android-release.yml`) builds successfully