### PR TITLE
Add time-off self-service and richer time-tracking UX to Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -273,6 +273,7 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.extended)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.security.crypto)
     implementation(libs.androidx.biometric)

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
@@ -48,7 +48,10 @@ import com.worktime.android.feature.session.BiometricGateScreen
 import com.worktime.android.feature.session.BiometricGateViewModel
 import com.worktime.android.feature.settings.SettingsScreen
 import com.worktime.android.feature.teamstatus.TeamStatusScreen
+import com.worktime.android.feature.timeoff.TimeOffFormState
 import com.worktime.android.feature.timeoff.TimeOffSummaryScreen
+import com.worktime.android.feature.timeoff.TimeOffUiState
+import com.worktime.android.feature.timeoff.TimeOffViewModel
 import com.worktime.android.feature.today.TodayScreen
 import com.worktime.android.ui.theme.WorktimeTheme
 import java.time.Duration
@@ -83,6 +86,12 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
         )
     val uiState by dashboardViewModel.uiState.collectAsStateWithLifecycle()
     val actionsState by dashboardViewModel.actionsState.collectAsStateWithLifecycle()
+    val timeOffViewModel: TimeOffViewModel =
+        viewModel(
+            factory = TimeOffViewModel.factory(container.dashboardRepository)
+        )
+    val timeOffUiState by timeOffViewModel.uiState.collectAsStateWithLifecycle()
+    val timeOffFormState by timeOffViewModel.formState.collectAsStateWithLifecycle()
     val notificationPreferences by container.notificationPreferencesStore.preferences.collectAsStateWithLifecycle(
         initialValue = NotificationPreferences()
     )
@@ -219,6 +228,8 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                 WorktimeAuthenticatedScaffold(
                     uiState = uiState,
                     actionsState = actionsState,
+                    timeOffUiState = timeOffUiState,
+                    timeOffFormState = timeOffFormState,
                     appConfig = container.appConfig,
                     oidcConfig = container.oidcConfig,
                     initialDestination = initialDestination,
@@ -243,6 +254,13 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                     onStopTracking = dashboardViewModel::stopTimeTracking,
                     onUpdateTask = dashboardViewModel::updateTask,
                     onSetWorkLocation = dashboardViewModel::setWorkLocation,
+                    onCreateLabel = dashboardViewModel::createLabel,
+                    onRetryTimeOff = timeOffViewModel::refresh,
+                    onAddTimeOff = timeOffViewModel::openCreateForm,
+                    onEditTimeOff = timeOffViewModel::openEditForm,
+                    onDismissTimeOffForm = timeOffViewModel::closeForm,
+                    onSubmitTimeOff = timeOffViewModel::submit,
+                    onDeleteTimeOff = timeOffViewModel::delete,
                     onShiftNotificationsChanged = {
                         coroutineScope.launch {
                             container.notificationPreferencesStore.setShiftsEnabled(it)
@@ -271,6 +289,8 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
 private fun WorktimeAuthenticatedScaffold(
     uiState: DashboardUiState,
     actionsState: com.worktime.android.feature.dashboard.MobileActionsUiState,
+    timeOffUiState: TimeOffUiState,
+    timeOffFormState: TimeOffFormState,
     appConfig: com.worktime.android.core.config.AppConfig,
     oidcConfig: com.worktime.android.core.auth.OidcConfig,
     initialDestination: String,
@@ -285,6 +305,13 @@ private fun WorktimeAuthenticatedScaffold(
     onStopTracking: (String) -> Unit,
     onUpdateTask: (String, String?, String?) -> Unit,
     onSetWorkLocation: (java.time.LocalDate, String, String?) -> Unit,
+    onCreateLabel: (String, String) -> Unit,
+    onRetryTimeOff: () -> Unit,
+    onAddTimeOff: () -> Unit,
+    onEditTimeOff: (String) -> Unit,
+    onDismissTimeOffForm: () -> Unit,
+    onSubmitTimeOff: (com.worktime.android.data.repository.TimeOffDraft) -> Unit,
+    onDeleteTimeOff: (String) -> Unit,
     onShiftNotificationsChanged: (Boolean) -> Unit,
     onTimeTrackingNotificationsChanged: (Boolean) -> Unit,
     onSyncNotificationsChanged: (Boolean) -> Unit,
@@ -336,7 +363,8 @@ private fun WorktimeAuthenticatedScaffold(
                         onStartTracking = onStartTracking,
                         onStopTracking = onStopTracking,
                         onUpdateTask = onUpdateTask,
-                        onSetWorkLocation = onSetWorkLocation
+                        onSetWorkLocation = onSetWorkLocation,
+                        onCreateLabel = onCreateLabel
                     )
                 }
             }
@@ -352,7 +380,16 @@ private fun WorktimeAuthenticatedScaffold(
             }
             composable(WorktimeDestination.TimeOff.route) {
                 androidx.compose.foundation.layout.Box(modifier = Modifier.padding(paddingValues)) {
-                    TimeOffSummaryScreen(uiState = uiState, onRetry = onRetry)
+                    TimeOffSummaryScreen(
+                        uiState = timeOffUiState,
+                        formState = timeOffFormState,
+                        onRetry = onRetryTimeOff,
+                        onAdd = onAddTimeOff,
+                        onEdit = onEditTimeOff,
+                        onDismissForm = onDismissTimeOffForm,
+                        onSubmit = onSubmitTimeOff,
+                        onDelete = onDeleteTimeOff
+                    )
                 }
             }
             composable(WorktimeDestination.Settings.route) {

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
@@ -171,6 +171,7 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                     .onSuccess {
                         loginError = null
                         dashboardViewModel.refresh()
+                        timeOffViewModel.refresh()
                     }.onFailure {
                         loginError = it.message ?: "Unable to complete sign-in"
                     }
@@ -254,6 +255,8 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                     onStopTracking = dashboardViewModel::stopTimeTracking,
                     onUpdateTask = dashboardViewModel::updateTask,
                     onSetWorkLocation = dashboardViewModel::setWorkLocation,
+                    onDeleteWorkLocation = dashboardViewModel::deleteWorkLocation,
+                    onUpdateWorkLocationPreferences = dashboardViewModel::updateWorkLocationPreferences,
                     onCreateLabel = dashboardViewModel::createLabel,
                     onRetryTimeOff = timeOffViewModel::refresh,
                     onAddTimeOff = timeOffViewModel::openCreateForm,
@@ -278,7 +281,12 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                     },
                     biometricLockPreferences = biometricLockPreferences,
                     onBiometricLockEnabledChanged = biometricGateViewModel::setLockEnabled,
-                    onBiometricIdleTimeoutChanged = biometricGateViewModel::setIdleTimeoutMinutes
+                    onBiometricIdleTimeoutChanged = biometricGateViewModel::setIdleTimeoutMinutes,
+                    onUpdateLabel = dashboardViewModel::updateLabel,
+                    onDeleteLabel = dashboardViewModel::deleteLabel,
+                    onCreateTemplate = dashboardViewModel::createTemplate,
+                    onUpdateTemplate = dashboardViewModel::updateTemplate,
+                    onDeleteTemplate = dashboardViewModel::deleteTemplate
                 )
             }
         }
@@ -305,6 +313,8 @@ private fun WorktimeAuthenticatedScaffold(
     onStopTracking: (String) -> Unit,
     onUpdateTask: (String, String?, String?) -> Unit,
     onSetWorkLocation: (java.time.LocalDate, String, String?) -> Unit,
+    onDeleteWorkLocation: (java.time.LocalDate) -> Unit,
+    onUpdateWorkLocationPreferences: (String?, String?) -> Unit,
     onCreateLabel: (String, String) -> Unit,
     onRetryTimeOff: () -> Unit,
     onAddTimeOff: () -> Unit,
@@ -317,7 +327,12 @@ private fun WorktimeAuthenticatedScaffold(
     onSyncNotificationsChanged: (Boolean) -> Unit,
     biometricLockPreferences: BiometricLockPreferences,
     onBiometricLockEnabledChanged: (Boolean) -> Unit,
-    onBiometricIdleTimeoutChanged: (Int) -> Unit
+    onBiometricIdleTimeoutChanged: (Int) -> Unit,
+    onUpdateLabel: (String, String, String) -> Unit,
+    onDeleteLabel: (String) -> Unit,
+    onCreateTemplate: (String, String?, java.time.LocalTime, java.time.LocalTime) -> Unit,
+    onUpdateTemplate: (String, String, String?, java.time.LocalTime, java.time.LocalTime) -> Unit,
+    onDeleteTemplate: (String) -> Unit
 ) {
     val navController = rememberNavController()
     val destinations = remember { WorktimeDestination.entries.toList() }
@@ -364,6 +379,7 @@ private fun WorktimeAuthenticatedScaffold(
                         onStopTracking = onStopTracking,
                         onUpdateTask = onUpdateTask,
                         onSetWorkLocation = onSetWorkLocation,
+                        onDeleteWorkLocation = onDeleteWorkLocation,
                         onCreateLabel = onCreateLabel
                     )
                 }
@@ -411,7 +427,15 @@ private fun WorktimeAuthenticatedScaffold(
                         onLogout = onLogout,
                         isDeletingAccount = actionsState.isDeletingAccount,
                         deleteAccountError = actionsState.deleteAccountError,
-                        onDeleteAccount = onDeleteAccount
+                        onDeleteAccount = onDeleteAccount,
+                        actionsState = actionsState,
+                        onUpdateWorkLocationPreferences = onUpdateWorkLocationPreferences,
+                        onCreateLabel = onCreateLabel,
+                        onUpdateLabel = onUpdateLabel,
+                        onDeleteLabel = onDeleteLabel,
+                        onCreateTemplate = onCreateTemplate,
+                        onUpdateTemplate = onUpdateTemplate,
+                        onDeleteTemplate = onDeleteTemplate
                     )
                 }
             }

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -357,7 +358,12 @@ private fun WorktimeAuthenticatedScaffold(
                                 }
                             }
                         },
-                        icon = { Text(destination.emoji) },
+                        icon = {
+                            Icon(
+                                imageVector = destination.icon,
+                                contentDescription = destination.label
+                            )
+                        },
                         label = { Text(destination.label) }
                     )
                 }

--- a/android/app/src/main/java/com/worktime/android/app/navigation/WorktimeDestination.kt
+++ b/android/app/src/main/java/com/worktime/android/app/navigation/WorktimeDestination.kt
@@ -1,9 +1,17 @@
 package com.worktime.android.app.navigation
 
-enum class WorktimeDestination(val route: String, val label: String, val emoji: String) {
-    Today(route = "today", label = "Today", emoji = "🕒"),
-    NextShifts(route = "next-shifts", label = "Next", emoji = "➡️"),
-    TeamStatus(route = "team-status", label = "Team", emoji = "👥"),
-    TimeOff(route = "time-off", label = "Time Off", emoji = "🌴"),
-    Settings(route = "settings", label = "Settings", emoji = "⚙️")
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class WorktimeDestination(val route: String, val label: String, val icon: ImageVector) {
+    Today(route = "today", label = "Today", icon = Icons.Filled.Schedule),
+    NextShifts(route = "next-shifts", label = "Next", icon = Icons.Filled.Event),
+    TeamStatus(route = "team-status", label = "Team", icon = Icons.Filled.Groups),
+    TimeOff(route = "time-off", label = "Time Off", icon = Icons.Filled.EventBusy),
+    Settings(route = "settings", label = "Settings", icon = Icons.Filled.Settings)
 }

--- a/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
+++ b/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
@@ -19,6 +19,8 @@ import com.worktime.android.data.model.TimeOffEntryListResponse
 import com.worktime.android.data.model.TimeOffEntryMutationRequest
 import com.worktime.android.data.model.TimeOffEntryPatchRequest
 import com.worktime.android.data.model.TimeOffEntryRecord
+import com.worktime.android.data.model.UserPreferencesRead
+import com.worktime.android.data.model.UserPreferencesWrite
 import com.worktime.android.data.model.WorkLocationListResponse
 import com.worktime.android.data.model.WorkLocationMutationRequest
 import com.worktime.android.data.model.WorkLocationRecord
@@ -92,6 +94,15 @@ interface WorktimeApi {
 
     @GET("api/sync/status")
     suspend fun getSyncStatus(@Header("Authorization") authorization: String): SyncStatusResponse
+
+    @GET("api/preferences")
+    suspend fun getPreferences(@Header("Authorization") authorization: String): UserPreferencesRead?
+
+    @PUT("api/preferences")
+    suspend fun putPreferences(
+        @Header("Authorization") authorization: String,
+        @Body payload: UserPreferencesWrite
+    ): UserPreferencesRead
 
     @DELETE("api/me")
     suspend fun deleteAccount(@Header("Authorization") authorization: String)

--- a/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
+++ b/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
@@ -39,6 +39,7 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
+@Suppress("TooManyFunctions") // one cohesive Retrofit client for the whole backend surface
 interface WorktimeApi {
     @GET("api/read-models/dashboard")
     suspend fun getDashboard(

--- a/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
+++ b/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
@@ -3,9 +3,22 @@ package com.worktime.android.data.api
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.worktime.android.core.network.DynamicBaseUrlInterceptor
 import com.worktime.android.data.model.DashboardResponse
+import com.worktime.android.data.model.LabelListResponse
+import com.worktime.android.data.model.LabelMutationRequest
+import com.worktime.android.data.model.LabelPatchRequest
+import com.worktime.android.data.model.LabelRecord
 import com.worktime.android.data.model.SyncStatusResponse
+import com.worktime.android.data.model.TaskListResponse
 import com.worktime.android.data.model.TaskMutationRequest
 import com.worktime.android.data.model.TaskRecord
+import com.worktime.android.data.model.TemplateListResponse
+import com.worktime.android.data.model.TemplateMutationRequest
+import com.worktime.android.data.model.TemplatePatchRequest
+import com.worktime.android.data.model.TemplateRecord
+import com.worktime.android.data.model.TimeOffEntryListResponse
+import com.worktime.android.data.model.TimeOffEntryMutationRequest
+import com.worktime.android.data.model.TimeOffEntryPatchRequest
+import com.worktime.android.data.model.TimeOffEntryRecord
 import com.worktime.android.data.model.WorkLocationListResponse
 import com.worktime.android.data.model.WorkLocationMutationRequest
 import com.worktime.android.data.model.WorkLocationRecord
@@ -20,6 +33,7 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -80,6 +94,117 @@ interface WorktimeApi {
 
     @DELETE("api/me")
     suspend fun deleteAccount(@Header("Authorization") authorization: String)
+
+    // Time off is resolved from the bearer token only - no user_id query param.
+    @POST("api/time-off/")
+    suspend fun upsertTimeOffEntry(
+        @Header("Authorization") authorization: String,
+        @Body payload: TimeOffEntryMutationRequest
+    ): Response<TimeOffEntryRecord>
+
+    @GET("api/time-off/")
+    suspend fun listTimeOffEntries(
+        @Header("Authorization") authorization: String,
+        @Query("start_date") startDate: String? = null,
+        @Query("end_date") endDate: String? = null
+    ): TimeOffEntryListResponse
+
+    @GET("api/time-off/{entryId}")
+    suspend fun getTimeOffEntry(
+        @Header("Authorization") authorization: String,
+        @Path("entryId") entryId: String
+    ): TimeOffEntryRecord
+
+    @PATCH("api/time-off/{entryId}")
+    suspend fun updateTimeOffEntry(
+        @Header("Authorization") authorization: String,
+        @Path("entryId") entryId: String,
+        @Body payload: TimeOffEntryPatchRequest
+    ): TimeOffEntryRecord
+
+    @DELETE("api/time-off/{entryId}")
+    suspend fun deleteTimeOffEntry(
+        @Header("Authorization") authorization: String,
+        @Path("entryId") entryId: String
+    )
+
+    @POST("api/time-tracking/labels")
+    suspend fun createLabel(
+        @Header("Authorization") authorization: String,
+        @Query("user_id") userId: Int,
+        @Body payload: LabelMutationRequest
+    ): LabelRecord
+
+    @GET("api/time-tracking/labels")
+    suspend fun listLabels(
+        @Header("Authorization") authorization: String,
+        @Query("user_id") userId: Int
+    ): LabelListResponse
+
+    @PUT("api/time-tracking/labels/{labelId}")
+    suspend fun updateLabel(
+        @Header("Authorization") authorization: String,
+        @Path("labelId") labelId: String,
+        @Query("user_id") userId: Int,
+        @Body payload: LabelPatchRequest
+    ): LabelRecord
+
+    @POST("api/time-tracking/templates")
+    suspend fun createTemplate(
+        @Header("Authorization") authorization: String,
+        @Query("user_id") userId: Int,
+        @Body payload: TemplateMutationRequest
+    ): TemplateRecord
+
+    @GET("api/time-tracking/templates")
+    suspend fun listTemplates(
+        @Header("Authorization") authorization: String,
+        @Query("user_id") userId: Int
+    ): TemplateListResponse
+
+    @PUT("api/time-tracking/templates/{templateId}")
+    suspend fun updateTemplate(
+        @Header("Authorization") authorization: String,
+        @Path("templateId") templateId: String,
+        @Query("user_id") userId: Int,
+        @Body payload: TemplatePatchRequest
+    ): TemplateRecord
+
+    @DELETE("api/time-tracking/templates/{templateId}")
+    suspend fun deleteTemplate(
+        @Header("Authorization") authorization: String,
+        @Path("templateId") templateId: String,
+        @Query("user_id") userId: Int
+    )
+
+    @GET("api/time-tracking/tasks")
+    suspend fun listTasks(
+        @Header("Authorization") authorization: String,
+        @Query("user_id") userId: Int,
+        @Query("start_date") startDate: String? = null,
+        @Query("end_date") endDate: String? = null
+    ): TaskListResponse
+
+    @DELETE("api/time-tracking/tasks/{taskId}")
+    suspend fun deleteTask(
+        @Header("Authorization") authorization: String,
+        @Path("taskId") taskId: String,
+        @Query("user_id") userId: Int
+    )
+
+    @GET("api/work-locations/{valueDate}")
+    suspend fun getWorkLocation(
+        @Header("Authorization") authorization: String,
+        @Path("valueDate") valueDate: String,
+        @Query("user_id") userId: Int
+    ): Response<WorkLocationRecord>
+
+    @DELETE("api/work-locations/{valueDate}")
+    suspend fun deleteWorkLocation(
+        @Header("Authorization") authorization: String,
+        @Path("valueDate") valueDate: String,
+        @Query("user_id") userId: Int
+    )
 
     companion object {
         fun create(

--- a/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
+++ b/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
@@ -124,10 +124,7 @@ interface WorktimeApi {
     ): TimeOffEntryRecord
 
     @DELETE("api/time-off/{entryId}")
-    suspend fun deleteTimeOffEntry(
-        @Header("Authorization") authorization: String,
-        @Path("entryId") entryId: String
-    )
+    suspend fun deleteTimeOffEntry(@Header("Authorization") authorization: String, @Path("entryId") entryId: String)
 
     @POST("api/time-tracking/labels")
     suspend fun createLabel(

--- a/android/app/src/main/java/com/worktime/android/data/model/LabelModels.kt
+++ b/android/app/src/main/java/com/worktime/android/data/model/LabelModels.kt
@@ -1,0 +1,22 @@
+package com.worktime.android.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LabelMutationRequest(val name: String, val color: String)
+
+@Serializable
+data class LabelPatchRequest(val name: String? = null, val color: String? = null)
+
+@Serializable
+data class LabelRecord(
+    val id: String,
+    @SerialName("user_id") val userId: Int,
+    val name: String,
+    val color: String,
+    @SerialName("created_at") val createdAt: String
+)
+
+@Serializable
+data class LabelListResponse(val items: List<LabelRecord>, val total: Int)

--- a/android/app/src/main/java/com/worktime/android/data/model/ReadModels.kt
+++ b/android/app/src/main/java/com/worktime/android/data/model/ReadModels.kt
@@ -2,6 +2,7 @@ package com.worktime.android.data.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 data class DashboardResponse(
@@ -155,3 +156,9 @@ data class SyncStatusResponse(
     @SerialName("preferences_updated_at") val preferencesUpdatedAt: String? = null,
     @SerialName("server_timestamp") val serverTimestamp: String
 )
+
+@Serializable
+data class UserPreferencesRead(val data: JsonObject)
+
+@Serializable
+data class UserPreferencesWrite(val data: JsonObject)

--- a/android/app/src/main/java/com/worktime/android/data/model/ReadModels.kt
+++ b/android/app/src/main/java/com/worktime/android/data/model/ReadModels.kt
@@ -122,6 +122,9 @@ data class TaskRecord(
 )
 
 @Serializable
+data class TaskListResponse(val items: List<TaskRecord>, val total: Int)
+
+@Serializable
 data class WorkLocationMutationRequest(
     val date: String,
     @SerialName("country_code") val countryCode: String,

--- a/android/app/src/main/java/com/worktime/android/data/model/TemplateModels.kt
+++ b/android/app/src/main/java/com/worktime/android/data/model/TemplateModels.kt
@@ -1,0 +1,34 @@
+package com.worktime.android.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TemplateMutationRequest(
+    val text: String,
+    @SerialName("label_id") val labelId: String? = null,
+    @SerialName("start_time") val startTime: String,
+    @SerialName("stop_time") val stopTime: String
+)
+
+@Serializable
+data class TemplatePatchRequest(
+    val text: String? = null,
+    @SerialName("label_id") val labelId: String? = null,
+    @SerialName("start_time") val startTime: String? = null,
+    @SerialName("stop_time") val stopTime: String? = null
+)
+
+@Serializable
+data class TemplateRecord(
+    val id: String,
+    @SerialName("user_id") val userId: Int,
+    @SerialName("label_id") val labelId: String? = null,
+    val text: String,
+    @SerialName("start_time") val startTime: String,
+    @SerialName("stop_time") val stopTime: String,
+    @SerialName("created_at") val createdAt: String
+)
+
+@Serializable
+data class TemplateListResponse(val items: List<TemplateRecord>, val total: Int)

--- a/android/app/src/main/java/com/worktime/android/data/model/TimeOffModels.kt
+++ b/android/app/src/main/java/com/worktime/android/data/model/TimeOffModels.kt
@@ -2,6 +2,7 @@ package com.worktime.android.data.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class TimeOffEntryMutationRequest(
@@ -25,7 +26,7 @@ data class TimeOffEntryPatchRequest(
     val weekday: Int? = null,
     @SerialName("entry_type") val entryType: String? = null,
     @SerialName("entry_flag") val entryFlag: String? = null,
-    val note: String? = null
+    val note: JsonElement? = null
 )
 
 @Serializable

--- a/android/app/src/main/java/com/worktime/android/data/model/TimeOffModels.kt
+++ b/android/app/src/main/java/com/worktime/android/data/model/TimeOffModels.kt
@@ -1,0 +1,49 @@
+package com.worktime.android.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TimeOffEntryMutationRequest(
+    @SerialName("entry_id") val entryId: String? = null,
+    @SerialName("entry_kind") val entryKind: String = "date",
+    val date: String? = null,
+    @SerialName("start_date") val startDate: String? = null,
+    @SerialName("end_date") val endDate: String? = null,
+    val weekday: Int? = null,
+    @SerialName("entry_type") val entryType: String = "vacation",
+    @SerialName("entry_flag") val entryFlag: String = "full_day",
+    val note: String? = null
+)
+
+@Serializable
+data class TimeOffEntryPatchRequest(
+    @SerialName("entry_kind") val entryKind: String? = null,
+    val date: String? = null,
+    @SerialName("start_date") val startDate: String? = null,
+    @SerialName("end_date") val endDate: String? = null,
+    val weekday: Int? = null,
+    @SerialName("entry_type") val entryType: String? = null,
+    @SerialName("entry_flag") val entryFlag: String? = null,
+    val note: String? = null
+)
+
+@Serializable
+data class TimeOffEntryRecord(
+    val id: Int,
+    @SerialName("entry_id") val entryId: String,
+    @SerialName("user_id") val userId: Int,
+    @SerialName("entry_kind") val entryKind: String,
+    val date: String? = null,
+    @SerialName("start_date") val startDate: String? = null,
+    @SerialName("end_date") val endDate: String? = null,
+    val weekday: Int? = null,
+    @SerialName("entry_type") val entryType: String,
+    @SerialName("entry_flag") val entryFlag: String,
+    val note: String? = null,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+@Serializable
+data class TimeOffEntryListResponse(val items: List<TimeOffEntryRecord>, val total: Int)

--- a/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
+++ b/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
@@ -4,25 +4,29 @@ import com.worktime.android.core.auth.SessionController
 import com.worktime.android.core.auth.SessionState
 import com.worktime.android.data.api.WorktimeApi
 import com.worktime.android.data.model.DashboardResponse
+import com.worktime.android.data.model.LabelMutationRequest
+import com.worktime.android.data.model.LabelPatchRequest
+import com.worktime.android.data.model.LabelRecord
 import com.worktime.android.data.model.SyncStatusResponse
 import com.worktime.android.data.model.TaskMutationRequest
 import com.worktime.android.data.model.TaskRecord
+import com.worktime.android.data.model.TemplateMutationRequest
+import com.worktime.android.data.model.TemplatePatchRequest
+import com.worktime.android.data.model.TemplateRecord
+import com.worktime.android.data.model.TimeOffEntryMutationRequest
+import com.worktime.android.data.model.TimeOffEntryPatchRequest
+import com.worktime.android.data.model.TimeOffEntryRecord
 import com.worktime.android.data.model.WorkLocationMutationRequest
 import com.worktime.android.data.model.WorkLocationRecord
 import java.io.IOException
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.TimeZone
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.StateFlow
 import retrofit2.HttpException
-
-private const val HTTP_NO_CONTENT = 204
-private const val HTTP_BAD_REQUEST = 400
-private const val HTTP_UNAUTHORIZED = 401
-private const val HTTP_CONFLICT = 409
-private const val WEEK_LOOKBACK_DAYS = 6L
 
 sealed interface DashboardLoadResult {
     data class Success(val dashboard: DashboardResponse) : DashboardLoadResult
@@ -42,6 +46,36 @@ sealed interface MutationResult<out T> {
     data class Error(val message: String) : MutationResult<Nothing>
 }
 
+/** Domain shape for creating/editing a time-off entry, mirroring the backend's discriminated `entry_kind`. */
+sealed interface TimeOffDraft {
+    val entryType: String
+    val entryFlag: String
+    val note: String?
+
+    data class SingleDate(
+        val date: LocalDate,
+        override val entryType: String,
+        override val entryFlag: String,
+        override val note: String? = null
+    ) : TimeOffDraft
+
+    data class DateRange(
+        val startDate: LocalDate,
+        val endDate: LocalDate,
+        override val entryType: String,
+        override val entryFlag: String,
+        override val note: String? = null
+    ) : TimeOffDraft
+
+    data class Weekly(
+        val weekday: Int,
+        override val entryType: String,
+        override val entryFlag: String,
+        override val note: String? = null
+    ) : TimeOffDraft
+}
+
+@Suppress("TooManyFunctions") // one cohesive repository facade over the whole backend surface
 interface DashboardRepository {
     val sessionState: StateFlow<SessionState>
 
@@ -55,6 +89,10 @@ interface DashboardRepository {
 
     suspend fun getRunningTask(): MutationResult<TaskRecord?>
 
+    suspend fun listTasks(startDate: LocalDate? = null, endDate: LocalDate? = null): MutationResult<List<TaskRecord>>
+
+    suspend fun deleteTask(taskId: String): MutationResult<Unit>
+
     suspend fun setWorkLocation(
         date: LocalDate,
         countryCode: String,
@@ -63,7 +101,49 @@ interface DashboardRepository {
 
     suspend fun loadWeeklyWorkLocations(until: LocalDate = LocalDate.now()): MutationResult<List<WorkLocationRecord>>
 
+    suspend fun getWorkLocation(date: LocalDate): MutationResult<WorkLocationRecord?>
+
+    suspend fun deleteWorkLocation(date: LocalDate): MutationResult<Unit>
+
+    suspend fun createLabel(name: String, color: String): MutationResult<LabelRecord>
+
+    suspend fun listLabels(): MutationResult<List<LabelRecord>>
+
+    suspend fun updateLabel(labelId: String, name: String? = null, color: String? = null): MutationResult<LabelRecord>
+
     suspend fun deleteLabel(labelId: String): MutationResult<Unit>
+
+    suspend fun createTemplate(
+        text: String,
+        labelId: String?,
+        startTime: LocalTime,
+        stopTime: LocalTime
+    ): MutationResult<TemplateRecord>
+
+    suspend fun listTemplates(): MutationResult<List<TemplateRecord>>
+
+    suspend fun updateTemplate(
+        templateId: String,
+        text: String? = null,
+        labelId: String? = null,
+        startTime: LocalTime? = null,
+        stopTime: LocalTime? = null
+    ): MutationResult<TemplateRecord>
+
+    suspend fun deleteTemplate(templateId: String): MutationResult<Unit>
+
+    suspend fun createTimeOffEntry(draft: TimeOffDraft): MutationResult<TimeOffEntryRecord>
+
+    suspend fun listTimeOffEntries(
+        startDate: LocalDate? = null,
+        endDate: LocalDate? = null
+    ): MutationResult<List<TimeOffEntryRecord>>
+
+    suspend fun getTimeOffEntry(entryId: String): MutationResult<TimeOffEntryRecord>
+
+    suspend fun updateTimeOffEntry(entryId: String, draft: TimeOffDraft): MutationResult<TimeOffEntryRecord>
+
+    suspend fun deleteTimeOffEntry(entryId: String): MutationResult<Unit>
 
     suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse>
 
@@ -72,10 +152,22 @@ interface DashboardRepository {
     fun logout()
 }
 
+@Suppress("TooManyFunctions") // implements the single-facade DashboardRepository
 class WorktimeRepository(private val api: WorktimeApi, private val sessionController: SessionController) :
     DashboardRepository {
     override val sessionState: StateFlow<SessionState> = sessionController.sessionState
     private var currentUserId: Int? = null
+
+    companion object {
+        private const val HTTP_NO_CONTENT = 204
+        private const val HTTP_BAD_REQUEST = 400
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_NOT_FOUND = 404
+        private const val HTTP_CONFLICT = 409
+        private const val WEEK_LOOKBACK_DAYS = 6L
+        private const val LABEL_NAME_CONFLICT_MESSAGE = "Label name must be unique"
+        private const val LABEL_IN_USE_MESSAGE = "Label is in use by tasks or templates and cannot be deleted"
+    }
 
     override suspend fun loadDashboard(): DashboardLoadResult {
         val token = sessionController.getFreshAccessToken() ?: return DashboardLoadResult.LoggedOut
@@ -101,7 +193,7 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
 
     override suspend fun startTimeTracking(text: String, labelId: String?): MutationResult<TaskRecord> {
         val now = OffsetDateTime.now(ZoneOffset.UTC).toString()
-        return withAuthorizedUser(sessionController, currentUserId) { token, userId ->
+        return withAuthorizedUser { token, userId ->
             api.createTask(
                 authorization = "Bearer $token",
                 userId = userId,
@@ -118,7 +210,7 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
 
     override suspend fun stopTimeTracking(taskId: String): MutationResult<TaskRecord> {
         val now = OffsetDateTime.now(ZoneOffset.UTC).toString()
-        return withAuthorizedUser(sessionController, currentUserId) { token, userId ->
+        return withAuthorizedUser { token, userId ->
             api.updateTask(
                 authorization = "Bearer $token",
                 taskId = taskId,
@@ -129,7 +221,7 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
     }
 
     override suspend fun updateTask(taskId: String, text: String?, labelId: String?): MutationResult<TaskRecord> =
-        withAuthorizedUser(sessionController, currentUserId) {
+        withAuthorizedUser {
                 token,
                 userId
             ->
@@ -141,22 +233,36 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
             )
         }
 
-    override suspend fun getRunningTask(): MutationResult<TaskRecord?> =
-        withAuthorizedUser(sessionController, currentUserId) { token, userId ->
-            val response =
-                api.getRunningTask(
+    override suspend fun getRunningTask(): MutationResult<TaskRecord?> = withAuthorizedUser { token, userId ->
+        val response =
+            api.getRunningTask(
+                authorization = "Bearer $token",
+                userId = userId
+            )
+        if (!response.isSuccessful) throw HttpException(response)
+        if (response.code() == HTTP_NO_CONTENT) null else response.body()
+    }
+
+    override suspend fun listTasks(startDate: LocalDate?, endDate: LocalDate?): MutationResult<List<TaskRecord>> =
+        withAuthorizedUser { token, userId ->
+            api
+                .listTasks(
                     authorization = "Bearer $token",
-                    userId = userId
-                )
-            if (!response.isSuccessful) throw HttpException(response)
-            if (response.code() == HTTP_NO_CONTENT) null else response.body()
+                    userId = userId,
+                    startDate = startDate?.toString(),
+                    endDate = endDate?.toString()
+                ).items
         }
+
+    override suspend fun deleteTask(taskId: String): MutationResult<Unit> = withAuthorizedUser { token, userId ->
+        api.deleteTask(authorization = "Bearer $token", taskId = taskId, userId = userId)
+    }
 
     override suspend fun setWorkLocation(
         date: LocalDate,
         countryCode: String,
         label: String?
-    ): MutationResult<WorkLocationRecord> = withAuthorizedUser(sessionController, currentUserId) { token, userId ->
+    ): MutationResult<WorkLocationRecord> = withAuthorizedUser { token, userId ->
         api.upsertWorkLocation(
             authorization = "Bearer $token",
             userId = userId,
@@ -170,7 +276,7 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
     }
 
     override suspend fun loadWeeklyWorkLocations(until: LocalDate): MutationResult<List<WorkLocationRecord>> =
-        withAuthorizedUser(sessionController, currentUserId) {
+        withAuthorizedUser {
                 token,
                 userId
             ->
@@ -183,22 +289,25 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
                 ).items
         }
 
-    override suspend fun deleteLabel(labelId: String): MutationResult<Unit> {
+    override suspend fun getWorkLocation(date: LocalDate): MutationResult<WorkLocationRecord?> {
         val token = sessionController.getFreshAccessToken() ?: return MutationResult.LoggedOut
         val userId = currentUserId ?: return MutationResult.Error("Reload your dashboard before making changes")
         return try {
-            api.deleteLabel(authorization = "Bearer $token", labelId = labelId, userId = userId)
-            MutationResult.Success(Unit)
+            val response =
+                api.getWorkLocation(authorization = "Bearer $token", valueDate = date.toString(), userId = userId)
+            if (response.code() == HTTP_NOT_FOUND) {
+                MutationResult.Success(null)
+            } else if (!response.isSuccessful) {
+                throw HttpException(response)
+            } else {
+                MutationResult.Success(response.body())
+            }
         } catch (error: HttpException) {
-            when (error.code()) {
-                HTTP_UNAUTHORIZED -> {
-                    sessionController.logout()
-                    MutationResult.LoggedOut
-                }
-                HTTP_CONFLICT -> MutationResult.ValidationError(
-                    "Label is in use by tasks or templates and cannot be deleted"
-                )
-                else -> MutationResult.Error("Request failed (${error.code()})")
+            if (error.code() == HTTP_UNAUTHORIZED) {
+                sessionController.logout()
+                MutationResult.LoggedOut
+            } else {
+                mapHttpError(error)
             }
         } catch (_: IOException) {
             MutationResult.Error("Unable to reach the Worktime backend")
@@ -208,61 +317,243 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
         }
     }
 
-    override suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse> =
-        withAuthorizedUser(sessionController, currentUserId) { token, _ ->
-            api.getSyncStatus(authorization = "Bearer $token")
+    override suspend fun deleteWorkLocation(date: LocalDate): MutationResult<Unit> =
+        withAuthorizedUser { token, userId ->
+            api.deleteWorkLocation(authorization = "Bearer $token", valueDate = date.toString(), userId = userId)
         }
 
-    override suspend fun deleteAccount(): MutationResult<Unit> {
-        val token = sessionController.getFreshAccessToken() ?: return MutationResult.LoggedOut
-        return try {
-            api.deleteAccount(authorization = "Bearer $token")
-            sessionController.logout()
-            currentUserId = null
-            MutationResult.Success(Unit)
-        } catch (error: HttpException) {
-            if (error.code() == HTTP_UNAUTHORIZED) {
-                sessionController.logout()
-                MutationResult.LoggedOut
-            } else {
-                MutationResult.Error("Request failed (${error.code()})")
-            }
-        } catch (_: IOException) {
-            MutationResult.Error("Unable to reach the Worktime backend")
-        } catch (error: Exception) {
-            if (error is CancellationException) throw error
-            MutationResult.Error(error.message ?: "Request failed")
+    override suspend fun createLabel(name: String, color: String): MutationResult<LabelRecord> =
+        withAuthorizedUser(conflictMessage = LABEL_NAME_CONFLICT_MESSAGE) { token, userId ->
+            api.createLabel(
+                authorization = "Bearer $token",
+                userId = userId,
+                payload = LabelMutationRequest(name = name, color = color)
+            )
         }
+
+    override suspend fun listLabels(): MutationResult<List<LabelRecord>> = withAuthorizedUser { token, userId ->
+        api.listLabels(authorization = "Bearer $token", userId = userId).items
+    }
+
+    override suspend fun updateLabel(labelId: String, name: String?, color: String?): MutationResult<LabelRecord> =
+        withAuthorizedUser(conflictMessage = LABEL_NAME_CONFLICT_MESSAGE) { token, userId ->
+            api.updateLabel(
+                authorization = "Bearer $token",
+                labelId = labelId,
+                userId = userId,
+                payload = LabelPatchRequest(name = name, color = color)
+            )
+        }
+
+    override suspend fun deleteLabel(labelId: String): MutationResult<Unit> =
+        withAuthorizedUser(conflictMessage = LABEL_IN_USE_MESSAGE) { token, userId ->
+            api.deleteLabel(authorization = "Bearer $token", labelId = labelId, userId = userId)
+        }
+
+    override suspend fun createTemplate(
+        text: String,
+        labelId: String?,
+        startTime: LocalTime,
+        stopTime: LocalTime
+    ): MutationResult<TemplateRecord> = withAuthorizedUser { token, userId ->
+        api.createTemplate(
+            authorization = "Bearer $token",
+            userId = userId,
+            payload =
+            TemplateMutationRequest(
+                text = text,
+                labelId = labelId,
+                startTime = startTime.toString(),
+                stopTime = stopTime.toString()
+            )
+        )
+    }
+
+    override suspend fun listTemplates(): MutationResult<List<TemplateRecord>> = withAuthorizedUser { token, userId ->
+        api.listTemplates(authorization = "Bearer $token", userId = userId).items
+    }
+
+    override suspend fun updateTemplate(
+        templateId: String,
+        text: String?,
+        labelId: String?,
+        startTime: LocalTime?,
+        stopTime: LocalTime?
+    ): MutationResult<TemplateRecord> = withAuthorizedUser { token, userId ->
+        api.updateTemplate(
+            authorization = "Bearer $token",
+            templateId = templateId,
+            userId = userId,
+            payload =
+            TemplatePatchRequest(
+                text = text,
+                labelId = labelId,
+                startTime = startTime?.toString(),
+                stopTime = stopTime?.toString()
+            )
+        )
+    }
+
+    override suspend fun deleteTemplate(templateId: String): MutationResult<Unit> =
+        withAuthorizedUser { token, userId ->
+            api.deleteTemplate(authorization = "Bearer $token", templateId = templateId, userId = userId)
+        }
+
+    override suspend fun createTimeOffEntry(draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
+        withAuthorizedToken { token ->
+            val response =
+                api.upsertTimeOffEntry(authorization = "Bearer $token", payload = draft.toMutationRequest())
+            if (!response.isSuccessful) throw HttpException(response)
+            response.body() ?: error("Empty response body for time-off entry")
+        }
+
+    override suspend fun listTimeOffEntries(
+        startDate: LocalDate?,
+        endDate: LocalDate?
+    ): MutationResult<List<TimeOffEntryRecord>> = withAuthorizedToken { token ->
+        api
+            .listTimeOffEntries(
+                authorization = "Bearer $token",
+                startDate = startDate?.toString(),
+                endDate = endDate?.toString()
+            ).items
+    }
+
+    override suspend fun getTimeOffEntry(entryId: String): MutationResult<TimeOffEntryRecord> =
+        withAuthorizedToken { token ->
+            api.getTimeOffEntry(authorization = "Bearer $token", entryId = entryId)
+        }
+
+    override suspend fun updateTimeOffEntry(entryId: String, draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
+        withAuthorizedToken { token ->
+            api.updateTimeOffEntry(
+                authorization = "Bearer $token",
+                entryId = entryId,
+                payload = draft.toPatchRequest()
+            )
+        }
+
+    override suspend fun deleteTimeOffEntry(entryId: String): MutationResult<Unit> = withAuthorizedToken { token ->
+        api.deleteTimeOffEntry(authorization = "Bearer $token", entryId = entryId)
+    }
+
+    override suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse> = withAuthorizedUser { token, _ ->
+        api.getSyncStatus(authorization = "Bearer $token")
+    }
+
+    override suspend fun deleteAccount(): MutationResult<Unit> = withAuthorizedToken { token ->
+        api.deleteAccount(authorization = "Bearer $token")
+        sessionController.logout()
+        currentUserId = null
     }
 
     override fun logout() {
         sessionController.logout()
         currentUserId = null
     }
+
+    private fun mapHttpError(error: HttpException, conflictMessage: String? = null): MutationResult<Nothing> =
+        when (error.code()) {
+            HTTP_BAD_REQUEST -> MutationResult.ValidationError("Request validation failed")
+            HTTP_CONFLICT -> MutationResult.ValidationError(conflictMessage ?: "Request conflicts with existing data")
+            else -> MutationResult.Error("Request failed (${error.code()})")
+        }
+
+    private suspend fun <T> withAuthorizedUser(
+        conflictMessage: String? = null,
+        block: suspend (token: String, userId: Int) -> T
+    ): MutationResult<T> {
+        val token = sessionController.getFreshAccessToken() ?: return MutationResult.LoggedOut
+        val userId = currentUserId ?: return MutationResult.Error("Reload your dashboard before making changes")
+        return try {
+            MutationResult.Success(block(token, userId))
+        } catch (error: HttpException) {
+            if (error.code() == HTTP_UNAUTHORIZED) {
+                sessionController.logout()
+                MutationResult.LoggedOut
+            } else {
+                mapHttpError(error, conflictMessage)
+            }
+        } catch (_: IOException) {
+            MutationResult.Error("Unable to reach the Worktime backend")
+        } catch (error: Exception) {
+            if (error is CancellationException) throw error
+            MutationResult.Error(error.message ?: "Request failed")
+        }
+    }
+
+    private suspend fun <T> withAuthorizedToken(block: suspend (token: String) -> T): MutationResult<T> {
+        val token = sessionController.getFreshAccessToken() ?: return MutationResult.LoggedOut
+        return try {
+            MutationResult.Success(block(token))
+        } catch (error: HttpException) {
+            if (error.code() == HTTP_UNAUTHORIZED) {
+                sessionController.logout()
+                MutationResult.LoggedOut
+            } else {
+                mapHttpError(error)
+            }
+        } catch (_: IOException) {
+            MutationResult.Error("Unable to reach the Worktime backend")
+        } catch (error: Exception) {
+            if (error is CancellationException) throw error
+            MutationResult.Error(error.message ?: "Request failed")
+        }
+    }
 }
 
-private suspend fun <T> withAuthorizedUser(
-    sessionController: SessionController,
-    currentUserId: Int?,
-    block: suspend (token: String, userId: Int) -> T
-): MutationResult<T> {
-    val token = sessionController.getFreshAccessToken() ?: return MutationResult.LoggedOut
-    val userId = currentUserId ?: return MutationResult.Error("Reload your dashboard before making changes")
-    return try {
-        MutationResult.Success(block(token, userId))
-    } catch (error: HttpException) {
-        if (error.code() == HTTP_UNAUTHORIZED) {
-            sessionController.logout()
-            MutationResult.LoggedOut
-        } else if (error.code() == HTTP_BAD_REQUEST) {
-            MutationResult.ValidationError("Request validation failed")
-        } else {
-            MutationResult.Error("Request failed (${error.code()})")
-        }
-    } catch (_: IOException) {
-        MutationResult.Error("Unable to reach the Worktime backend")
-    } catch (error: Exception) {
-        if (error is CancellationException) throw error
-        MutationResult.Error(error.message ?: "Request failed")
-    }
+private fun TimeOffDraft.toMutationRequest(): TimeOffEntryMutationRequest = when (this) {
+    is TimeOffDraft.SingleDate ->
+        TimeOffEntryMutationRequest(
+            entryKind = "date",
+            date = date.toString(),
+            entryType = entryType,
+            entryFlag = entryFlag,
+            note = note
+        )
+    is TimeOffDraft.DateRange ->
+        TimeOffEntryMutationRequest(
+            entryKind = "range",
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+            entryType = entryType,
+            entryFlag = entryFlag,
+            note = note
+        )
+    is TimeOffDraft.Weekly ->
+        TimeOffEntryMutationRequest(
+            entryKind = "weekly",
+            weekday = weekday,
+            entryType = entryType,
+            entryFlag = entryFlag,
+            note = note
+        )
+}
+
+private fun TimeOffDraft.toPatchRequest(): TimeOffEntryPatchRequest = when (this) {
+    is TimeOffDraft.SingleDate ->
+        TimeOffEntryPatchRequest(
+            entryKind = "date",
+            date = date.toString(),
+            entryType = entryType,
+            entryFlag = entryFlag,
+            note = note
+        )
+    is TimeOffDraft.DateRange ->
+        TimeOffEntryPatchRequest(
+            entryKind = "range",
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+            entryType = entryType,
+            entryFlag = entryFlag,
+            note = note
+        )
+    is TimeOffDraft.Weekly ->
+        TimeOffEntryPatchRequest(
+            entryKind = "weekly",
+            weekday = weekday,
+            entryType = entryType,
+            entryFlag = entryFlag,
+            note = note
+        )
 }

--- a/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
+++ b/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
@@ -16,6 +16,7 @@ import com.worktime.android.data.model.TemplateRecord
 import com.worktime.android.data.model.TimeOffEntryMutationRequest
 import com.worktime.android.data.model.TimeOffEntryPatchRequest
 import com.worktime.android.data.model.TimeOffEntryRecord
+import com.worktime.android.data.model.UserPreferencesWrite
 import com.worktime.android.data.model.WorkLocationMutationRequest
 import com.worktime.android.data.model.WorkLocationRecord
 import java.io.IOException
@@ -26,6 +27,13 @@ import java.time.ZoneOffset
 import java.util.TimeZone
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import retrofit2.HttpException
 
 sealed interface DashboardLoadResult {
@@ -45,6 +53,8 @@ sealed interface MutationResult<out T> {
 
     data class Error(val message: String) : MutationResult<Nothing>
 }
+
+data class WorkLocationPreferences(val homeCountry: String? = null, val officeCountry: String? = null)
 
 /** Domain shape for creating/editing a time-off entry, mirroring the backend's discriminated `entry_kind`. */
 sealed interface TimeOffDraft {
@@ -146,6 +156,13 @@ interface DashboardRepository {
     suspend fun deleteTimeOffEntry(entryId: String): MutationResult<Unit>
 
     suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse>
+
+    suspend fun loadWorkLocationPreferences(): MutationResult<WorkLocationPreferences>
+
+    suspend fun updateWorkLocationPreferences(
+        homeCountry: String?,
+        officeCountry: String?
+    ): MutationResult<WorkLocationPreferences>
 
     suspend fun deleteAccount(): MutationResult<Unit>
 
@@ -441,6 +458,21 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
         api.getSyncStatus(authorization = "Bearer $token")
     }
 
+    override suspend fun loadWorkLocationPreferences(): MutationResult<WorkLocationPreferences> =
+        withAuthorizedToken { token ->
+            api.getPreferences(authorization = "Bearer $token")?.data.toWorkLocationPreferences()
+        }
+
+    override suspend fun updateWorkLocationPreferences(
+        homeCountry: String?,
+        officeCountry: String?
+    ): MutationResult<WorkLocationPreferences> = withAuthorizedToken { token ->
+        val existing = api.getPreferences(authorization = "Bearer $token")?.data ?: JsonObject(emptyMap())
+        val updated = existing.withWorkLocationPreferences(homeCountry, officeCountry)
+        api.putPreferences(authorization = "Bearer $token", payload = UserPreferencesWrite(data = updated))
+        updated.toWorkLocationPreferences()
+    }
+
     override suspend fun deleteAccount(): MutationResult<Unit> = withAuthorizedToken { token ->
         api.deleteAccount(authorization = "Bearer $token")
         sessionController.logout()
@@ -537,7 +569,7 @@ private fun TimeOffDraft.toPatchRequest(): TimeOffEntryPatchRequest = when (this
             date = date.toString(),
             entryType = entryType,
             entryFlag = entryFlag,
-            note = note
+            note = note.toPatchNote()
         )
     is TimeOffDraft.DateRange ->
         TimeOffEntryPatchRequest(
@@ -546,7 +578,7 @@ private fun TimeOffDraft.toPatchRequest(): TimeOffEntryPatchRequest = when (this
             endDate = endDate.toString(),
             entryType = entryType,
             entryFlag = entryFlag,
-            note = note
+            note = note.toPatchNote()
         )
     is TimeOffDraft.Weekly ->
         TimeOffEntryPatchRequest(
@@ -554,6 +586,38 @@ private fun TimeOffDraft.toPatchRequest(): TimeOffEntryPatchRequest = when (this
             weekday = weekday,
             entryType = entryType,
             entryFlag = entryFlag,
-            note = note
+            note = note.toPatchNote()
         )
 }
+
+private fun String?.toPatchNote() = this?.let(::JsonPrimitive) ?: JsonNull
+
+private fun JsonObject?.toWorkLocationPreferences(): WorkLocationPreferences {
+    val settings = this?.get("settings")?.asJsonObjectOrNull()
+    return WorkLocationPreferences(
+        homeCountry = settings?.get("homeCountry")?.asStringOrNull()?.normalizeCountryCode(),
+        officeCountry = settings?.get("officeCountry")?.asStringOrNull()?.normalizeCountryCode()
+    )
+}
+
+private fun JsonObject.withWorkLocationPreferences(homeCountry: String?, officeCountry: String?): JsonObject {
+    val settings = this["settings"]?.asJsonObjectOrNull() ?: JsonObject(emptyMap())
+    val updatedSettings =
+        JsonObject(
+            settings
+                .toMutableMap()
+                .apply {
+                    put("homeCountry", homeCountry.toCountryJson())
+                    put("officeCountry", officeCountry.toCountryJson())
+                }
+        )
+    return JsonObject(toMutableMap().apply { put("settings", updatedSettings) })
+}
+
+private fun JsonElement.asJsonObjectOrNull(): JsonObject? = runCatching { jsonObject }.getOrNull()
+
+private fun JsonElement.asStringOrNull(): String? = runCatching { jsonPrimitive.contentOrNull }.getOrNull()
+
+private fun String?.toCountryJson(): JsonElement = normalizeCountryCode()?.let(::JsonPrimitive) ?: JsonNull
+
+private fun String?.normalizeCountryCode(): String? = this?.trim()?.uppercase()?.takeIf { it.length == 2 }

--- a/android/app/src/main/java/com/worktime/android/feature/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/dashboard/DashboardViewModel.kt
@@ -14,6 +14,7 @@ import com.worktime.android.data.model.WorkLocationRecord
 import com.worktime.android.data.repository.DashboardLoadResult
 import com.worktime.android.data.repository.DashboardRepository
 import com.worktime.android.data.repository.MutationResult
+import com.worktime.android.data.repository.WorkLocationPreferences
 import java.time.LocalDate
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -37,6 +38,7 @@ data class MobileActionsUiState(
     val weeklyWorkLocations: List<WorkLocationRecord> = emptyList(),
     val labels: List<LabelRecord> = emptyList(),
     val templates: List<TemplateRecord> = emptyList(),
+    val workLocationPreferences: WorkLocationPreferences = WorkLocationPreferences(),
     val syncStatus: SyncStatusResponse? = null,
     val isSubmitting: Boolean = false,
     val message: String? = null,
@@ -44,6 +46,7 @@ data class MobileActionsUiState(
     val deleteAccountError: String? = null
 )
 
+@Suppress("TooManyFunctions") // one view model facade for all mobile dashboard actions
 class DashboardViewModel(private val repository: DashboardRepository) : ViewModel() {
     private val _uiState = MutableStateFlow<DashboardUiState>(DashboardUiState.Loading)
     val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
@@ -102,6 +105,13 @@ class DashboardViewModel(private val repository: DashboardRepository) : ViewMode
                         else -> null
                     }
                 }
+            val workLocationPreferencesDeferred =
+                async {
+                    when (val result = repository.loadWorkLocationPreferences()) {
+                        is MutationResult.Success -> result.value
+                        else -> WorkLocationPreferences()
+                    }
+                }
             val labelsDeferred =
                 async {
                     when (val result = repository.listLabels()) {
@@ -121,6 +131,7 @@ class DashboardViewModel(private val repository: DashboardRepository) : ViewMode
                     runningTask = runningTaskDeferred.await(),
                     weeklyWorkLocations = weeklyLocationsDeferred.await(),
                     syncStatus = syncStatusDeferred.await(),
+                    workLocationPreferences = workLocationPreferencesDeferred.await(),
                     labels = labelsDeferred.await(),
                     templates = templatesDeferred.await()
                 )
@@ -143,8 +154,57 @@ class DashboardViewModel(private val repository: DashboardRepository) : ViewMode
         submitMutation { repository.setWorkLocation(date = date, countryCode = countryCode, label = label) }
     }
 
+    fun deleteWorkLocation(date: LocalDate) {
+        submitMutation { repository.deleteWorkLocation(date) }
+    }
+
+    fun updateWorkLocationPreferences(homeCountry: String?, officeCountry: String?) {
+        submitMutation { repository.updateWorkLocationPreferences(homeCountry, officeCountry) }
+    }
+
     fun createLabel(name: String, color: String) {
         submitMutation { repository.createLabel(name, color) }
+    }
+
+    fun updateLabel(labelId: String, name: String, color: String) {
+        submitMutation { repository.updateLabel(labelId = labelId, name = name, color = color) }
+    }
+
+    fun deleteLabel(labelId: String) {
+        submitMutation { repository.deleteLabel(labelId) }
+    }
+
+    fun createTemplate(text: String, labelId: String?, startTime: java.time.LocalTime, stopTime: java.time.LocalTime) {
+        submitMutation {
+            repository.createTemplate(
+                text = text,
+                labelId = labelId,
+                startTime = startTime,
+                stopTime = stopTime
+            )
+        }
+    }
+
+    fun updateTemplate(
+        templateId: String,
+        text: String,
+        labelId: String?,
+        startTime: java.time.LocalTime,
+        stopTime: java.time.LocalTime
+    ) {
+        submitMutation {
+            repository.updateTemplate(
+                templateId = templateId,
+                text = text,
+                labelId = labelId,
+                startTime = startTime,
+                stopTime = stopTime
+            )
+        }
+    }
+
+    fun deleteTemplate(templateId: String) {
+        submitMutation { repository.deleteTemplate(templateId) }
     }
 
     fun logout() {

--- a/android/app/src/main/java/com/worktime/android/feature/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/dashboard/DashboardViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.worktime.android.data.model.DashboardResponse
+import com.worktime.android.data.model.LabelRecord
 import com.worktime.android.data.model.SyncStatusResponse
 import com.worktime.android.data.model.TaskRecord
+import com.worktime.android.data.model.TemplateRecord
 import com.worktime.android.data.model.WorkLocationRecord
 import com.worktime.android.data.repository.DashboardLoadResult
 import com.worktime.android.data.repository.DashboardRepository
@@ -33,6 +35,8 @@ sealed interface DashboardUiState {
 data class MobileActionsUiState(
     val runningTask: TaskRecord? = null,
     val weeklyWorkLocations: List<WorkLocationRecord> = emptyList(),
+    val labels: List<LabelRecord> = emptyList(),
+    val templates: List<TemplateRecord> = emptyList(),
     val syncStatus: SyncStatusResponse? = null,
     val isSubmitting: Boolean = false,
     val message: String? = null,
@@ -98,11 +102,27 @@ class DashboardViewModel(private val repository: DashboardRepository) : ViewMode
                         else -> null
                     }
                 }
+            val labelsDeferred =
+                async {
+                    when (val result = repository.listLabels()) {
+                        is MutationResult.Success -> result.value
+                        else -> emptyList()
+                    }
+                }
+            val templatesDeferred =
+                async {
+                    when (val result = repository.listTemplates()) {
+                        is MutationResult.Success -> result.value
+                        else -> emptyList()
+                    }
+                }
             _actionsState.value =
                 _actionsState.value.copy(
                     runningTask = runningTaskDeferred.await(),
                     weeklyWorkLocations = weeklyLocationsDeferred.await(),
-                    syncStatus = syncStatusDeferred.await()
+                    syncStatus = syncStatusDeferred.await(),
+                    labels = labelsDeferred.await(),
+                    templates = templatesDeferred.await()
                 )
         }
     }
@@ -121,6 +141,10 @@ class DashboardViewModel(private val repository: DashboardRepository) : ViewMode
 
     fun setWorkLocation(date: LocalDate, countryCode: String, label: String?) {
         submitMutation { repository.setWorkLocation(date = date, countryCode = countryCode, label = label) }
+    }
+
+    fun createLabel(name: String, color: String) {
+        submitMutation { repository.createLabel(name, color) }
     }
 
     fun logout() {

--- a/android/app/src/main/java/com/worktime/android/feature/settings/LabelsTemplatesSettingsCards.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/LabelsTemplatesSettingsCards.kt
@@ -1,0 +1,416 @@
+package com.worktime.android.feature.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.worktime.android.data.model.LabelRecord
+import com.worktime.android.data.model.TemplateRecord
+import com.worktime.android.ui.components.SummaryCard
+import java.time.LocalTime
+
+private const val PRESET_COLOR_RED = "#F44336"
+private const val PRESET_COLOR_ORANGE = "#FF9800"
+private const val PRESET_COLOR_YELLOW = "#FBC02D"
+private const val PRESET_COLOR_GREEN = "#4CAF50"
+private const val PRESET_COLOR_TEAL = "#009688"
+private const val PRESET_COLOR_BLUE = "#2196F3"
+private const val PRESET_COLOR_PURPLE = "#9C27B0"
+private const val PRESET_COLOR_GREY = "#607D8B"
+private const val OPAQUE_ALPHA_MASK = 0xFF000000L
+
+private val PRESET_LABEL_COLORS =
+    listOf(
+        PRESET_COLOR_RED,
+        PRESET_COLOR_ORANGE,
+        PRESET_COLOR_YELLOW,
+        PRESET_COLOR_GREEN,
+        PRESET_COLOR_TEAL,
+        PRESET_COLOR_BLUE,
+        PRESET_COLOR_PURPLE,
+        PRESET_COLOR_GREY
+    )
+
+@Composable
+fun LabelManagementCard(
+    labels: List<LabelRecord>,
+    isSubmitting: Boolean,
+    onCreateLabel: (String, String) -> Unit,
+    onUpdateLabel: (String, String, String) -> Unit,
+    onDeleteLabel: (String) -> Unit
+) {
+    var dialogTarget by remember { mutableStateOf<LabelRecord?>(null) }
+    var showCreateDialog by rememberSaveable { mutableStateOf(false) }
+
+    SummaryCard(title = "Labels") {
+        content {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (labels.isEmpty()) {
+                    Text("No labels yet", style = MaterialTheme.typography.bodySmall)
+                } else {
+                    labels.forEach { label ->
+                        LabelRow(
+                            label = label,
+                            isSubmitting = isSubmitting,
+                            onEdit = { dialogTarget = label },
+                            onDelete = { onDeleteLabel(label.id) }
+                        )
+                    }
+                }
+                Button(onClick = { showCreateDialog = true }, enabled = !isSubmitting) {
+                    Text("Add label")
+                }
+            }
+        }
+    }
+
+    if (showCreateDialog) {
+        LabelDialog(
+            label = null,
+            onDismiss = { showCreateDialog = false },
+            onSave = { name, color ->
+                onCreateLabel(name, color)
+                showCreateDialog = false
+            }
+        )
+    }
+    dialogTarget?.let { label ->
+        LabelDialog(
+            label = label,
+            onDismiss = { dialogTarget = null },
+            onSave = { name, color ->
+                onUpdateLabel(label.id, name, color)
+                dialogTarget = null
+            }
+        )
+    }
+}
+
+@Composable
+fun TemplateManagementCard(
+    labels: List<LabelRecord>,
+    templates: List<TemplateRecord>,
+    isSubmitting: Boolean,
+    onCreateTemplate: (String, String?, LocalTime, LocalTime) -> Unit,
+    onUpdateTemplate: (String, String, String?, LocalTime, LocalTime) -> Unit,
+    onDeleteTemplate: (String) -> Unit
+) {
+    var dialogTarget by remember { mutableStateOf<TemplateRecord?>(null) }
+    var showCreateDialog by rememberSaveable { mutableStateOf(false) }
+
+    SummaryCard(title = "Templates") {
+        content {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (templates.isEmpty()) {
+                    Text("No templates yet", style = MaterialTheme.typography.bodySmall)
+                } else {
+                    templates.forEach { template ->
+                        TemplateRow(
+                            template = template,
+                            labelName = labels.firstOrNull { it.id == template.labelId }?.name,
+                            isSubmitting = isSubmitting,
+                            onEdit = { dialogTarget = template },
+                            onDelete = { onDeleteTemplate(template.id) }
+                        )
+                    }
+                }
+                Button(onClick = { showCreateDialog = true }, enabled = !isSubmitting) {
+                    Text("Add template")
+                }
+            }
+        }
+    }
+
+    if (showCreateDialog) {
+        TemplateDialog(
+            labels = labels,
+            template = null,
+            onDismiss = { showCreateDialog = false },
+            onSave = { text, labelId, startTime, stopTime ->
+                onCreateTemplate(text, labelId, startTime, stopTime)
+                showCreateDialog = false
+            }
+        )
+    }
+    dialogTarget?.let { template ->
+        TemplateDialog(
+            labels = labels,
+            template = template,
+            onDismiss = { dialogTarget = null },
+            onSave = { text, labelId, startTime, stopTime ->
+                onUpdateTemplate(template.id, text, labelId, startTime, stopTime)
+                dialogTarget = null
+            }
+        )
+    }
+}
+
+@Composable
+private fun LabelRow(label: LabelRecord, isSubmitting: Boolean, onEdit: () -> Unit, onDelete: () -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(
+            modifier =
+            Modifier
+                .padding(top = 10.dp)
+                .size(16.dp)
+                .background(color = parseHexColor(label.color), shape = CircleShape)
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label.name)
+            Text(label.color, style = MaterialTheme.typography.bodySmall)
+        }
+        TextButton(onClick = onEdit, enabled = !isSubmitting) {
+            Text("Edit")
+        }
+        TextButton(onClick = onDelete, enabled = !isSubmitting) {
+            Text("Delete")
+        }
+    }
+}
+
+@Composable
+private fun TemplateRow(
+    template: TemplateRecord,
+    labelName: String?,
+    isSubmitting: Boolean,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(template.text)
+            Text(
+                listOfNotNull("${template.startTime}-${template.stopTime}", labelName).joinToString(" - "),
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+        TextButton(onClick = onEdit, enabled = !isSubmitting) {
+            Text("Edit")
+        }
+        TextButton(onClick = onDelete, enabled = !isSubmitting) {
+            Text("Delete")
+        }
+    }
+}
+
+@Composable
+private fun LabelDialog(label: LabelRecord?, onDismiss: () -> Unit, onSave: (String, String) -> Unit) {
+    var name by remember(label) { mutableStateOf(label?.name ?: "") }
+    var selectedColor by remember(label) { mutableStateOf(label?.color ?: PRESET_LABEL_COLORS.first()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (label == null) "Add label" else "Edit label") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                ColorPicker(selectedColor = selectedColor, onSelect = { selectedColor = it })
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onSave(name.trim(), selectedColor) }, enabled = name.isNotBlank()) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+@Composable
+private fun TemplateDialog(
+    labels: List<LabelRecord>,
+    template: TemplateRecord?,
+    onDismiss: () -> Unit,
+    onSave: (String, String?, LocalTime, LocalTime) -> Unit
+) {
+    var text by remember(template) { mutableStateOf(template?.text ?: "") }
+    var labelId by remember(template) { mutableStateOf(template?.labelId ?: "") }
+    var startTimeText by remember(template) { mutableStateOf(template?.startTime?.take(5) ?: "09:00") }
+    var stopTimeText by remember(template) { mutableStateOf(template?.stopTime?.take(5) ?: "17:00") }
+    var error by rememberSaveable { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (template == null) "Add template" else "Edit template") },
+        text = {
+            TemplateDialogFields(
+                text = text,
+                onTextChange = { text = it },
+                labels = labels,
+                labelId = labelId,
+                onLabelSelected = { labelId = it },
+                startTimeText = startTimeText,
+                onStartTimeChange = { startTimeText = it },
+                stopTimeText = stopTimeText,
+                onStopTimeChange = { stopTimeText = it },
+                error = error
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    val startTime = parseLocalTime(startTimeText)
+                    val stopTime = parseLocalTime(stopTimeText)
+                    if (startTime == null || stopTime == null) {
+                        error = "Use HH:mm time values"
+                    } else {
+                        onSave(text.trim(), labelId.ifBlank { null }, startTime, stopTime)
+                    }
+                },
+                enabled = text.isNotBlank()
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+@Composable
+private fun TemplateDialogFields(
+    text: String,
+    onTextChange: (String) -> Unit,
+    labels: List<LabelRecord>,
+    labelId: String,
+    onLabelSelected: (String) -> Unit,
+    startTimeText: String,
+    onStartTimeChange: (String) -> Unit,
+    stopTimeText: String,
+    onStopTimeChange: (String) -> Unit,
+    error: String?
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            label = { Text("Task") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        LabelDropdown(labels = labels, selectedLabelId = labelId, onLabelSelected = onLabelSelected)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = startTimeText,
+                onValueChange = onStartTimeChange,
+                label = { Text("Start") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+            OutlinedTextField(
+                value = stopTimeText,
+                onValueChange = onStopTimeChange,
+                label = { Text("Stop") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        error?.let {
+            Text(text = it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun ColorPicker(selectedColor: String, onSelect: (String) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        PRESET_LABEL_COLORS.forEach { color ->
+            Box(
+                modifier =
+                Modifier
+                    .size(32.dp)
+                    .background(color = parseHexColor(color), shape = CircleShape)
+                    .border(
+                        width = if (color == selectedColor) 2.dp else 0.dp,
+                        color = Color.Black,
+                        shape = CircleShape
+                    ).clip(CircleShape)
+                    .clickable { onSelect(color) }
+            )
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun LabelDropdown(labels: List<LabelRecord>, selectedLabelId: String, onLabelSelected: (String) -> Unit) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val selectedLabel = labels.firstOrNull { it.id == selectedLabelId }
+
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = selectedLabel?.name ?: "None",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Label") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .menuAnchor(androidx.compose.material3.ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text("None") },
+                onClick = {
+                    onLabelSelected("")
+                    expanded = false
+                }
+            )
+            labels.forEach { label ->
+                DropdownMenuItem(
+                    text = { Text(label.name) },
+                    onClick = {
+                        onLabelSelected(label.id)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+private fun parseHexColor(hex: String): Color = Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK)
+
+private fun parseLocalTime(value: String): LocalTime? = runCatching { LocalTime.parse(value.trim()) }.getOrNull()

--- a/android/app/src/main/java/com/worktime/android/feature/settings/LabelsTemplatesSettingsCards.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/LabelsTemplatesSettingsCards.kt
@@ -13,9 +13,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
@@ -390,7 +390,7 @@ private fun LabelDropdown(labels: List<LabelRecord>, selectedLabelId: String, on
                 .fillMaxWidth()
                 .menuAnchor(androidx.compose.material3.ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
         )
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(
                 text = { Text("None") },
                 onClick = {
@@ -411,6 +411,7 @@ private fun LabelDropdown(labels: List<LabelRecord>, selectedLabelId: String, on
     }
 }
 
-private fun parseHexColor(hex: String): Color = Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK)
+private fun parseHexColor(hex: String): Color =
+    runCatching { Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK) }.getOrDefault(Color.Gray)
 
 private fun parseLocalTime(value: String): LocalTime? = runCatching { LocalTime.parse(value.trim()) }.getOrNull()

--- a/android/app/src/main/java/com/worktime/android/feature/settings/LabelsTemplatesSettingsCards.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/LabelsTemplatesSettingsCards.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme

--- a/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
@@ -30,8 +30,10 @@ import com.worktime.android.core.config.AppConfig
 import com.worktime.android.core.storage.BiometricLockPreferences
 import com.worktime.android.core.storage.NotificationPreferences
 import com.worktime.android.feature.dashboard.DashboardUiState
+import com.worktime.android.feature.dashboard.MobileActionsUiState
 import com.worktime.android.ui.components.ScreenList
 import com.worktime.android.ui.components.SummaryCard
+import java.time.LocalTime
 
 private const val IDLE_TIMEOUT_OPTION_1_MIN = 1
 private const val IDLE_TIMEOUT_OPTION_5_MIN = 5
@@ -58,7 +60,15 @@ fun SettingsScreen(
     onLogout: () -> Unit,
     isDeletingAccount: Boolean = false,
     deleteAccountError: String? = null,
-    onDeleteAccount: () -> Unit = {}
+    onDeleteAccount: () -> Unit = {},
+    actionsState: MobileActionsUiState = MobileActionsUiState(),
+    onUpdateWorkLocationPreferences: (String?, String?) -> Unit = { _, _ -> },
+    onCreateLabel: (String, String) -> Unit = { _, _ -> },
+    onUpdateLabel: (String, String, String) -> Unit = { _, _, _ -> },
+    onDeleteLabel: (String) -> Unit = {},
+    onCreateTemplate: (String, String?, LocalTime, LocalTime) -> Unit = { _, _, _, _ -> },
+    onUpdateTemplate: (String, String, String?, LocalTime, LocalTime) -> Unit = { _, _, _, _, _ -> },
+    onDeleteTemplate: (String) -> Unit = {}
 ) {
     val uriHandler = LocalUriHandler.current
     var showDeleteAccountConfirm by rememberSaveable { mutableStateOf(false) }
@@ -92,6 +102,33 @@ fun SettingsScreen(
                     text("Admin", if (uiState.dashboard.identity.isAdmin) "Yes" else "No")
                 }
             }
+        }
+        item {
+            WorkLocationPreferencesCard(
+                homeCountry = actionsState.workLocationPreferences.homeCountry.orEmpty(),
+                officeCountry = actionsState.workLocationPreferences.officeCountry.orEmpty(),
+                isSubmitting = actionsState.isSubmitting,
+                onSave = onUpdateWorkLocationPreferences
+            )
+        }
+        item {
+            LabelManagementCard(
+                labels = actionsState.labels,
+                isSubmitting = actionsState.isSubmitting,
+                onCreateLabel = onCreateLabel,
+                onUpdateLabel = onUpdateLabel,
+                onDeleteLabel = onDeleteLabel
+            )
+        }
+        item {
+            TemplateManagementCard(
+                labels = actionsState.labels,
+                templates = actionsState.templates,
+                isSubmitting = actionsState.isSubmitting,
+                onCreateTemplate = onCreateTemplate,
+                onUpdateTemplate = onUpdateTemplate,
+                onDeleteTemplate = onDeleteTemplate
+            )
         }
         item {
             SummaryCard(title = "Notifications") {
@@ -233,6 +270,48 @@ fun SettingsScreen(
 private const val PRIVACY_POLICY_URL = "https://worktime.tjor.im/privacy"
 
 @Composable
+private fun WorkLocationPreferencesCard(
+    homeCountry: String,
+    officeCountry: String,
+    isSubmitting: Boolean,
+    onSave: (String?, String?) -> Unit
+) {
+    var home by rememberSaveable(homeCountry) { mutableStateOf(homeCountry) }
+    var office by rememberSaveable(officeCountry) { mutableStateOf(officeCountry) }
+
+    SummaryCard(title = "Work location defaults") {
+        content {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = home,
+                        onValueChange = { home = it.take(2).uppercase() },
+                        label = { Text("Home") },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f)
+                    )
+                    OutlinedTextField(
+                        value = office,
+                        onValueChange = { office = it.take(2).uppercase() },
+                        label = { Text("Office") },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                Button(
+                    onClick = { onSave(home.ifBlank { null }, office.ifBlank { null }) },
+                    enabled = !isSubmitting && home.isValidCountryField() && office.isValidCountryField()
+                ) {
+                    Text("Save defaults")
+                }
+            }
+        }
+    }
+}
+
+private fun String.isValidCountryField(): Boolean = isBlank() || length == 2
+
+@Composable
 @OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 private fun IdleTimeoutDropdown(selectedMinutes: Int, onSelected: (Int) -> Unit) {
     var expanded by rememberSaveable { mutableStateOf(false) }
@@ -245,7 +324,7 @@ private fun IdleTimeoutDropdown(selectedMinutes: Int, onSelected: (Int) -> Unit)
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(androidx.compose.material3.MenuAnchorType.PrimaryNotEditable, true)
+                .menuAnchor(androidx.compose.material3.ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             IDLE_TIMEOUT_OPTIONS_MINUTES.forEach { minutes ->

--- a/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
@@ -326,7 +326,7 @@ private fun IdleTimeoutDropdown(selectedMinutes: Int, onSelected: (Int) -> Unit)
                 .fillMaxWidth()
                 .menuAnchor(androidx.compose.material3.ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
         )
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             IDLE_TIMEOUT_OPTIONS_MINUTES.forEach { minutes ->
                 DropdownMenuItem(
                     text = { Text("$minutes min") },

--- a/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/settings/SettingsScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -79,34 +78,33 @@ private val ENTRY_FLAG_OPTIONS =
         "can_fly" to "Can fly"
     )
 
-@Composable
-fun TimeOffEntryFormDialog(
-    existingEntry: TimeOffEntryRecord?,
-    isSubmitting: Boolean,
-    message: String?,
-    onDismiss: () -> Unit,
-    onSubmit: (TimeOffDraft) -> Unit
-) {
+/** Compose state holder for the form fields; created fresh per [existingEntry] so switching between entries resets it. */
+private class TimeOffFormFieldsState(existingEntry: TimeOffEntryRecord?) {
     var entryKind by
-        rememberSaveable {
-            mutableStateOf(
-                when (existingEntry?.entryKind) {
-                    "range" -> EntryKindOption.DATE_RANGE
-                    "weekly" -> EntryKindOption.WEEKLY
-                    else -> EntryKindOption.SINGLE_DATE
-                }
-            )
-        }
-    var singleDate by rememberSaveable { mutableStateOf(existingEntry?.date?.let(LocalDate::parse)) }
-    var rangeStart by rememberSaveable { mutableStateOf(existingEntry?.startDate?.let(LocalDate::parse)) }
-    var rangeEnd by rememberSaveable { mutableStateOf(existingEntry?.endDate?.let(LocalDate::parse)) }
-    var weekday by rememberSaveable { mutableStateOf(existingEntry?.weekday ?: WEEKDAY_MONDAY) }
-    var entryType by rememberSaveable { mutableStateOf(existingEntry?.entryType ?: ENTRY_TYPE_OPTIONS.first().first) }
-    var entryFlag by rememberSaveable { mutableStateOf(existingEntry?.entryFlag ?: ENTRY_FLAG_OPTIONS.first().first) }
-    var note by rememberSaveable { mutableStateOf(existingEntry?.note ?: "") }
+        mutableStateOf(
+            when (existingEntry?.entryKind) {
+                "range" -> EntryKindOption.DATE_RANGE
+                "weekly" -> EntryKindOption.WEEKLY
+                else -> EntryKindOption.SINGLE_DATE
+            }
+        )
+    var singleDate by mutableStateOf(existingEntry?.date?.let(LocalDate::parse))
+    var rangeStart by mutableStateOf(existingEntry?.startDate?.let(LocalDate::parse))
+    var rangeEnd by mutableStateOf(existingEntry?.endDate?.let(LocalDate::parse))
+    var weekday by mutableStateOf(existingEntry?.weekday ?: WEEKDAY_MONDAY)
+    var entryType by mutableStateOf(existingEntry?.entryType ?: ENTRY_TYPE_OPTIONS.first().first)
+    var entryFlag by mutableStateOf(existingEntry?.entryFlag ?: ENTRY_FLAG_OPTIONS.first().first)
+    var note by mutableStateOf(existingEntry?.note ?: "")
 
-    val draft =
-        when (entryKind) {
+    val rangeIsInvalid: Boolean
+        get() {
+            val start = rangeStart
+            val end = rangeEnd
+            return entryKind == EntryKindOption.DATE_RANGE && start != null && end != null && end <= start
+        }
+
+    val draft: TimeOffDraft?
+        get() = when (entryKind) {
             EntryKindOption.SINGLE_DATE ->
                 singleDate?.let { TimeOffDraft.SingleDate(it, entryType, entryFlag, note.ifBlank { null }) }
             EntryKindOption.DATE_RANGE -> {
@@ -120,52 +118,23 @@ fun TimeOffEntryFormDialog(
             }
             EntryKindOption.WEEKLY -> TimeOffDraft.Weekly(weekday, entryType, entryFlag, note.ifBlank { null })
         }
+}
+
+@Composable
+fun TimeOffEntryFormDialog(
+    existingEntry: TimeOffEntryRecord?,
+    isSubmitting: Boolean,
+    message: String?,
+    onDismiss: () -> Unit,
+    onSubmit: (TimeOffDraft) -> Unit
+) {
+    val formState = remember(existingEntry) { TimeOffFormFieldsState(existingEntry) }
+    val draft = formState.draft
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(if (existingEntry == null) "Add time off" else "Edit time off") },
-        text = {
-            Column(
-                modifier = Modifier.verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                EntryKindSelector(selected = entryKind, onSelect = { entryKind = it })
-                when (entryKind) {
-                    EntryKindOption.SINGLE_DATE ->
-                        DatePickerField(label = "Date", date = singleDate, onDateSelected = { singleDate = it })
-                    EntryKindOption.DATE_RANGE -> {
-                        DatePickerField(label = "Start date", date = rangeStart, onDateSelected = { rangeStart = it })
-                        DatePickerField(label = "End date", date = rangeEnd, onDateSelected = { rangeEnd = it })
-                    }
-                    EntryKindOption.WEEKLY ->
-                        LabeledDropdown(
-                            label = "Weekday",
-                            options = WEEKDAY_OPTIONS,
-                            selected = weekday,
-                            onSelect = { weekday = it }
-                        )
-                }
-                LabeledDropdown(
-                    label = "Type",
-                    options = ENTRY_TYPE_OPTIONS,
-                    selected = entryType,
-                    onSelect = { entryType = it }
-                )
-                LabeledDropdown(
-                    label = "Flag",
-                    options = ENTRY_FLAG_OPTIONS,
-                    selected = entryFlag,
-                    onSelect = { entryFlag = it }
-                )
-                OutlinedTextField(
-                    value = note,
-                    onValueChange = { note = it },
-                    label = { Text("Note (optional)") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                message?.takeIf { it.isNotBlank() }?.let { Text(text = it) }
-            }
-        },
+        text = { TimeOffFormFields(formState = formState, message = message) },
         confirmButton = {
             Button(
                 onClick = { draft?.let(onSubmit) },
@@ -180,6 +149,66 @@ fun TimeOffEntryFormDialog(
             }
         }
     )
+}
+
+@Composable
+private fun TimeOffFormFields(formState: TimeOffFormFieldsState, message: String?) {
+    Column(
+        modifier = Modifier.verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        EntryKindSelector(selected = formState.entryKind, onSelect = { formState.entryKind = it })
+        TimeOffKindFields(formState)
+        LabeledDropdown(
+            label = "Type",
+            options = ENTRY_TYPE_OPTIONS,
+            selected = formState.entryType,
+            onSelect = { formState.entryType = it }
+        )
+        LabeledDropdown(
+            label = "Flag",
+            options = ENTRY_FLAG_OPTIONS,
+            selected = formState.entryFlag,
+            onSelect = { formState.entryFlag = it }
+        )
+        OutlinedTextField(
+            value = formState.note,
+            onValueChange = { formState.note = it },
+            label = { Text("Note (optional)") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        message?.takeIf { it.isNotBlank() }?.let { Text(text = it) }
+    }
+}
+
+@Composable
+private fun TimeOffKindFields(formState: TimeOffFormFieldsState) {
+    when (formState.entryKind) {
+        EntryKindOption.SINGLE_DATE ->
+            DatePickerField(
+                label = "Date",
+                date = formState.singleDate,
+                onDateSelected = { formState.singleDate = it }
+            )
+        EntryKindOption.DATE_RANGE -> {
+            DatePickerField(
+                label = "Start date",
+                date = formState.rangeStart,
+                onDateSelected = { formState.rangeStart = it }
+            )
+            DatePickerField(label = "End date", date = formState.rangeEnd, onDateSelected = { formState.rangeEnd = it })
+            if (formState.rangeIsInvalid) {
+                Text("End date must be after start date. Use \"Single day\" for a one-day entry.")
+            }
+        }
+        EntryKindOption.WEEKLY ->
+            LabeledDropdown(
+                label = "Weekday",
+                options = WEEKDAY_OPTIONS,
+                selected = formState.weekday,
+                onSelect = { formState.weekday = it }
+            )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
@@ -10,9 +10,9 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -100,7 +100,7 @@ private class TimeOffFormFieldsState(existingEntry: TimeOffEntryRecord?) {
         get() {
             val start = rangeStart
             val end = rangeEnd
-            return entryKind == EntryKindOption.DATE_RANGE && start != null && end != null && end <= start
+            return entryKind == EntryKindOption.DATE_RANGE && start != null && end != null && end < start
         }
 
     val draft: TimeOffDraft?
@@ -110,7 +110,7 @@ private class TimeOffFormFieldsState(existingEntry: TimeOffEntryRecord?) {
             EntryKindOption.DATE_RANGE -> {
                 val start = rangeStart
                 val end = rangeEnd
-                if (start != null && end != null && end > start) {
+                if (start != null && end != null && end >= start) {
                     TimeOffDraft.DateRange(start, end, entryType, entryFlag, note.ifBlank { null })
                 } else {
                     null
@@ -128,7 +128,7 @@ fun TimeOffEntryFormDialog(
     onDismiss: () -> Unit,
     onSubmit: (TimeOffDraft) -> Unit
 ) {
-    val formState = remember(existingEntry) { TimeOffFormFieldsState(existingEntry) }
+    val formState = remember(existingEntry?.entryId) { TimeOffFormFieldsState(existingEntry) }
     val draft = formState.draft
 
     AlertDialog(
@@ -198,7 +198,7 @@ private fun TimeOffKindFields(formState: TimeOffFormFieldsState) {
             )
             DatePickerField(label = "End date", date = formState.rangeEnd, onDateSelected = { formState.rangeEnd = it })
             if (formState.rangeIsInvalid) {
-                Text("End date must be after start date. Use \"Single day\" for a one-day entry.")
+                Text("End date must be on or after start date.")
             }
         }
         EntryKindOption.WEEKLY ->
@@ -242,7 +242,7 @@ private fun <T> LabeledDropdown(label: String, options: List<Pair<T, String>>, s
             modifier =
             Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable, true)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             options.forEach { (value, text) ->

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -244,7 +244,7 @@ private fun <T> LabeledDropdown(label: String, options: List<Pair<T, String>>, s
                 .fillMaxWidth()
                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
         )
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             options.forEach { (value, text) ->
                 DropdownMenuItem(
                     text = { Text(text) },

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
@@ -1,0 +1,230 @@
+package com.worktime.android.feature.timeoff
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.worktime.android.data.model.TimeOffEntryRecord
+import com.worktime.android.data.repository.TimeOffDraft
+import com.worktime.android.ui.components.DatePickerField
+import java.time.LocalDate
+
+private enum class EntryKindOption(val label: String) {
+    SINGLE_DATE("Single day"),
+    DATE_RANGE("Date range"),
+    WEEKLY("Weekly")
+}
+
+private const val WEEKDAY_MONDAY = 1
+private const val WEEKDAY_TUESDAY = 2
+private const val WEEKDAY_WEDNESDAY = 3
+private const val WEEKDAY_THURSDAY = 4
+private const val WEEKDAY_FRIDAY = 5
+private const val WEEKDAY_SATURDAY = 6
+private const val WEEKDAY_SUNDAY = 7
+
+private val WEEKDAY_OPTIONS =
+    listOf(
+        WEEKDAY_MONDAY to "Monday",
+        WEEKDAY_TUESDAY to "Tuesday",
+        WEEKDAY_WEDNESDAY to "Wednesday",
+        WEEKDAY_THURSDAY to "Thursday",
+        WEEKDAY_FRIDAY to "Friday",
+        WEEKDAY_SATURDAY to "Saturday",
+        WEEKDAY_SUNDAY to "Sunday"
+    )
+
+private val ENTRY_TYPE_OPTIONS =
+    listOf(
+        "vacation" to "Vacation",
+        "business" to "Business trip",
+        "course" to "Course",
+        "in" to "In lieu",
+        "weekend" to "Weekend",
+        "birthday" to "Birthday",
+        "ill" to "Sick",
+        "other" to "Other"
+    )
+
+private val ENTRY_FLAG_OPTIONS =
+    listOf(
+        "full_day" to "Full day",
+        "half_am" to "Half day (morning)",
+        "half_pm" to "Half day (afternoon)",
+        "onsite" to "Onsite",
+        "no_fly" to "No fly",
+        "can_fly" to "Can fly"
+    )
+
+@Composable
+fun TimeOffEntryFormDialog(
+    existingEntry: TimeOffEntryRecord?,
+    isSubmitting: Boolean,
+    message: String?,
+    onDismiss: () -> Unit,
+    onSubmit: (TimeOffDraft) -> Unit
+) {
+    var entryKind by
+        rememberSaveable {
+            mutableStateOf(
+                when (existingEntry?.entryKind) {
+                    "range" -> EntryKindOption.DATE_RANGE
+                    "weekly" -> EntryKindOption.WEEKLY
+                    else -> EntryKindOption.SINGLE_DATE
+                }
+            )
+        }
+    var singleDate by rememberSaveable { mutableStateOf(existingEntry?.date?.let(LocalDate::parse)) }
+    var rangeStart by rememberSaveable { mutableStateOf(existingEntry?.startDate?.let(LocalDate::parse)) }
+    var rangeEnd by rememberSaveable { mutableStateOf(existingEntry?.endDate?.let(LocalDate::parse)) }
+    var weekday by rememberSaveable { mutableStateOf(existingEntry?.weekday ?: WEEKDAY_MONDAY) }
+    var entryType by rememberSaveable { mutableStateOf(existingEntry?.entryType ?: ENTRY_TYPE_OPTIONS.first().first) }
+    var entryFlag by rememberSaveable { mutableStateOf(existingEntry?.entryFlag ?: ENTRY_FLAG_OPTIONS.first().first) }
+    var note by rememberSaveable { mutableStateOf(existingEntry?.note ?: "") }
+
+    val draft =
+        when (entryKind) {
+            EntryKindOption.SINGLE_DATE ->
+                singleDate?.let { TimeOffDraft.SingleDate(it, entryType, entryFlag, note.ifBlank { null }) }
+            EntryKindOption.DATE_RANGE -> {
+                val start = rangeStart
+                val end = rangeEnd
+                if (start != null && end != null && end > start) {
+                    TimeOffDraft.DateRange(start, end, entryType, entryFlag, note.ifBlank { null })
+                } else {
+                    null
+                }
+            }
+            EntryKindOption.WEEKLY -> TimeOffDraft.Weekly(weekday, entryType, entryFlag, note.ifBlank { null })
+        }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (existingEntry == null) "Add time off" else "Edit time off") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                EntryKindSelector(selected = entryKind, onSelect = { entryKind = it })
+                when (entryKind) {
+                    EntryKindOption.SINGLE_DATE ->
+                        DatePickerField(label = "Date", date = singleDate, onDateSelected = { singleDate = it })
+                    EntryKindOption.DATE_RANGE -> {
+                        DatePickerField(label = "Start date", date = rangeStart, onDateSelected = { rangeStart = it })
+                        DatePickerField(label = "End date", date = rangeEnd, onDateSelected = { rangeEnd = it })
+                    }
+                    EntryKindOption.WEEKLY ->
+                        LabeledDropdown(
+                            label = "Weekday",
+                            options = WEEKDAY_OPTIONS,
+                            selected = weekday,
+                            onSelect = { weekday = it }
+                        )
+                }
+                LabeledDropdown(
+                    label = "Type",
+                    options = ENTRY_TYPE_OPTIONS,
+                    selected = entryType,
+                    onSelect = { entryType = it }
+                )
+                LabeledDropdown(
+                    label = "Flag",
+                    options = ENTRY_FLAG_OPTIONS,
+                    selected = entryFlag,
+                    onSelect = { entryFlag = it }
+                )
+                OutlinedTextField(
+                    value = note,
+                    onValueChange = { note = it },
+                    label = { Text("Note (optional)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                message?.takeIf { it.isNotBlank() }?.let { Text(text = it) }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { draft?.let(onSubmit) },
+                enabled = !isSubmitting && draft != null
+            ) {
+                Text(if (existingEntry == null) "Add" else "Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isSubmitting) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EntryKindSelector(selected: EntryKindOption, onSelect: (EntryKindOption) -> Unit) {
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        EntryKindOption.entries.forEachIndexed { index, option ->
+            SegmentedButton(
+                selected = selected == option,
+                onClick = { onSelect(option) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = EntryKindOption.entries.size)
+            ) {
+                Text(option.label)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun <T> LabeledDropdown(label: String, options: List<Pair<T, String>>, selected: T, onSelect: (T) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedLabel = options.firstOrNull { it.first == selected }?.second ?: ""
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = selectedLabel,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, true)
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { (value, text) ->
+                DropdownMenuItem(
+                    text = { Text(text) },
+                    onClick = {
+                        onSelect(value)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffEntryFormDialog.kt
@@ -78,7 +78,7 @@ private val ENTRY_FLAG_OPTIONS =
         "can_fly" to "Can fly"
     )
 
-/** Compose state holder for the form fields; created fresh per [existingEntry] so switching between entries resets it. */
+/** Form fields state, created fresh per [existingEntry] so switching between entries resets it. */
 private class TimeOffFormFieldsState(existingEntry: TimeOffEntryRecord?) {
     var entryKind by
         mutableStateOf(

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffSummaryScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffSummaryScreen.kt
@@ -159,7 +159,11 @@ private fun TimeOffEntryCard(entry: TimeOffEntryRecord, onEdit: () -> Unit, onDe
 }
 
 private fun TimeOffEntryRecord.datesLabel(): String = when (entryKind) {
-    "range" -> "${startDate?.let(::formatDate) ?: "—"} → ${endDate?.let(::formatDate) ?: "—"}"
+    "range" -> {
+        val start = startDate?.let(::formatDate) ?: "—"
+        val end = endDate?.let(::formatDate) ?: "—"
+        "$start → $end"
+    }
     "weekly" -> "Every ${weekday?.let { WEEKDAY_NAMES[it] } ?: "week"}"
     else -> date?.let(::formatDate) ?: "—"
 }

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffSummaryScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffSummaryScreen.kt
@@ -1,46 +1,153 @@
 package com.worktime.android.feature.timeoff
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import com.worktime.android.feature.dashboard.DashboardUiState
-import com.worktime.android.ui.components.ReadModelScreen
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.worktime.android.data.model.TimeOffEntryRecord
+import com.worktime.android.data.repository.TimeOffDraft
+import com.worktime.android.ui.components.EmptyPane
 import com.worktime.android.ui.components.ScreenList
 import com.worktime.android.ui.components.SummaryCard
+import com.worktime.android.ui.components.formatDate
 
 @Composable
-fun TimeOffSummaryScreen(uiState: DashboardUiState, onRetry: () -> Unit) {
-    ReadModelScreen(title = "Time off", uiState = uiState, onRetry = onRetry) { dashboard ->
-        ScreenList(title = "Time off") {
-            item {
-                SummaryCard(title = "Summary") {
-                    text("Upcoming entries", dashboard.timeOffSummary.totalUpcoming.toString())
-                    text(
-                        "Active now",
-                        dashboard.timeOffSummary.activeItems.size
-                            .toString()
-                    )
-                    text(
-                        "Feature flag",
-                        if (dashboard.workContext.featureFlags.timeOffEnabled) "Enabled" else "Disabled"
-                    )
-                }
-            }
-            dashboard.timeOffSummary.activeItems.forEach { activeItem ->
+fun TimeOffSummaryScreen(
+    uiState: TimeOffUiState,
+    formState: TimeOffFormState,
+    onRetry: () -> Unit,
+    onAdd: () -> Unit,
+    onEdit: (String) -> Unit,
+    onDismissForm: () -> Unit,
+    onSubmit: (TimeOffDraft) -> Unit,
+    onDelete: (String) -> Unit
+) {
+    var pendingDeleteId by remember { mutableStateOf<String?>(null) }
+
+    when (uiState) {
+        TimeOffUiState.Loading ->
+            EmptyPane(
+                title = "Time off",
+                headline = "Loading",
+                body = "Fetching your time-off entries…"
+            )
+        TimeOffUiState.LoggedOut ->
+            EmptyPane(
+                title = "Time off",
+                headline = "Sign in required",
+                body = "Authenticate to manage your time off."
+            )
+        is TimeOffUiState.Error ->
+            EmptyPane(
+                title = "Time off",
+                headline = "Unable to load time off",
+                body = uiState.message,
+                actionLabel = "Retry",
+                onAction = onRetry
+            )
+        is TimeOffUiState.Success ->
+            ScreenList(title = "Time off") {
                 item {
-                    SummaryCard(title = "Active • ${activeItem.entryType}") {
-                        text("Dates", "${activeItem.startsOn} → ${activeItem.endsOn}")
-                        text("Note", activeItem.note ?: "—")
+                    Button(onClick = onAdd) {
+                        Text("Add time off")
+                    }
+                }
+                if (uiState.entries.isEmpty()) {
+                    item {
+                        SummaryCard(title = "No entries yet") {
+                            text("Entries", "0")
+                        }
+                    }
+                }
+                uiState.entries.forEach { entry ->
+                    item {
+                        TimeOffEntryCard(
+                            entry = entry,
+                            onEdit = { onEdit(entry.entryId) },
+                            onDelete = { pendingDeleteId = entry.entryId }
+                        )
                     }
                 }
             }
-            dashboard.timeOffSummary.upcomingItems.forEach { upcomingItem ->
-                item {
-                    SummaryCard(title = "Upcoming • ${upcomingItem.entryType}") {
-                        text("Dates", "${upcomingItem.startsOn} → ${upcomingItem.endsOn}")
-                        text("Recurring", if (upcomingItem.isRecurringWeekly) "Weekly" else "No")
-                        text("Note", upcomingItem.note ?: "—")
-                    }
+    }
+
+    if (formState.target != null) {
+        val existingEntry =
+            (uiState as? TimeOffUiState.Success)?.entries?.firstOrNull { entry ->
+                (formState.target as? TimeOffFormTarget.Edit)?.entryId == entry.entryId
+            }
+        TimeOffEntryFormDialog(
+            existingEntry = existingEntry,
+            isSubmitting = formState.isSubmitting,
+            message = formState.message,
+            onDismiss = onDismissForm,
+            onSubmit = onSubmit
+        )
+    }
+
+    pendingDeleteId?.let { entryId ->
+        AlertDialog(
+            onDismissRequest = { pendingDeleteId = null },
+            title = { Text("Delete time off entry?") },
+            text = { Text("This cannot be undone.") },
+            confirmButton = {
+                Button(onClick = {
+                    onDelete(entryId)
+                    pendingDeleteId = null
+                }) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDeleteId = null }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun TimeOffEntryCard(entry: TimeOffEntryRecord, onEdit: () -> Unit, onDelete: () -> Unit) {
+    SummaryCard(title = entry.entryType.replaceFirstChar { it.uppercase() }) {
+        text("Dates", entry.datesLabel())
+        text("Flag", entry.entryFlag.replace('_', ' '))
+        entry.note?.takeIf { it.isNotBlank() }?.let { text("Note", it) }
+        content {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onEdit) {
+                    Text("Edit")
+                }
+                TextButton(onClick = onDelete) {
+                    Text("Delete")
                 }
             }
         }
     }
 }
+
+private fun TimeOffEntryRecord.datesLabel(): String = when (entryKind) {
+    "range" -> "${startDate?.let(::formatDate)} → ${endDate?.let(::formatDate)}"
+    "weekly" -> "Every ${weekday?.let { WEEKDAY_NAMES[it] } ?: "week"}"
+    else -> date?.let(::formatDate) ?: "—"
+}
+
+private val WEEKDAY_NAMES =
+    mapOf(
+        1 to "Monday",
+        2 to "Tuesday",
+        3 to "Wednesday",
+        4 to "Thursday",
+        5 to "Friday",
+        6 to "Saturday",
+        7 to "Sunday"
+    )

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffSummaryScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffSummaryScreen.kt
@@ -55,29 +55,12 @@ fun TimeOffSummaryScreen(
                 onAction = onRetry
             )
         is TimeOffUiState.Success ->
-            ScreenList(title = "Time off") {
-                item {
-                    Button(onClick = onAdd) {
-                        Text("Add time off")
-                    }
-                }
-                if (uiState.entries.isEmpty()) {
-                    item {
-                        SummaryCard(title = "No entries yet") {
-                            text("Entries", "0")
-                        }
-                    }
-                }
-                uiState.entries.forEach { entry ->
-                    item {
-                        TimeOffEntryCard(
-                            entry = entry,
-                            onEdit = { onEdit(entry.entryId) },
-                            onDelete = { pendingDeleteId = entry.entryId }
-                        )
-                    }
-                }
-            }
+            TimeOffEntryList(
+                entries = uiState.entries,
+                onAdd = onAdd,
+                onEdit = onEdit,
+                onDeleteRequested = { pendingDeleteId = it }
+            )
     }
 
     if (formState.target != null) {
@@ -95,25 +78,65 @@ fun TimeOffSummaryScreen(
     }
 
     pendingDeleteId?.let { entryId ->
-        AlertDialog(
-            onDismissRequest = { pendingDeleteId = null },
-            title = { Text("Delete time off entry?") },
-            text = { Text("This cannot be undone.") },
-            confirmButton = {
-                Button(onClick = {
-                    onDelete(entryId)
-                    pendingDeleteId = null
-                }) {
-                    Text("Delete")
-                }
+        DeleteConfirmationDialog(
+            onConfirm = {
+                onDelete(entryId)
+                pendingDeleteId = null
             },
-            dismissButton = {
-                TextButton(onClick = { pendingDeleteId = null }) {
-                    Text("Cancel")
-                }
-            }
+            onDismiss = { pendingDeleteId = null }
         )
     }
+}
+
+@Composable
+private fun TimeOffEntryList(
+    entries: List<TimeOffEntryRecord>,
+    onAdd: () -> Unit,
+    onEdit: (String) -> Unit,
+    onDeleteRequested: (String) -> Unit
+) {
+    ScreenList(title = "Time off") {
+        item {
+            Button(onClick = onAdd) {
+                Text("Add time off")
+            }
+        }
+        if (entries.isEmpty()) {
+            item {
+                SummaryCard(title = "No entries yet") {
+                    text("Entries", "0")
+                }
+            }
+        }
+        entries.forEach { entry ->
+            item {
+                TimeOffEntryCard(
+                    entry = entry,
+                    onEdit = { onEdit(entry.entryId) },
+                    onDelete = { onDeleteRequested(entry.entryId) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeleteConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Delete time off entry?") },
+        text = { Text("This cannot be undone.") },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text("Delete")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }
 
 @Composable
@@ -136,7 +159,7 @@ private fun TimeOffEntryCard(entry: TimeOffEntryRecord, onEdit: () -> Unit, onDe
 }
 
 private fun TimeOffEntryRecord.datesLabel(): String = when (entryKind) {
-    "range" -> "${startDate?.let(::formatDate)} → ${endDate?.let(::formatDate)}"
+    "range" -> "${startDate?.let(::formatDate) ?: "—"} → ${endDate?.let(::formatDate) ?: "—"}"
     "weekly" -> "Every ${weekday?.let { WEEKDAY_NAMES[it] } ?: "week"}"
     else -> date?.let(::formatDate) ?: "—"
 }

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffViewModel.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffViewModel.kt
@@ -1,0 +1,124 @@
+package com.worktime.android.feature.timeoff
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.worktime.android.data.model.TimeOffEntryRecord
+import com.worktime.android.data.repository.DashboardRepository
+import com.worktime.android.data.repository.MutationResult
+import com.worktime.android.data.repository.TimeOffDraft
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed interface TimeOffUiState {
+    data object Loading : TimeOffUiState
+
+    data object LoggedOut : TimeOffUiState
+
+    data class Error(val message: String) : TimeOffUiState
+
+    data class Success(val entries: List<TimeOffEntryRecord>) : TimeOffUiState
+}
+
+/** Which form, if any, is currently presented over the time-off list. */
+sealed interface TimeOffFormTarget {
+    data object Create : TimeOffFormTarget
+
+    data class Edit(val entryId: String) : TimeOffFormTarget
+}
+
+data class TimeOffFormState(
+    val target: TimeOffFormTarget? = null,
+    val isSubmitting: Boolean = false,
+    val message: String? = null
+)
+
+class TimeOffViewModel(private val repository: DashboardRepository) : ViewModel() {
+    private val _uiState = MutableStateFlow<TimeOffUiState>(TimeOffUiState.Loading)
+    val uiState: StateFlow<TimeOffUiState> = _uiState.asStateFlow()
+    private val _formState = MutableStateFlow(TimeOffFormState())
+    val formState: StateFlow<TimeOffFormState> = _formState.asStateFlow()
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob =
+            viewModelScope.launch {
+                _uiState.value = TimeOffUiState.Loading
+                _uiState.value =
+                    when (val result = repository.listTimeOffEntries()) {
+                        is MutationResult.Success -> TimeOffUiState.Success(result.value)
+                        MutationResult.LoggedOut -> TimeOffUiState.LoggedOut
+                        is MutationResult.ValidationError -> TimeOffUiState.Error(result.message)
+                        is MutationResult.Error -> TimeOffUiState.Error(result.message)
+                    }
+            }
+    }
+
+    fun openCreateForm() {
+        _formState.value = TimeOffFormState(target = TimeOffFormTarget.Create)
+    }
+
+    fun openEditForm(entryId: String) {
+        _formState.value = TimeOffFormState(target = TimeOffFormTarget.Edit(entryId))
+    }
+
+    fun closeForm() {
+        _formState.value = TimeOffFormState()
+    }
+
+    fun submit(draft: TimeOffDraft) {
+        val target = _formState.value.target ?: return
+        viewModelScope.launch {
+            _formState.value = _formState.value.copy(isSubmitting = true, message = null)
+            val result =
+                when (target) {
+                    TimeOffFormTarget.Create -> repository.createTimeOffEntry(draft)
+                    is TimeOffFormTarget.Edit -> repository.updateTimeOffEntry(target.entryId, draft)
+                }
+            applyMutationOutcome(result)
+        }
+    }
+
+    fun delete(entryId: String) {
+        viewModelScope.launch {
+            _formState.value = _formState.value.copy(isSubmitting = true, message = null)
+            applyMutationOutcome(repository.deleteTimeOffEntry(entryId))
+        }
+    }
+
+    private fun applyMutationOutcome(result: MutationResult<*>) {
+        _formState.value =
+            when (result) {
+                is MutationResult.Success -> {
+                    refresh()
+                    TimeOffFormState()
+                }
+                MutationResult.LoggedOut -> {
+                    _uiState.value = TimeOffUiState.LoggedOut
+                    _formState.value.copy(isSubmitting = false, message = "Session expired. Sign in again.")
+                }
+                is MutationResult.ValidationError ->
+                    _formState.value.copy(isSubmitting = false, message = result.message)
+                is MutationResult.Error ->
+                    _formState.value.copy(isSubmitting = false, message = result.message)
+            }
+    }
+
+    companion object {
+        fun factory(repository: DashboardRepository): ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                TimeOffViewModel(repository = repository)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffViewModel.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 sealed interface TimeOffUiState {
@@ -86,7 +87,7 @@ class TimeOffViewModel(private val repository: DashboardRepository) : ViewModel(
                     TimeOffFormTarget.Create -> repository.createTimeOffEntry(draft)
                     is TimeOffFormTarget.Edit -> repository.updateTimeOffEntry(target.entryId, draft)
                 }
-            applyMutationOutcome(result)
+            applyUpsertOutcome(result)
         }
     }
 
@@ -94,15 +95,15 @@ class TimeOffViewModel(private val repository: DashboardRepository) : ViewModel(
         if (_formState.value.isSubmitting) return
         viewModelScope.launch {
             _formState.value = _formState.value.copy(isSubmitting = true, message = null)
-            applyMutationOutcome(repository.deleteTimeOffEntry(entryId))
+            applyDeleteOutcome(entryId, repository.deleteTimeOffEntry(entryId))
         }
     }
 
-    private fun applyMutationOutcome(result: MutationResult<*>) {
+    private fun applyUpsertOutcome(result: MutationResult<TimeOffEntryRecord>) {
         _formState.value =
             when (result) {
                 is MutationResult.Success -> {
-                    refresh()
+                    upsertEntry(result.value)
                     TimeOffFormState()
                 }
                 MutationResult.LoggedOut -> {
@@ -115,6 +116,50 @@ class TimeOffViewModel(private val repository: DashboardRepository) : ViewModel(
                     _formState.value.copy(isSubmitting = false, message = result.message)
             }
     }
+
+    private fun applyDeleteOutcome(entryId: String, result: MutationResult<Unit>) {
+        _formState.value =
+            when (result) {
+                is MutationResult.Success -> {
+                    removeEntry(entryId)
+                    TimeOffFormState()
+                }
+                MutationResult.LoggedOut -> {
+                    _uiState.value = TimeOffUiState.LoggedOut
+                    _formState.value.copy(isSubmitting = false, message = "Session expired. Sign in again.")
+                }
+                is MutationResult.ValidationError ->
+                    _formState.value.copy(isSubmitting = false, message = result.message)
+                is MutationResult.Error ->
+                    _formState.value.copy(isSubmitting = false, message = result.message)
+            }
+    }
+
+    private fun upsertEntry(entry: TimeOffEntryRecord) {
+        _uiState.update { current ->
+            if (current !is TimeOffUiState.Success) return@update current
+            val entries = current.entries.filterNot { it.entryId == entry.entryId } + entry
+            current.copy(
+                entries =
+                entries.sortedWith(
+                    compareBy<TimeOffEntryRecord> { sortDate(it) }.thenBy { it.entryId }
+                )
+            )
+        }
+    }
+
+    private fun removeEntry(entryId: String) {
+        _uiState.update { current ->
+            if (current is TimeOffUiState.Success) {
+                current.copy(entries = current.entries.filterNot { it.entryId == entryId })
+            } else {
+                current
+            }
+        }
+    }
+
+    private fun sortDate(entry: TimeOffEntryRecord): String =
+        entry.date ?: entry.startDate ?: entry.weekday?.toString()?.padStart(2, '0') ?: entry.entryId
 
     companion object {
         fun factory(repository: DashboardRepository): ViewModelProvider.Factory = viewModelFactory {

--- a/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffViewModel.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/timeoff/TimeOffViewModel.kt
@@ -77,6 +77,7 @@ class TimeOffViewModel(private val repository: DashboardRepository) : ViewModel(
     }
 
     fun submit(draft: TimeOffDraft) {
+        if (_formState.value.isSubmitting) return
         val target = _formState.value.target ?: return
         viewModelScope.launch {
             _formState.value = _formState.value.copy(isSubmitting = true, message = null)
@@ -90,6 +91,7 @@ class TimeOffViewModel(private val repository: DashboardRepository) : ViewModel(
     }
 
     fun delete(entryId: String) {
+        if (_formState.value.isSubmitting) return
         viewModelScope.launch {
             _formState.value = _formState.value.copy(isSubmitting = true, message = null)
             applyMutationOutcome(repository.deleteTimeOffEntry(entryId))

--- a/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
@@ -1,27 +1,70 @@
 package com.worktime.android.feature.today
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.worktime.android.data.model.LabelRecord
+import com.worktime.android.data.model.TemplateRecord
 import com.worktime.android.feature.dashboard.DashboardUiState
 import com.worktime.android.feature.dashboard.MobileActionsUiState
+import com.worktime.android.ui.components.DatePickerField
 import com.worktime.android.ui.components.ReadModelScreen
 import com.worktime.android.ui.components.ScreenList
 import com.worktime.android.ui.components.SummaryCard
 import com.worktime.android.ui.components.formatInstant
 import com.worktime.android.ui.components.formatShift
 import java.time.LocalDate
+
+private const val PRESET_COLOR_RED = "#F44336"
+private const val PRESET_COLOR_ORANGE = "#FF9800"
+private const val PRESET_COLOR_YELLOW = "#FBC02D"
+private const val PRESET_COLOR_GREEN = "#4CAF50"
+private const val PRESET_COLOR_TEAL = "#009688"
+private const val PRESET_COLOR_BLUE = "#2196F3"
+private const val PRESET_COLOR_PURPLE = "#9C27B0"
+private const val PRESET_COLOR_GREY = "#607D8B"
+
+private val PRESET_LABEL_COLORS =
+    listOf(
+        PRESET_COLOR_RED,
+        PRESET_COLOR_ORANGE,
+        PRESET_COLOR_YELLOW,
+        PRESET_COLOR_GREEN,
+        PRESET_COLOR_TEAL,
+        PRESET_COLOR_BLUE,
+        PRESET_COLOR_PURPLE,
+        PRESET_COLOR_GREY
+    )
 
 @Composable
 fun TodayScreen(
@@ -31,12 +74,15 @@ fun TodayScreen(
     onStartTracking: (String, String?) -> Unit,
     onStopTracking: (String) -> Unit,
     onUpdateTask: (String, String?, String?) -> Unit,
-    onSetWorkLocation: (LocalDate, String, String?) -> Unit
+    onSetWorkLocation: (LocalDate, String, String?) -> Unit,
+    onCreateLabel: (String, String) -> Unit
 ) {
     ReadModelScreen(title = "Today", uiState = uiState, onRetry = onRetry) { dashboard ->
         var taskText by remember(actionsState.runningTask) { mutableStateOf(actionsState.runningTask?.text ?: "") }
-        var taskLabel by remember(actionsState.runningTask) { mutableStateOf(actionsState.runningTask?.labelId ?: "") }
-        var workLocationDate by remember { mutableStateOf(LocalDate.now().toString()) }
+        var taskLabelId by remember(actionsState.runningTask) {
+            mutableStateOf(actionsState.runningTask?.labelId ?: "")
+        }
+        var workLocationDate by remember { mutableStateOf(LocalDate.now()) }
         var countryCode by remember { mutableStateOf("") }
         var workLocationLabel by remember { mutableStateOf("") }
 
@@ -74,6 +120,15 @@ fun TodayScreen(
                         modifier = Modifier.fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
+                        if (actionsState.templates.isNotEmpty()) {
+                            TemplateChipsRow(
+                                templates = actionsState.templates,
+                                onApply = { template ->
+                                    taskText = template.text
+                                    taskLabelId = template.labelId ?: ""
+                                }
+                            )
+                        }
                         OutlinedTextField(
                             value = taskText,
                             onValueChange = { taskText = it },
@@ -81,16 +136,15 @@ fun TodayScreen(
                             label = { Text("Task") },
                             singleLine = true
                         )
-                        OutlinedTextField(
-                            value = taskLabel,
-                            onValueChange = { taskLabel = it },
-                            modifier = Modifier.fillMaxWidth(),
-                            label = { Text("Label (optional)") },
-                            singleLine = true
+                        LabelPickerField(
+                            labels = actionsState.labels,
+                            selectedLabelId = taskLabelId,
+                            onLabelSelected = { taskLabelId = it },
+                            onCreateLabel = onCreateLabel
                         )
                         if (actionsState.runningTask == null) {
                             Button(
-                                onClick = { onStartTracking(taskText, taskLabel.ifBlank { null }) },
+                                onClick = { onStartTracking(taskText, taskLabelId.ifBlank { null }) },
                                 enabled = !actionsState.isSubmitting && taskText.isNotBlank()
                             ) {
                                 Text("Start timer")
@@ -101,7 +155,7 @@ fun TodayScreen(
                                     onUpdateTask(
                                         actionsState.runningTask.id,
                                         taskText,
-                                        taskLabel.ifBlank { null }
+                                        taskLabelId.ifBlank { null }
                                     )
                                 },
                                 enabled = !actionsState.isSubmitting && taskText.isNotBlank()
@@ -125,12 +179,10 @@ fun TodayScreen(
                         modifier = Modifier.fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        OutlinedTextField(
-                            value = workLocationDate,
-                            onValueChange = { workLocationDate = it },
-                            modifier = Modifier.fillMaxWidth(),
-                            label = { Text("Date (YYYY-MM-DD)") },
-                            singleLine = true
+                        DatePickerField(
+                            label = "Date",
+                            date = workLocationDate,
+                            onDateSelected = { workLocationDate = it }
                         )
                         OutlinedTextField(
                             value = countryCode,
@@ -148,9 +200,7 @@ fun TodayScreen(
                         )
                         Button(
                             onClick = {
-                                runCatching { LocalDate.parse(workLocationDate) }.getOrNull()?.let { parsedDate ->
-                                    onSetWorkLocation(parsedDate, countryCode, workLocationLabel.ifBlank { null })
-                                }
+                                onSetWorkLocation(workLocationDate, countryCode, workLocationLabel.ifBlank { null })
                             },
                             enabled = !actionsState.isSubmitting && countryCode.length >= 2
                         ) {
@@ -165,14 +215,137 @@ fun TodayScreen(
                     text("Server timestamp", actionsState.syncStatus?.serverTimestamp ?: "Unavailable")
                     text("Task updates", actionsState.syncStatus?.tasksUpdatedAt ?: "—")
                     text("Location updates", actionsState.syncStatus?.workLocationsUpdatedAt ?: "—")
-                    if (!actionsState.message.isNullOrBlank()) {
-                        Text(
-                            text = actionsState.message,
-                            modifier = Modifier.padding(top = 8.dp)
-                        )
+                    actionsState.message?.takeIf { it.isNotBlank() }?.let {
+                        Text(text = it, modifier = Modifier.padding(top = 8.dp))
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun TemplateChipsRow(templates: List<TemplateRecord>, onApply: (TemplateRecord) -> Unit) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        templates.forEach { template ->
+            AssistChip(onClick = { onApply(template) }, label = { Text(template.text) })
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LabelPickerField(
+    labels: List<LabelRecord>,
+    selectedLabelId: String,
+    onLabelSelected: (String) -> Unit,
+    onCreateLabel: (String, String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    val selectedLabel = labels.firstOrNull { it.id == selectedLabelId }
+
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = selectedLabel?.name ?: "",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Label (optional)") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, true)
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text("None") },
+                onClick = {
+                    onLabelSelected("")
+                    expanded = false
+                }
+            )
+            labels.forEach { label ->
+                DropdownMenuItem(
+                    text = { Text(label.name) },
+                    onClick = {
+                        onLabelSelected(label.id)
+                        expanded = false
+                    }
+                )
+            }
+            DropdownMenuItem(
+                text = { Text("+ New label") },
+                onClick = {
+                    expanded = false
+                    showCreateDialog = true
+                }
+            )
+        }
+    }
+
+    if (showCreateDialog) {
+        NewLabelDialog(
+            onDismiss = { showCreateDialog = false },
+            onCreate = { name, color ->
+                onCreateLabel(name, color)
+                showCreateDialog = false
+            }
+        )
+    }
+}
+
+@Composable
+private fun NewLabelDialog(onDismiss: () -> Unit, onCreate: (String, String) -> Unit) {
+    var name by remember { mutableStateOf("") }
+    var selectedColor by remember { mutableStateOf(PRESET_LABEL_COLORS.first()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("New label") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    PRESET_LABEL_COLORS.forEach { color ->
+                        Box(
+                            modifier =
+                            Modifier
+                                .size(32.dp)
+                                .background(
+                                    color = Color(android.graphics.Color.parseColor(color)),
+                                    shape = CircleShape
+                                ).border(
+                                    width = if (color == selectedColor) 2.dp else 0.dp,
+                                    color = Color.Black,
+                                    shape = CircleShape
+                                ).clickable { selectedColor = color }
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onCreate(name, selectedColor) }, enabled = name.isNotBlank()) {
+                Text("Create")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }

--- a/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
@@ -16,9 +16,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -76,7 +76,8 @@ private const val DEFAULT_COUNTRY_CODE = "BE"
 private const val HOME_LOCATION_LABEL = "Home"
 private const val OFFICE_LOCATION_LABEL = "Office"
 
-private fun parseHexColor(hex: String): Color = Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK)
+private fun parseHexColor(hex: String): Color =
+    runCatching { Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK) }.getOrDefault(Color.Gray)
 
 @Composable
 fun TodayScreen(
@@ -362,11 +363,14 @@ private fun WorkLocationChipsRow(
         locations.forEach { location ->
             AssistChip(
                 onClick = { onEdit(location) },
-                label = { Text(location.chipLabel()) }
+                label = { Text(location.chipLabel()) },
+                trailingIcon = {
+                    Text(
+                        text = "✕",
+                        modifier = Modifier.clickable(enabled = !isSubmitting) { onDelete(location) }
+                    )
+                }
             )
-            TextButton(onClick = { onDelete(location) }, enabled = !isSubmitting) {
-                Text("Clear")
-            }
         }
     }
 }
@@ -410,7 +414,7 @@ private fun LabelPickerField(
                 .fillMaxWidth()
                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
         )
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(
                 text = { Text("None") },
                 onClick = {

--- a/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.worktime.android.data.model.LabelRecord
@@ -65,6 +66,11 @@ private val PRESET_LABEL_COLORS =
         PRESET_COLOR_PURPLE,
         PRESET_COLOR_GREY
     )
+
+private const val OPAQUE_ALPHA_MASK = 0xFF000000L
+
+private fun parseHexColor(hex: String): Color =
+    Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK)
 
 @Composable
 fun TodayScreen(
@@ -324,14 +330,13 @@ private fun NewLabelDialog(onDismiss: () -> Unit, onCreate: (String, String) -> 
                             modifier =
                             Modifier
                                 .size(32.dp)
-                                .background(
-                                    color = Color(android.graphics.Color.parseColor(color)),
-                                    shape = CircleShape
-                                ).border(
+                                .background(color = parseHexColor(color), shape = CircleShape)
+                                .border(
                                     width = if (color == selectedColor) 2.dp else 0.dp,
                                     color = Color.Black,
                                     shape = CircleShape
-                                ).clickable { selectedColor = color }
+                                ).clip(CircleShape)
+                                .clickable { selectedColor = color }
                         )
                     }
                 }

--- a/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults

--- a/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
@@ -19,9 +19,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -36,15 +37,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.worktime.android.data.model.LabelRecord
 import com.worktime.android.data.model.TemplateRecord
+import com.worktime.android.data.model.WorkLocationRecord
 import com.worktime.android.feature.dashboard.DashboardUiState
 import com.worktime.android.feature.dashboard.MobileActionsUiState
 import com.worktime.android.ui.components.DatePickerField
 import com.worktime.android.ui.components.ReadModelScreen
 import com.worktime.android.ui.components.ScreenList
 import com.worktime.android.ui.components.SummaryCard
+import com.worktime.android.ui.components.formatDate
 import com.worktime.android.ui.components.formatInstant
 import com.worktime.android.ui.components.formatShift
 import java.time.LocalDate
+import java.util.Locale
 
 private const val PRESET_COLOR_RED = "#F44336"
 private const val PRESET_COLOR_ORANGE = "#FF9800"
@@ -68,6 +72,9 @@ private val PRESET_LABEL_COLORS =
     )
 
 private const val OPAQUE_ALPHA_MASK = 0xFF000000L
+private const val DEFAULT_COUNTRY_CODE = "BE"
+private const val HOME_LOCATION_LABEL = "Home"
+private const val OFFICE_LOCATION_LABEL = "Office"
 
 private fun parseHexColor(hex: String): Color = Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK)
 
@@ -80,6 +87,7 @@ fun TodayScreen(
     onStopTracking: (String) -> Unit,
     onUpdateTask: (String, String?, String?) -> Unit,
     onSetWorkLocation: (LocalDate, String, String?) -> Unit,
+    onDeleteWorkLocation: (LocalDate) -> Unit,
     onCreateLabel: (String, String) -> Unit
 ) {
     ReadModelScreen(title = "Today", uiState = uiState, onRetry = onRetry) { dashboard ->
@@ -90,6 +98,12 @@ fun TodayScreen(
         var workLocationDate by remember { mutableStateOf(LocalDate.now()) }
         var countryCode by remember { mutableStateOf("") }
         var workLocationLabel by remember { mutableStateOf("") }
+        val defaultCountryCode =
+            remember {
+                Locale.getDefault().country.takeIf { it.length == 2 } ?: DEFAULT_COUNTRY_CODE
+            }
+        val homeCountryCode = actionsState.workLocationPreferences.homeCountry ?: defaultCountryCode
+        val officeCountryCode = actionsState.workLocationPreferences.officeCountry ?: defaultCountryCode
 
         ScreenList(title = "Today") {
             item {
@@ -179,41 +193,27 @@ fun TodayScreen(
                 }
             }
             item {
-                SummaryCard(title = "Work location") {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        DatePickerField(
-                            label = "Date",
-                            date = workLocationDate,
-                            onDateSelected = { workLocationDate = it }
-                        )
-                        OutlinedTextField(
-                            value = countryCode,
-                            onValueChange = { countryCode = it },
-                            modifier = Modifier.fillMaxWidth(),
-                            label = { Text("Country code") },
-                            singleLine = true
-                        )
-                        OutlinedTextField(
-                            value = workLocationLabel,
-                            onValueChange = { workLocationLabel = it },
-                            modifier = Modifier.fillMaxWidth(),
-                            label = { Text("Label (optional)") },
-                            singleLine = true
-                        )
-                        Button(
-                            onClick = {
-                                onSetWorkLocation(workLocationDate, countryCode, workLocationLabel.ifBlank { null })
-                            },
-                            enabled = !actionsState.isSubmitting && countryCode.length >= 2
-                        ) {
-                            Text("Set work location")
-                        }
-                        text("Weekly entries", actionsState.weeklyWorkLocations.size.toString())
-                    }
-                }
+                WorkLocationCard(
+                    workLocationDate = workLocationDate,
+                    onDateSelected = { workLocationDate = it },
+                    countryCode = countryCode,
+                    onCountryCodeChange = { countryCode = it.take(2).uppercase() },
+                    workLocationLabel = workLocationLabel,
+                    onWorkLocationLabelChange = { workLocationLabel = it },
+                    weeklyWorkLocations = actionsState.weeklyWorkLocations,
+                    isSubmitting = actionsState.isSubmitting,
+                    homeCountryCode = homeCountryCode,
+                    officeCountryCode = officeCountryCode,
+                    onSetWorkLocation = { selectedCountryCode, selectedLabel ->
+                        onSetWorkLocation(workLocationDate, selectedCountryCode, selectedLabel)
+                    },
+                    onEditWorkLocation = { location ->
+                        workLocationDate = LocalDate.parse(location.date)
+                        countryCode = location.countryCode
+                        workLocationLabel = location.label.orEmpty()
+                    },
+                    onDeleteWorkLocation = { location -> onDeleteWorkLocation(LocalDate.parse(location.date)) }
+                )
             }
             item {
                 SummaryCard(title = "Sync") {
@@ -224,6 +224,148 @@ fun TodayScreen(
                         Text(text = it, modifier = Modifier.padding(top = 8.dp))
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkLocationCard(
+    workLocationDate: LocalDate,
+    onDateSelected: (LocalDate) -> Unit,
+    countryCode: String,
+    onCountryCodeChange: (String) -> Unit,
+    workLocationLabel: String,
+    onWorkLocationLabelChange: (String) -> Unit,
+    weeklyWorkLocations: List<WorkLocationRecord>,
+    isSubmitting: Boolean,
+    homeCountryCode: String,
+    officeCountryCode: String,
+    onSetWorkLocation: (String, String?) -> Unit,
+    onEditWorkLocation: (WorkLocationRecord) -> Unit,
+    onDeleteWorkLocation: (WorkLocationRecord) -> Unit
+) {
+    var showOtherFields by remember { mutableStateOf(false) }
+
+    SummaryCard(title = "Work location") {
+        content {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                DatePickerField(
+                    label = "Date",
+                    date = workLocationDate,
+                    onDateSelected = onDateSelected
+                )
+                WorkLocationQuickChips(
+                    showOtherFields = showOtherFields,
+                    isSubmitting = isSubmitting,
+                    onHome = {
+                        showOtherFields = false
+                        onSetWorkLocation(homeCountryCode, HOME_LOCATION_LABEL)
+                    },
+                    onOffice = {
+                        showOtherFields = false
+                        onSetWorkLocation(officeCountryCode, OFFICE_LOCATION_LABEL)
+                    },
+                    onOther = { showOtherFields = !showOtherFields }
+                )
+                if (showOtherFields) {
+                    OtherWorkLocationFields(
+                        countryCode = countryCode,
+                        onCountryCodeChange = onCountryCodeChange,
+                        workLocationLabel = workLocationLabel,
+                        onWorkLocationLabelChange = onWorkLocationLabelChange,
+                        isSubmitting = isSubmitting,
+                        onSave = { onSetWorkLocation(countryCode, workLocationLabel.ifBlank { null }) }
+                    )
+                }
+                if (weeklyWorkLocations.isNotEmpty()) {
+                    WorkLocationChipsRow(
+                        locations = weeklyWorkLocations,
+                        isSubmitting = isSubmitting,
+                        onEdit = { location ->
+                            showOtherFields = true
+                            onEditWorkLocation(location)
+                        },
+                        onDelete = onDeleteWorkLocation
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkLocationQuickChips(
+    showOtherFields: Boolean,
+    isSubmitting: Boolean,
+    onHome: () -> Unit,
+    onOffice: () -> Unit,
+    onOther: () -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        FilterChip(selected = false, onClick = onHome, enabled = !isSubmitting, label = { Text("Home") })
+        FilterChip(selected = false, onClick = onOffice, enabled = !isSubmitting, label = { Text("Office") })
+        FilterChip(selected = showOtherFields, onClick = onOther, enabled = !isSubmitting, label = { Text("Other") })
+    }
+}
+
+@Composable
+private fun OtherWorkLocationFields(
+    countryCode: String,
+    onCountryCodeChange: (String) -> Unit,
+    workLocationLabel: String,
+    onWorkLocationLabelChange: (String) -> Unit,
+    isSubmitting: Boolean,
+    onSave: () -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedTextField(
+            value = countryCode,
+            onValueChange = onCountryCodeChange,
+            modifier = Modifier.weight(1f),
+            label = { Text("Country") },
+            singleLine = true
+        )
+        OutlinedTextField(
+            value = workLocationLabel,
+            onValueChange = onWorkLocationLabelChange,
+            modifier = Modifier.weight(2f),
+            label = { Text("Label") },
+            singleLine = true
+        )
+    }
+    Button(
+        onClick = onSave,
+        enabled = !isSubmitting && countryCode.length == 2
+    ) {
+        Text("Save other")
+    }
+}
+
+@Composable
+private fun WorkLocationChipsRow(
+    locations: List<WorkLocationRecord>,
+    isSubmitting: Boolean,
+    onEdit: (WorkLocationRecord) -> Unit,
+    onDelete: (WorkLocationRecord) -> Unit
+) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        locations.forEach { location ->
+            AssistChip(
+                onClick = { onEdit(location) },
+                label = { Text(location.chipLabel()) }
+            )
+            TextButton(onClick = { onDelete(location) }, enabled = !isSubmitting) {
+                Text("Clear")
             }
         }
     }
@@ -266,7 +408,7 @@ private fun LabelPickerField(
             modifier =
             Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable, true)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(
@@ -353,3 +495,6 @@ private fun NewLabelDialog(onDismiss: () -> Unit, onCreate: (String, String) -> 
         }
     )
 }
+
+private fun WorkLocationRecord.chipLabel(): String =
+    listOfNotNull(formatDate(date), countryCode, label?.takeIf { it.isNotBlank() }).joinToString(" · ")

--- a/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/today/TodayScreen.kt
@@ -69,8 +69,7 @@ private val PRESET_LABEL_COLORS =
 
 private const val OPAQUE_ALPHA_MASK = 0xFF000000L
 
-private fun parseHexColor(hex: String): Color =
-    Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK)
+private fun parseHexColor(hex: String): Color = Color(hex.removePrefix("#").toLong(radix = 16) or OPAQUE_ALPHA_MASK)
 
 @Composable
 fun TodayScreen(

--- a/android/app/src/main/java/com/worktime/android/ui/components/DateField.kt
+++ b/android/app/src/main/java/com/worktime/android/ui/components/DateField.kt
@@ -1,0 +1,53 @@
+package com.worktime.android.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatePickerField(label: String, date: LocalDate?, onDateSelected: (LocalDate) -> Unit) {
+    var showPicker by remember { mutableStateOf(false) }
+    OutlinedButton(onClick = { showPicker = true }, modifier = Modifier.fillMaxWidth()) {
+        Text(date?.toString() ?: "Select $label")
+    }
+    if (showPicker) {
+        val state =
+            rememberDatePickerState(
+                initialSelectedDateMillis = date?.atStartOfDay(ZoneOffset.UTC)?.toInstant()?.toEpochMilli()
+            )
+        DatePickerDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { millis ->
+                        onDateSelected(Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDate())
+                    }
+                    showPicker = false
+                }) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) {
+                    Text("Cancel")
+                }
+            }
+        ) {
+            androidx.compose.material3.DatePicker(state = state)
+        }
+    }
+}

--- a/android/app/src/main/java/com/worktime/android/ui/components/DateField.kt
+++ b/android/app/src/main/java/com/worktime/android/ui/components/DateField.kt
@@ -1,9 +1,13 @@
 package com.worktime.android.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
@@ -13,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -21,9 +26,24 @@ import java.time.ZoneOffset
 @Composable
 fun DatePickerField(label: String, date: LocalDate?, onDateSelected: (LocalDate) -> Unit) {
     var showPicker by remember { mutableStateOf(false) }
-    OutlinedButton(onClick = { showPicker = true }, modifier = Modifier.fillMaxWidth()) {
-        Text(date?.toString() ?: "Select $label")
-    }
+    OutlinedTextField(
+        value = date?.toString().orEmpty(),
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(label) },
+        placeholder = { Text("Select $label") },
+        trailingIcon = {
+            Icon(
+                imageVector = Icons.Filled.Event,
+                contentDescription = label
+            )
+        },
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .focusProperties { canFocus = false }
+            .clickable { showPicker = true }
+    )
     if (showPicker) {
         val state =
             rememberDatePickerState(

--- a/android/app/src/test/java/com/worktime/android/data/api/WorktimeApiTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/api/WorktimeApiTest.kt
@@ -82,4 +82,57 @@ class WorktimeApiTest {
         assertEquals("/api/me", request.requestLine.substringAfter(' ').substringBefore(' '))
         assertEquals("Bearer token-123", request.headers["Authorization"])
     }
+
+    @Test
+    fun listTimeOffEntriesResolvesUserFromTokenOnlyWithoutUserIdParam() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body(
+                    """{"items":[{"id":1,"entry_id":"entry-1","user_id":1,"entry_kind":"date",""" +
+                        """"date":"2026-06-01","start_date":null,"end_date":null,"weekday":null,""" +
+                        """"entry_type":"vacation","entry_flag":"full_day","note":null,""" +
+                        """"created_at":"2026-05-26T12:00:00Z","updated_at":"2026-05-26T12:00:00Z"}],"total":1}"""
+                ).build()
+        )
+        val api = WorktimeApi.create(baseUrl = server.url("/").toString(), enableNetworkLogging = false)
+
+        val response = api.listTimeOffEntries(authorization = "Bearer token-123")
+
+        val request = server.takeRequest()
+        assertEquals("/api/time-off/", request.requestLine.substringAfter(' ').substringBefore(' '))
+        assertEquals("Bearer token-123", request.headers["Authorization"])
+        assertEquals(1, response.items.size)
+        assertEquals("entry-1", response.items.first().entryId)
+    }
+
+    @Test
+    fun listLabelsSendsUserIdQueryParam() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body("""{"items":[],"total":0}""")
+                .build()
+        )
+        val api = WorktimeApi.create(baseUrl = server.url("/").toString(), enableNetworkLogging = false)
+
+        api.listLabels(authorization = "Bearer token-123", userId = 42)
+
+        val request = server.takeRequest()
+        val path = request.requestLine.substringAfter(' ').substringBefore(' ')
+        assertEquals("/api/time-tracking/labels?user_id=42", path)
+        assertEquals("Bearer token-123", request.headers["Authorization"])
+    }
+
+    @Test
+    fun deleteTimeOffEntrySendsCorrectMethodAndPath() = runTest {
+        server.enqueue(MockResponse.Builder().code(204).build())
+        val api = WorktimeApi.create(baseUrl = server.url("/").toString(), enableNetworkLogging = false)
+
+        api.deleteTimeOffEntry(authorization = "Bearer token-123", entryId = "entry-1")
+
+        val request = server.takeRequest()
+        assertEquals("DELETE", request.method)
+        assertEquals("/api/time-off/entry-1", request.requestLine.substringAfter(' ').substringBefore(' '))
+    }
 }

--- a/android/app/src/test/java/com/worktime/android/data/api/WorktimeApiTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/api/WorktimeApiTest.kt
@@ -1,6 +1,13 @@
 package com.worktime.android.data.api
 
+import com.worktime.android.data.model.LabelMutationRequest
+import com.worktime.android.data.model.TemplatePatchRequest
+import com.worktime.android.data.model.TimeOffEntryPatchRequest
+import com.worktime.android.data.model.UserPreferencesWrite
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import org.junit.After
@@ -134,5 +141,147 @@ class WorktimeApiTest {
         val request = server.takeRequest()
         assertEquals("DELETE", request.method)
         assertEquals("/api/time-off/entry-1", request.requestLine.substringAfter(' ').substringBefore(' '))
+    }
+
+    @Test
+    fun createLabelSendsUserIdAndPayload() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body(
+                    """{"id":"label-1","user_id":42,"name":"Focus","color":"#2196F3","created_at":"2026-05-26T12:00:00Z"}"""
+                ).build()
+        )
+        val api = WorktimeApi.create(baseUrl = server.url("/").toString(), enableNetworkLogging = false)
+
+        val response =
+            api.createLabel(
+                authorization = "Bearer token-123",
+                userId = 42,
+                payload = LabelMutationRequest(name = "Focus", color = "#2196F3")
+            )
+
+        val request = server.takeRequest()
+        val body = request.body?.utf8().orEmpty()
+        assertEquals("POST", request.method)
+        assertEquals(
+            "/api/time-tracking/labels?user_id=42",
+            request.requestLine.substringAfter(' ').substringBefore(' ')
+        )
+        assertEquals("Bearer token-123", request.headers["Authorization"])
+        assertEquals(true, body.contains(""""name":"Focus""""))
+        assertEquals(true, body.contains(""""color":"#2196F3""""))
+        assertEquals("label-1", response.id)
+    }
+
+    @Test
+    fun updateTemplateSendsPatchPayload() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body(
+                    """{"id":"template-1","user_id":42,"label_id":"label-1","text":"Standup",""" +
+                        """"start_time":"09:00","stop_time":"09:15","created_at":"2026-05-26T12:00:00Z"}"""
+                ).build()
+        )
+        val api = WorktimeApi.create(baseUrl = server.url("/").toString(), enableNetworkLogging = false)
+
+        val response =
+            api.updateTemplate(
+                authorization = "Bearer token-123",
+                templateId = "template-1",
+                userId = 42,
+                payload =
+                TemplatePatchRequest(
+                    text = "Standup",
+                    labelId = "label-1",
+                    startTime = "09:00",
+                    stopTime = "09:15"
+                )
+            )
+
+        val request = server.takeRequest()
+        val body = request.body?.utf8().orEmpty()
+        assertEquals("PUT", request.method)
+        assertEquals(
+            "/api/time-tracking/templates/template-1?user_id=42",
+            request.requestLine.substringAfter(' ').substringBefore(' ')
+        )
+        assertEquals(true, body.contains(""""label_id":"label-1""""))
+        assertEquals(true, body.contains(""""start_time":"09:00""""))
+        assertEquals("template-1", response.id)
+    }
+
+    @Test
+    fun updateTimeOffEntrySendsPatchWithoutUserIdAndPreservesExplicitNullNote() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body(
+                    """{"id":1,"entry_id":"entry-1","user_id":42,"entry_kind":"range","date":null,""" +
+                        """"start_date":"2026-06-01","end_date":"2026-06-03","weekday":null,""" +
+                        """"entry_type":"vacation","entry_flag":"full_day","note":null,""" +
+                        """"created_at":"2026-05-26T12:00:00Z","updated_at":"2026-05-26T12:00:00Z"}"""
+                ).build()
+        )
+        val api = WorktimeApi.create(baseUrl = server.url("/").toString(), enableNetworkLogging = false)
+
+        val response =
+            api.updateTimeOffEntry(
+                authorization = "Bearer token-123",
+                entryId = "entry-1",
+                payload =
+                TimeOffEntryPatchRequest(
+                    entryKind = "range",
+                    startDate = "2026-06-01",
+                    endDate = "2026-06-03",
+                    entryType = "vacation",
+                    entryFlag = "full_day",
+                    note = JsonNull
+                )
+            )
+
+        val request = server.takeRequest()
+        val path = request.requestLine.substringAfter(' ').substringBefore(' ')
+        val body = request.body?.utf8().orEmpty()
+        assertEquals("PATCH", request.method)
+        assertEquals("/api/time-off/entry-1", path)
+        assertEquals(false, path.contains("user_id"))
+        assertEquals(true, body.contains(""""entry_kind":"range""""))
+        assertEquals(true, body.contains(""""note":null"""))
+        assertEquals("entry-1", response.entryId)
+    }
+
+    @Test
+    fun putPreferencesSendsNestedDataPayload() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body("""{"data":{"work_location_home_country":"BE","work_location_office_country":"NL"}}""")
+                .build()
+        )
+        val api = WorktimeApi.create(baseUrl = server.url("/").toString(), enableNetworkLogging = false)
+
+        val response =
+            api.putPreferences(
+                authorization = "Bearer token-123",
+                payload =
+                UserPreferencesWrite(
+                    data =
+                    JsonObject(
+                        mapOf(
+                            "work_location_home_country" to JsonPrimitive("BE"),
+                            "work_location_office_country" to JsonPrimitive("NL")
+                        )
+                    )
+                )
+            )
+
+        val request = server.takeRequest()
+        val body = request.body?.utf8().orEmpty()
+        assertEquals("PUT", request.method)
+        assertEquals("/api/preferences", request.requestLine.substringAfter(' ').substringBefore(' '))
+        assertEquals(true, body.contains(""""work_location_home_country":"BE""""))
+        assertEquals(JsonPrimitive("NL"), response.data["work_location_office_country"])
     }
 }

--- a/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
@@ -226,7 +226,7 @@ class WorktimeRepositoryTest {
     fun getWorkLocationReturnsNullOnNotFound() = runTest {
         val repository =
             WorktimeRepository(
-                api = FakeApi(workLocationThrowable = httpException(404)),
+                api = FakeApi(workLocationNotFound = true),
                 sessionController = FakeSessionController(token = "token-123")
             )
         repository.loadDashboard()
@@ -505,6 +505,7 @@ class WorktimeRepositoryTest {
         private val taskThrowable: Throwable? = null,
         private val taskListResponse: TaskListResponse = TaskListResponse(items = emptyList(), total = 0),
         private val workLocationThrowable: Throwable? = null,
+        private val workLocationNotFound: Boolean = false,
         private val labelThrowable: Throwable? = null,
         private val labelListResponse: LabelListResponse = LabelListResponse(items = emptyList(), total = 0),
         private val templateThrowable: Throwable? = null,
@@ -580,6 +581,9 @@ class WorktimeRepositoryTest {
             userId: Int
         ): Response<WorkLocationRecord> {
             workLocationThrowable?.let { throw it }
+            if (workLocationNotFound) {
+                return Response.error(404, "".toResponseBody("text/plain".toMediaType()))
+            }
             return Response.success(
                 WorkLocationRecord(
                     id = 1,

--- a/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
@@ -7,16 +7,31 @@ import com.worktime.android.data.model.CurrentStatus
 import com.worktime.android.data.model.DashboardResponse
 import com.worktime.android.data.model.FeatureFlags
 import com.worktime.android.data.model.Identity
+import com.worktime.android.data.model.LabelListResponse
+import com.worktime.android.data.model.LabelMutationRequest
+import com.worktime.android.data.model.LabelPatchRequest
+import com.worktime.android.data.model.LabelRecord
 import com.worktime.android.data.model.NextShifts
 import com.worktime.android.data.model.SyncStatusResponse
+import com.worktime.android.data.model.TaskListResponse
 import com.worktime.android.data.model.TaskMutationRequest
 import com.worktime.android.data.model.TaskRecord
 import com.worktime.android.data.model.TeamStatus
+import com.worktime.android.data.model.TemplateListResponse
+import com.worktime.android.data.model.TemplateMutationRequest
+import com.worktime.android.data.model.TemplatePatchRequest
+import com.worktime.android.data.model.TemplateRecord
+import com.worktime.android.data.model.TimeOffEntryListResponse
+import com.worktime.android.data.model.TimeOffEntryMutationRequest
+import com.worktime.android.data.model.TimeOffEntryPatchRequest
+import com.worktime.android.data.model.TimeOffEntryRecord
 import com.worktime.android.data.model.TimeOffSummary
 import com.worktime.android.data.model.WorkContext
 import com.worktime.android.data.model.WorkLocationListResponse
 import com.worktime.android.data.model.WorkLocationMutationRequest
 import com.worktime.android.data.model.WorkLocationRecord
+import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -178,10 +193,325 @@ class WorktimeRepositoryTest {
         assertEquals(SessionState.Authenticated(hasRefreshToken = true), sessionController.sessionState.value)
     }
 
+    @Test
+    fun listTasksReturnsItems() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(taskListResponse = TaskListResponse(items = listOf(sampleTask(userId = 1)), total = 1)),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.listTasks()
+
+        assertTrue(result is MutationResult.Success)
+        assertEquals(1, (result as MutationResult.Success).value.size)
+    }
+
+    @Test
+    fun deleteTaskReturnsSuccess() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.deleteTask("task-1")
+
+        assertEquals(MutationResult.Success(Unit), result)
+    }
+
+    @Test
+    fun getWorkLocationReturnsNullOnNotFound() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(workLocationThrowable = httpException(404)),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.getWorkLocation(LocalDate.parse("2026-05-26"))
+
+        assertEquals(MutationResult.Success(null), result)
+    }
+
+    @Test
+    fun getWorkLocationReturnsSuccessWhenPresent() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.getWorkLocation(LocalDate.parse("2026-05-26"))
+
+        assertTrue(result is MutationResult.Success)
+        assertEquals("BE", (result as MutationResult.Success).value?.countryCode)
+    }
+
+    @Test
+    fun deleteWorkLocationReturnsSuccess() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.deleteWorkLocation(LocalDate.parse("2026-05-26"))
+
+        assertEquals(MutationResult.Success(Unit), result)
+    }
+
+    @Test
+    fun createLabelReturnsValidationErrorOnConflict() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(labelThrowable = httpException(409)),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.createLabel("Focus", "#FF0000")
+
+        assertEquals(MutationResult.ValidationError("Label name must be unique"), result)
+    }
+
+    @Test
+    fun listLabelsReturnsItems() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(labelListResponse = LabelListResponse(items = listOf(sampleLabel()), total = 1)),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.listLabels()
+
+        assertTrue(result is MutationResult.Success)
+        assertEquals(1, (result as MutationResult.Success).value.size)
+    }
+
+    @Test
+    fun updateLabelReturnsSuccess() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.updateLabel("label-1", name = "Renamed")
+
+        assertTrue(result is MutationResult.Success)
+    }
+
+    @Test
+    fun deleteLabelReturnsValidationErrorWhenInUse() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(labelThrowable = httpException(409)),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.deleteLabel("label-1")
+
+        assertEquals(
+            MutationResult.ValidationError("Label is in use by tasks or templates and cannot be deleted"),
+            result
+        )
+    }
+
+    @Test
+    fun createTemplateReturnsSuccess() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result =
+            repository.createTemplate(
+                text = "Deep work",
+                labelId = null,
+                startTime = LocalTime.parse("09:00:00"),
+                stopTime = LocalTime.parse("11:00:00")
+            )
+
+        assertTrue(result is MutationResult.Success)
+    }
+
+    @Test
+    fun listTemplatesReturnsItems() = runTest {
+        val repository =
+            WorktimeRepository(
+                api =
+                FakeApi(templateListResponse = TemplateListResponse(items = listOf(sampleTemplate()), total = 1)),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.listTemplates()
+
+        assertTrue(result is MutationResult.Success)
+        assertEquals(1, (result as MutationResult.Success).value.size)
+    }
+
+    @Test
+    fun deleteTemplateReturnsSuccess() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+        repository.loadDashboard()
+
+        val result = repository.deleteTemplate("template-1")
+
+        assertEquals(MutationResult.Success(Unit), result)
+    }
+
+    @Test
+    fun createTimeOffEntryReturnsLoggedOutWhenNoToken() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = null)
+            )
+
+        val result =
+            repository.createTimeOffEntry(
+                TimeOffDraft.SingleDate(
+                    date = LocalDate.parse("2026-06-01"),
+                    entryType = "vacation",
+                    entryFlag = "full_day"
+                )
+            )
+
+        assertEquals(MutationResult.LoggedOut, result)
+    }
+
+    @Test
+    fun createTimeOffEntryDoesNotRequireDashboardLoad() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+
+        val result =
+            repository.createTimeOffEntry(
+                TimeOffDraft.DateRange(
+                    startDate = LocalDate.parse("2026-06-01"),
+                    endDate = LocalDate.parse("2026-06-05"),
+                    entryType = "vacation",
+                    entryFlag = "full_day"
+                )
+            )
+
+        assertTrue(result is MutationResult.Success)
+        assertEquals("range", (result as MutationResult.Success).value.entryKind)
+    }
+
+    @Test
+    fun createTimeOffEntryReturnsValidationErrorForBadRequest() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(timeOffThrowable = httpException(400)),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+
+        val result =
+            repository.createTimeOffEntry(
+                TimeOffDraft.Weekly(weekday = 1, entryType = "vacation", entryFlag = "full_day")
+            )
+
+        assertEquals(MutationResult.ValidationError("Request validation failed"), result)
+    }
+
+    @Test
+    fun listTimeOffEntriesReturnsItems() = runTest {
+        val repository =
+            WorktimeRepository(
+                api =
+                FakeApi(
+                    timeOffListResponse = TimeOffEntryListResponse(items = listOf(sampleTimeOffEntry()), total = 1)
+                ),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+
+        val result = repository.listTimeOffEntries()
+
+        assertTrue(result is MutationResult.Success)
+        assertEquals(1, (result as MutationResult.Success).value.size)
+    }
+
+    @Test
+    fun updateTimeOffEntryReturnsSuccess() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+
+        val result =
+            repository.updateTimeOffEntry(
+                "entry-1",
+                TimeOffDraft.SingleDate(
+                    date = LocalDate.parse("2026-06-02"),
+                    entryType = "sick",
+                    entryFlag = "full_day"
+                )
+            )
+
+        assertTrue(result is MutationResult.Success)
+    }
+
+    @Test
+    fun deleteTimeOffEntryReturnsSuccess() = runTest {
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+
+        val result = repository.deleteTimeOffEntry("entry-1")
+
+        assertEquals(MutationResult.Success(Unit), result)
+    }
+
+    @Test
+    fun deleteTimeOffEntryReturnsLoggedOutOnUnauthorized() = runTest {
+        val sessionController = FakeSessionController(token = "token-123")
+        val repository =
+            WorktimeRepository(
+                api = FakeApi(timeOffThrowable = httpException(401)),
+                sessionController = sessionController
+            )
+
+        val result = repository.deleteTimeOffEntry("entry-1")
+
+        assertEquals(MutationResult.LoggedOut, result)
+        assertEquals(SessionState.LoggedOut, sessionController.sessionState.value)
+    }
+
     private class FakeApi(
         private val response: DashboardResponse = sampleDashboard(),
         private val dashboardThrowable: Throwable? = null,
         private val taskThrowable: Throwable? = null,
+        private val taskListResponse: TaskListResponse = TaskListResponse(items = emptyList(), total = 0),
+        private val workLocationThrowable: Throwable? = null,
+        private val labelThrowable: Throwable? = null,
+        private val labelListResponse: LabelListResponse = LabelListResponse(items = emptyList(), total = 0),
+        private val templateThrowable: Throwable? = null,
+        private val templateListResponse: TemplateListResponse = TemplateListResponse(items = emptyList(), total = 0),
+        private val timeOffThrowable: Throwable? = null,
+        private val timeOffListResponse: TimeOffEntryListResponse =
+            TimeOffEntryListResponse(items = emptyList(), total = 0),
         private val deleteAccountThrowable: Throwable? = null
     ) : WorktimeApi {
         override suspend fun getDashboard(authorization: String, timezone: String): DashboardResponse {
@@ -207,6 +537,20 @@ class WorktimeRepositoryTest {
         override suspend fun getRunningTask(authorization: String, userId: Int): Response<TaskRecord> =
             Response.success(sampleTask(userId = userId))
 
+        override suspend fun listTasks(
+            authorization: String,
+            userId: Int,
+            startDate: String?,
+            endDate: String?
+        ): TaskListResponse {
+            taskThrowable?.let { throw it }
+            return taskListResponse
+        }
+
+        override suspend fun deleteTask(authorization: String, taskId: String, userId: Int) {
+            taskThrowable?.let { throw it }
+        }
+
         override suspend fun upsertWorkLocation(
             authorization: String,
             userId: Int,
@@ -230,7 +574,118 @@ class WorktimeRepositoryTest {
             total = 0
         )
 
-        override suspend fun deleteLabel(authorization: String, labelId: String, userId: Int) = Unit
+        override suspend fun getWorkLocation(
+            authorization: String,
+            valueDate: String,
+            userId: Int
+        ): Response<WorkLocationRecord> {
+            workLocationThrowable?.let { throw it }
+            return Response.success(
+                WorkLocationRecord(
+                    id = 1,
+                    userId = userId,
+                    date = valueDate,
+                    countryCode = "BE",
+                    label = null,
+                    createdAt = "2026-05-26T12:00:00Z"
+                )
+            )
+        }
+
+        override suspend fun deleteWorkLocation(authorization: String, valueDate: String, userId: Int) {
+            workLocationThrowable?.let { throw it }
+        }
+
+        override suspend fun createLabel(
+            authorization: String,
+            userId: Int,
+            payload: LabelMutationRequest
+        ): LabelRecord {
+            labelThrowable?.let { throw it }
+            return sampleLabel(name = payload.name, color = payload.color)
+        }
+
+        override suspend fun listLabels(authorization: String, userId: Int): LabelListResponse {
+            labelThrowable?.let { throw it }
+            return labelListResponse
+        }
+
+        override suspend fun updateLabel(
+            authorization: String,
+            labelId: String,
+            userId: Int,
+            payload: LabelPatchRequest
+        ): LabelRecord {
+            labelThrowable?.let { throw it }
+            return sampleLabel(id = labelId, name = payload.name ?: "Label")
+        }
+
+        override suspend fun deleteLabel(authorization: String, labelId: String, userId: Int) {
+            labelThrowable?.let { throw it }
+        }
+
+        override suspend fun createTemplate(
+            authorization: String,
+            userId: Int,
+            payload: TemplateMutationRequest
+        ): TemplateRecord {
+            templateThrowable?.let { throw it }
+            return sampleTemplate(text = payload.text)
+        }
+
+        override suspend fun listTemplates(authorization: String, userId: Int): TemplateListResponse {
+            templateThrowable?.let { throw it }
+            return templateListResponse
+        }
+
+        override suspend fun updateTemplate(
+            authorization: String,
+            templateId: String,
+            userId: Int,
+            payload: TemplatePatchRequest
+        ): TemplateRecord {
+            templateThrowable?.let { throw it }
+            return sampleTemplate(id = templateId, text = payload.text ?: "Template")
+        }
+
+        override suspend fun deleteTemplate(authorization: String, templateId: String, userId: Int) {
+            templateThrowable?.let { throw it }
+        }
+
+        override suspend fun upsertTimeOffEntry(
+            authorization: String,
+            payload: TimeOffEntryMutationRequest
+        ): Response<TimeOffEntryRecord> {
+            timeOffThrowable?.let { throw it }
+            return Response.success(sampleTimeOffEntry(entryKind = payload.entryKind, entryType = payload.entryType))
+        }
+
+        override suspend fun listTimeOffEntries(
+            authorization: String,
+            startDate: String?,
+            endDate: String?
+        ): TimeOffEntryListResponse {
+            timeOffThrowable?.let { throw it }
+            return timeOffListResponse
+        }
+
+        override suspend fun getTimeOffEntry(authorization: String, entryId: String): TimeOffEntryRecord {
+            timeOffThrowable?.let { throw it }
+            return sampleTimeOffEntry(entryId = entryId)
+        }
+
+        override suspend fun updateTimeOffEntry(
+            authorization: String,
+            entryId: String,
+            payload: TimeOffEntryPatchRequest
+        ): TimeOffEntryRecord {
+            timeOffThrowable?.let { throw it }
+            return sampleTimeOffEntry(entryId = entryId, entryType = payload.entryType ?: "vacation")
+        }
+
+        override suspend fun deleteTimeOffEntry(authorization: String, entryId: String) {
+            timeOffThrowable?.let { throw it }
+        }
 
         override suspend fun getSyncStatus(authorization: String): SyncStatusResponse = SyncStatusResponse(
             serverTimestamp = "2026-05-26T12:00:00Z"
@@ -299,6 +754,39 @@ private fun sampleTask(userId: Int, id: String = "task-1", text: String = "Task"
     stopTime = null,
     includesBreak = false,
     createdAt = "2026-05-26T12:00:00Z"
+)
+
+private fun sampleLabel(id: String = "label-1", name: String = "Focus", color: String = "#FF0000"): LabelRecord =
+    LabelRecord(id = id, userId = 1, name = name, color = color, createdAt = "2026-05-26T12:00:00Z")
+
+private fun sampleTemplate(id: String = "template-1", text: String = "Deep work"): TemplateRecord = TemplateRecord(
+    id = id,
+    userId = 1,
+    labelId = null,
+    text = text,
+    startTime = "09:00:00",
+    stopTime = "11:00:00",
+    createdAt = "2026-05-26T12:00:00Z"
+)
+
+private fun sampleTimeOffEntry(
+    entryId: String = "entry-1",
+    entryKind: String = "date",
+    entryType: String = "vacation"
+): TimeOffEntryRecord = TimeOffEntryRecord(
+    id = 1,
+    entryId = entryId,
+    userId = 1,
+    entryKind = entryKind,
+    date = "2026-06-01",
+    startDate = null,
+    endDate = null,
+    weekday = null,
+    entryType = entryType,
+    entryFlag = "full_day",
+    note = null,
+    createdAt = "2026-05-26T12:00:00Z",
+    updatedAt = "2026-05-26T12:00:00Z"
 )
 
 private fun httpException(code: Int): HttpException {

--- a/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
@@ -26,6 +26,8 @@ import com.worktime.android.data.model.TimeOffEntryMutationRequest
 import com.worktime.android.data.model.TimeOffEntryPatchRequest
 import com.worktime.android.data.model.TimeOffEntryRecord
 import com.worktime.android.data.model.TimeOffSummary
+import com.worktime.android.data.model.UserPreferencesRead
+import com.worktime.android.data.model.UserPreferencesWrite
 import com.worktime.android.data.model.WorkContext
 import com.worktime.android.data.model.WorkLocationListResponse
 import com.worktime.android.data.model.WorkLocationMutationRequest
@@ -34,6 +36,13 @@ import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -266,6 +275,70 @@ class WorktimeRepositoryTest {
     }
 
     @Test
+    fun loadWorkLocationPreferencesReadsBackendPreferencesBlob() = runTest {
+        val repository =
+            WorktimeRepository(
+                api =
+                FakeApi(
+                    preferencesResponse =
+                    UserPreferencesRead(
+                        data =
+                        JsonObject(
+                            mapOf(
+                                "settings" to
+                                    JsonObject(
+                                        mapOf(
+                                            "homeCountry" to JsonPrimitive("be"),
+                                            "officeCountry" to JsonPrimitive("nl")
+                                        )
+                                    )
+                            )
+                        )
+                    )
+                ),
+                sessionController = FakeSessionController(token = "token-123")
+            )
+
+        val result = repository.loadWorkLocationPreferences()
+
+        assertEquals(MutationResult.Success(WorkLocationPreferences(homeCountry = "BE", officeCountry = "NL")), result)
+    }
+
+    @Test
+    fun updateWorkLocationPreferencesPreservesExistingPreferencesBlob() = runTest {
+        val api =
+            FakeApi(
+                preferencesResponse =
+                UserPreferencesRead(
+                    data =
+                    JsonObject(
+                        mapOf(
+                            "activeTab" to JsonPrimitive("today"),
+                            "settings" to
+                                JsonObject(
+                                    mapOf(
+                                        "theme" to JsonPrimitive("dark"),
+                                        "homeCountry" to JsonPrimitive("BE")
+                                    )
+                                )
+                        )
+                    )
+                )
+            )
+        val repository = WorktimeRepository(api = api, sessionController = FakeSessionController(token = "token-123"))
+
+        val result = repository.updateWorkLocationPreferences(homeCountry = "de", officeCountry = "nl")
+
+        assertEquals(MutationResult.Success(WorkLocationPreferences(homeCountry = "DE", officeCountry = "NL")), result)
+        val data = requireNotNull(api.lastPreferencesWritePayload).data
+        assertEquals("today", data["activeTab"]?.jsonPrimitive?.content)
+        val settings = data["settings"]?.jsonObject
+        assertEquals("dark", settings?.get("theme")?.jsonPrimitive?.content)
+        assertEquals("DE", settings?.get("homeCountry")?.jsonPrimitive?.content)
+        assertEquals("NL", settings?.get("officeCountry")?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun createLabelReturnsValidationErrorOnConflict() = runTest {
         val repository =
             WorktimeRepository(
@@ -452,9 +525,10 @@ class WorktimeRepositoryTest {
 
     @Test
     fun updateTimeOffEntryReturnsSuccess() = runTest {
+        val api = FakeApi()
         val repository =
             WorktimeRepository(
-                api = FakeApi(),
+                api = api,
                 sessionController = FakeSessionController(token = "token-123")
             )
 
@@ -469,6 +543,30 @@ class WorktimeRepositoryTest {
             )
 
         assertTrue(result is MutationResult.Success)
+    }
+
+    @Test
+    fun updateTimeOffEntrySendsExplicitNullWhenNoteIsCleared() = runTest {
+        val api = FakeApi()
+        val repository =
+            WorktimeRepository(
+                api = api,
+                sessionController = FakeSessionController(token = "token-123")
+            )
+
+        repository.updateTimeOffEntry(
+            "entry-1",
+            TimeOffDraft.SingleDate(
+                date = LocalDate.parse("2026-06-02"),
+                entryType = "sick",
+                entryFlag = "full_day",
+                note = null
+            )
+        )
+
+        val payload = requireNotNull(api.lastTimeOffPatchPayload)
+        assertEquals(JsonNull, payload.note)
+        assertTrue(patchJson.encodeToString(payload).contains("\"note\":null"))
     }
 
     @Test
@@ -513,8 +611,14 @@ class WorktimeRepositoryTest {
         private val timeOffThrowable: Throwable? = null,
         private val timeOffListResponse: TimeOffEntryListResponse =
             TimeOffEntryListResponse(items = emptyList(), total = 0),
-        private val deleteAccountThrowable: Throwable? = null
+        private val deleteAccountThrowable: Throwable? = null,
+        private val preferencesResponse: UserPreferencesRead? = null
     ) : WorktimeApi {
+        var lastTimeOffPatchPayload: TimeOffEntryPatchRequest? = null
+            private set
+        var lastPreferencesWritePayload: UserPreferencesWrite? = null
+            private set
+
         override suspend fun getDashboard(authorization: String, timezone: String): DashboardResponse {
             dashboardThrowable?.let { throw it }
             return response
@@ -684,6 +788,7 @@ class WorktimeRepositoryTest {
             payload: TimeOffEntryPatchRequest
         ): TimeOffEntryRecord {
             timeOffThrowable?.let { throw it }
+            lastTimeOffPatchPayload = payload
             return sampleTimeOffEntry(entryId = entryId, entryType = payload.entryType ?: "vacation")
         }
 
@@ -694,6 +799,13 @@ class WorktimeRepositoryTest {
         override suspend fun getSyncStatus(authorization: String): SyncStatusResponse = SyncStatusResponse(
             serverTimestamp = "2026-05-26T12:00:00Z"
         )
+
+        override suspend fun getPreferences(authorization: String): UserPreferencesRead? = preferencesResponse
+
+        override suspend fun putPreferences(authorization: String, payload: UserPreferencesWrite): UserPreferencesRead {
+            lastPreferencesWritePayload = payload
+            return UserPreferencesRead(data = payload.data)
+        }
 
         override suspend fun deleteAccount(authorization: String) {
             deleteAccountThrowable?.let { throw it }
@@ -797,3 +909,5 @@ private fun httpException(code: Int): HttpException {
     val response = Response.error<String>(code, "".toResponseBody("text/plain".toMediaType()))
     return HttpException(response)
 }
+
+private val patchJson = Json { explicitNulls = false }

--- a/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
@@ -20,6 +20,7 @@ import com.worktime.android.data.repository.DashboardLoadResult
 import com.worktime.android.data.repository.DashboardRepository
 import com.worktime.android.data.repository.MutationResult
 import com.worktime.android.data.repository.TimeOffDraft
+import com.worktime.android.data.repository.WorkLocationPreferences
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.CompletableDeferred
@@ -168,13 +169,19 @@ class DashboardViewModelTest {
             FakeDashboardRepository(
                 result = DashboardLoadResult.Success(sampleDashboard()),
                 listLabelsResult = MutationResult.Success(listOf(sampleLabel())),
-                listTemplatesResult = MutationResult.Success(listOf(sampleTemplate()))
+                listTemplatesResult = MutationResult.Success(listOf(sampleTemplate())),
+                workLocationPreferencesResult =
+                MutationResult.Success(WorkLocationPreferences(homeCountry = "BE", officeCountry = "NL"))
             )
         val viewModel = DashboardViewModel(repository)
         advanceUntilIdle()
 
         assertEquals(listOf(sampleLabel()), viewModel.actionsState.value.labels)
         assertEquals(listOf(sampleTemplate()), viewModel.actionsState.value.templates)
+        assertEquals(
+            WorkLocationPreferences(homeCountry = "BE", officeCountry = "NL"),
+            viewModel.actionsState.value.workLocationPreferences
+        )
     }
 
     @Test
@@ -193,16 +200,116 @@ class DashboardViewModelTest {
         assertEquals("Label name must be unique", viewModel.actionsState.value.message)
     }
 
+    @Test
+    fun deleteWorkLocationSubmitsMutation() = runTest(dispatcher) {
+        val repository = FakeDashboardRepository(result = DashboardLoadResult.Success(sampleDashboard()))
+        val viewModel = DashboardViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.deleteWorkLocation(LocalDate.parse("2026-06-01"))
+        advanceUntilIdle()
+
+        assertEquals(LocalDate.parse("2026-06-01"), repository.deletedWorkLocationDate)
+        assertEquals("Saved", viewModel.actionsState.value.message)
+    }
+
+    @Test
+    fun updateWorkLocationPreferencesSubmitsMutation() = runTest(dispatcher) {
+        val repository = FakeDashboardRepository(result = DashboardLoadResult.Success(sampleDashboard()))
+        val viewModel = DashboardViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.updateWorkLocationPreferences(homeCountry = "BE", officeCountry = "NL")
+        advanceUntilIdle()
+
+        assertEquals("BE", repository.updatedHomeCountry)
+        assertEquals("NL", repository.updatedOfficeCountry)
+        assertEquals("Saved", viewModel.actionsState.value.message)
+    }
+
+    @Test
+    fun updateLabelSubmitsMutation() = runTest(dispatcher) {
+        val repository = FakeDashboardRepository(result = DashboardLoadResult.Success(sampleDashboard()))
+        val viewModel = DashboardViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.updateLabel("label-1", "Renamed", "#2196F3")
+        advanceUntilIdle()
+
+        assertEquals("label-1", repository.updatedLabelId)
+        assertEquals("Renamed", repository.updatedLabelName)
+        assertEquals("#2196F3", repository.updatedLabelColor)
+        assertEquals("Saved", viewModel.actionsState.value.message)
+    }
+
+    @Test
+    fun createTemplateSubmitsMutation() = runTest(dispatcher) {
+        val repository = FakeDashboardRepository(result = DashboardLoadResult.Success(sampleDashboard()))
+        val viewModel = DashboardViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.createTemplate(
+            text = "Standup",
+            labelId = "label-1",
+            startTime = LocalTime.parse("09:00"),
+            stopTime = LocalTime.parse("09:15")
+        )
+        advanceUntilIdle()
+
+        assertEquals("Standup", repository.createdTemplateText)
+        assertEquals("label-1", repository.createdTemplateLabelId)
+        assertEquals(LocalTime.parse("09:00"), repository.createdTemplateStartTime)
+        assertEquals(LocalTime.parse("09:15"), repository.createdTemplateStopTime)
+        assertEquals("Saved", viewModel.actionsState.value.message)
+    }
+
+    @Test
+    fun deleteTemplateSubmitsMutation() = runTest(dispatcher) {
+        val repository = FakeDashboardRepository(result = DashboardLoadResult.Success(sampleDashboard()))
+        val viewModel = DashboardViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.deleteTemplate("template-1")
+        advanceUntilIdle()
+
+        assertEquals("template-1", repository.deletedTemplateId)
+        assertEquals("Saved", viewModel.actionsState.value.message)
+    }
+
     private class FakeDashboardRepository(
         private val result: DashboardLoadResult,
         private val gate: CompletableDeferred<Unit>? = null,
         private val startTrackingResult: MutationResult<TaskRecord> = MutationResult.Success(sampleTask()),
         private val listLabelsResult: MutationResult<List<LabelRecord>> = MutationResult.Success(emptyList()),
         private val listTemplatesResult: MutationResult<List<TemplateRecord>> = MutationResult.Success(emptyList()),
+        private val workLocationPreferencesResult: MutationResult<WorkLocationPreferences> =
+            MutationResult.Success(WorkLocationPreferences()),
         private val createLabelResult: MutationResult<LabelRecord> = MutationResult.Success(sampleLabel()),
         private val deleteAccountResult: MutationResult<Unit> = MutationResult.Success(Unit)
     ) : DashboardRepository {
         override val sessionState = MutableStateFlow<SessionState>(SessionState.Authenticated(hasRefreshToken = true))
+        var updatedLabelId: String? = null
+            private set
+        var updatedLabelName: String? = null
+            private set
+        var updatedLabelColor: String? = null
+            private set
+        var createdTemplateText: String? = null
+            private set
+        var createdTemplateLabelId: String? = null
+            private set
+        var createdTemplateStartTime: LocalTime? = null
+            private set
+        var createdTemplateStopTime: LocalTime? = null
+            private set
+        var deletedWorkLocationDate: LocalDate? = null
+            private set
+        var updatedHomeCountry: String? = null
+            private set
+        var updatedOfficeCountry: String? = null
+            private set
+        var deletedTemplateId: String? = null
+            private set
 
         override suspend fun loadDashboard(): DashboardLoadResult {
             gate?.await()
@@ -245,7 +352,22 @@ class DashboardViewModelTest {
         override suspend fun getWorkLocation(date: LocalDate): MutationResult<WorkLocationRecord?> =
             MutationResult.Success(null)
 
-        override suspend fun deleteWorkLocation(date: LocalDate): MutationResult<Unit> = MutationResult.Success(Unit)
+        override suspend fun deleteWorkLocation(date: LocalDate): MutationResult<Unit> {
+            deletedWorkLocationDate = date
+            return MutationResult.Success(Unit)
+        }
+
+        override suspend fun loadWorkLocationPreferences(): MutationResult<WorkLocationPreferences> =
+            workLocationPreferencesResult
+
+        override suspend fun updateWorkLocationPreferences(
+            homeCountry: String?,
+            officeCountry: String?
+        ): MutationResult<WorkLocationPreferences> {
+            updatedHomeCountry = homeCountry
+            updatedOfficeCountry = officeCountry
+            return MutationResult.Success(WorkLocationPreferences(homeCountry, officeCountry))
+        }
 
         override suspend fun listTasks(startDate: LocalDate?, endDate: LocalDate?): MutationResult<List<TaskRecord>> =
             MutationResult.Success(emptyList())
@@ -256,8 +378,12 @@ class DashboardViewModelTest {
 
         override suspend fun listLabels(): MutationResult<List<LabelRecord>> = listLabelsResult
 
-        override suspend fun updateLabel(labelId: String, name: String?, color: String?): MutationResult<LabelRecord> =
-            throw UnsupportedOperationException()
+        override suspend fun updateLabel(labelId: String, name: String?, color: String?): MutationResult<LabelRecord> {
+            updatedLabelId = labelId
+            updatedLabelName = name
+            updatedLabelColor = color
+            return MutationResult.Success(sampleLabel())
+        }
 
         override suspend fun deleteLabel(labelId: String): MutationResult<Unit> = MutationResult.Success(Unit)
 
@@ -266,7 +392,13 @@ class DashboardViewModelTest {
             labelId: String?,
             startTime: LocalTime,
             stopTime: LocalTime
-        ): MutationResult<TemplateRecord> = throw UnsupportedOperationException()
+        ): MutationResult<TemplateRecord> {
+            createdTemplateText = text
+            createdTemplateLabelId = labelId
+            createdTemplateStartTime = startTime
+            createdTemplateStopTime = stopTime
+            return MutationResult.Success(sampleTemplate())
+        }
 
         override suspend fun listTemplates(): MutationResult<List<TemplateRecord>> = listTemplatesResult
 
@@ -276,9 +408,12 @@ class DashboardViewModelTest {
             labelId: String?,
             startTime: LocalTime?,
             stopTime: LocalTime?
-        ): MutationResult<TemplateRecord> = throw UnsupportedOperationException()
+        ): MutationResult<TemplateRecord> = MutationResult.Success(sampleTemplate())
 
-        override suspend fun deleteTemplate(templateId: String): MutationResult<Unit> = MutationResult.Success(Unit)
+        override suspend fun deleteTemplate(templateId: String): MutationResult<Unit> {
+            deletedTemplateId = templateId
+            return MutationResult.Success(Unit)
+        }
 
         override suspend fun createTimeOffEntry(draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
             throw UnsupportedOperationException()

--- a/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
@@ -6,17 +6,22 @@ import com.worktime.android.data.model.CurrentStatus
 import com.worktime.android.data.model.DashboardResponse
 import com.worktime.android.data.model.FeatureFlags
 import com.worktime.android.data.model.Identity
+import com.worktime.android.data.model.LabelRecord
 import com.worktime.android.data.model.NextShifts
 import com.worktime.android.data.model.SyncStatusResponse
 import com.worktime.android.data.model.TaskRecord
 import com.worktime.android.data.model.TeamStatus
+import com.worktime.android.data.model.TemplateRecord
+import com.worktime.android.data.model.TimeOffEntryRecord
 import com.worktime.android.data.model.TimeOffSummary
 import com.worktime.android.data.model.WorkContext
 import com.worktime.android.data.model.WorkLocationRecord
 import com.worktime.android.data.repository.DashboardLoadResult
 import com.worktime.android.data.repository.DashboardRepository
 import com.worktime.android.data.repository.MutationResult
+import com.worktime.android.data.repository.TimeOffDraft
 import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -157,10 +162,44 @@ class DashboardViewModelTest {
         assertEquals("Request failed (500)", viewModel.actionsState.value.deleteAccountError)
     }
 
+    @Test
+    fun refreshActionsPopulatesLabelsAndTemplates() = runTest(dispatcher) {
+        val repository =
+            FakeDashboardRepository(
+                result = DashboardLoadResult.Success(sampleDashboard()),
+                listLabelsResult = MutationResult.Success(listOf(sampleLabel())),
+                listTemplatesResult = MutationResult.Success(listOf(sampleTemplate()))
+            )
+        val viewModel = DashboardViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals(listOf(sampleLabel()), viewModel.actionsState.value.labels)
+        assertEquals(listOf(sampleTemplate()), viewModel.actionsState.value.templates)
+    }
+
+    @Test
+    fun createLabelSurfacesConflictMessage() = runTest(dispatcher) {
+        val repository =
+            FakeDashboardRepository(
+                result = DashboardLoadResult.Success(sampleDashboard()),
+                createLabelResult = MutationResult.ValidationError("Label name must be unique")
+            )
+        val viewModel = DashboardViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.createLabel("Focus", "#FF0000")
+        advanceUntilIdle()
+
+        assertEquals("Label name must be unique", viewModel.actionsState.value.message)
+    }
+
     private class FakeDashboardRepository(
         private val result: DashboardLoadResult,
         private val gate: CompletableDeferred<Unit>? = null,
         private val startTrackingResult: MutationResult<TaskRecord> = MutationResult.Success(sampleTask()),
+        private val listLabelsResult: MutationResult<List<LabelRecord>> = MutationResult.Success(emptyList()),
+        private val listTemplatesResult: MutationResult<List<TemplateRecord>> = MutationResult.Success(emptyList()),
+        private val createLabelResult: MutationResult<LabelRecord> = MutationResult.Success(sampleLabel()),
         private val deleteAccountResult: MutationResult<Unit> = MutationResult.Success(Unit)
     ) : DashboardRepository {
         override val sessionState = MutableStateFlow<SessionState>(SessionState.Authenticated(hasRefreshToken = true))
@@ -203,7 +242,60 @@ class DashboardViewModelTest {
         override suspend fun loadWeeklyWorkLocations(until: LocalDate): MutationResult<List<WorkLocationRecord>> =
             MutationResult.Success(emptyList())
 
+        override suspend fun getWorkLocation(date: LocalDate): MutationResult<WorkLocationRecord?> =
+            MutationResult.Success(null)
+
+        override suspend fun deleteWorkLocation(date: LocalDate): MutationResult<Unit> = MutationResult.Success(Unit)
+
+        override suspend fun listTasks(startDate: LocalDate?, endDate: LocalDate?): MutationResult<List<TaskRecord>> =
+            MutationResult.Success(emptyList())
+
+        override suspend fun deleteTask(taskId: String): MutationResult<Unit> = MutationResult.Success(Unit)
+
+        override suspend fun createLabel(name: String, color: String): MutationResult<LabelRecord> = createLabelResult
+
+        override suspend fun listLabels(): MutationResult<List<LabelRecord>> = listLabelsResult
+
+        override suspend fun updateLabel(labelId: String, name: String?, color: String?): MutationResult<LabelRecord> =
+            throw UnsupportedOperationException()
+
         override suspend fun deleteLabel(labelId: String): MutationResult<Unit> = MutationResult.Success(Unit)
+
+        override suspend fun createTemplate(
+            text: String,
+            labelId: String?,
+            startTime: LocalTime,
+            stopTime: LocalTime
+        ): MutationResult<TemplateRecord> = throw UnsupportedOperationException()
+
+        override suspend fun listTemplates(): MutationResult<List<TemplateRecord>> = listTemplatesResult
+
+        override suspend fun updateTemplate(
+            templateId: String,
+            text: String?,
+            labelId: String?,
+            startTime: LocalTime?,
+            stopTime: LocalTime?
+        ): MutationResult<TemplateRecord> = throw UnsupportedOperationException()
+
+        override suspend fun deleteTemplate(templateId: String): MutationResult<Unit> = MutationResult.Success(Unit)
+
+        override suspend fun createTimeOffEntry(draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
+            throw UnsupportedOperationException()
+
+        override suspend fun listTimeOffEntries(
+            startDate: LocalDate?,
+            endDate: LocalDate?
+        ): MutationResult<List<TimeOffEntryRecord>> = MutationResult.Success(emptyList())
+
+        override suspend fun getTimeOffEntry(entryId: String): MutationResult<TimeOffEntryRecord> =
+            throw UnsupportedOperationException()
+
+        override suspend fun updateTimeOffEntry(entryId: String, draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
+            throw UnsupportedOperationException()
+
+        override suspend fun deleteTimeOffEntry(entryId: String): MutationResult<Unit> =
+            throw UnsupportedOperationException()
 
         override suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse> =
             MutationResult.Success(SyncStatusResponse(serverTimestamp = "2026-05-26T12:00:00Z"))
@@ -249,5 +341,23 @@ private fun sampleTask(): TaskRecord = TaskRecord(
     startTime = "2026-05-26T12:00:00Z",
     stopTime = null,
     includesBreak = false,
+    createdAt = "2026-05-26T12:00:00Z"
+)
+
+private fun sampleLabel(): LabelRecord = LabelRecord(
+    id = "label-1",
+    userId = 1,
+    name = "Focus",
+    color = "#FF0000",
+    createdAt = "2026-05-26T12:00:00Z"
+)
+
+private fun sampleTemplate(): TemplateRecord = TemplateRecord(
+    id = "template-1",
+    userId = 1,
+    labelId = null,
+    text = "Deep work",
+    startTime = "09:00:00",
+    stopTime = "11:00:00",
     createdAt = "2026-05-26T12:00:00Z"
 )

--- a/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
@@ -291,8 +291,10 @@ class DashboardViewModelTest {
         override suspend fun getTimeOffEntry(entryId: String): MutationResult<TimeOffEntryRecord> =
             throw UnsupportedOperationException()
 
-        override suspend fun updateTimeOffEntry(entryId: String, draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
-            throw UnsupportedOperationException()
+        override suspend fun updateTimeOffEntry(
+            entryId: String,
+            draft: TimeOffDraft
+        ): MutationResult<TimeOffEntryRecord> = throw UnsupportedOperationException()
 
         override suspend fun deleteTimeOffEntry(entryId: String): MutationResult<Unit> =
             throw UnsupportedOperationException()

--- a/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
@@ -87,7 +87,11 @@ class TimeOffViewModelTest {
 
         viewModel.openCreateForm()
         viewModel.submit(
-            TimeOffDraft.SingleDate(date = LocalDate.parse("2026-06-01"), entryType = "vacation", entryFlag = "full_day")
+            TimeOffDraft.SingleDate(
+                date = LocalDate.parse("2026-06-01"),
+                entryType = "vacation",
+                entryFlag = "full_day"
+            )
         )
         advanceUntilIdle()
 
@@ -107,7 +111,11 @@ class TimeOffViewModelTest {
 
         viewModel.openCreateForm()
         viewModel.submit(
-            TimeOffDraft.SingleDate(date = LocalDate.parse("2026-06-01"), entryType = "vacation", entryFlag = "full_day")
+            TimeOffDraft.SingleDate(
+                date = LocalDate.parse("2026-06-01"),
+                entryType = "vacation",
+                entryFlag = "full_day"
+            )
         )
         advanceUntilIdle()
 
@@ -195,8 +203,7 @@ class TimeOffViewModelTest {
 
         override suspend fun deleteTemplate(templateId: String) = throw UnsupportedOperationException()
 
-        override suspend fun createTimeOffEntry(draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
-            createResult
+        override suspend fun createTimeOffEntry(draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> = createResult
 
         override suspend fun listTimeOffEntries(
             startDate: LocalDate?,
@@ -206,12 +213,15 @@ class TimeOffViewModelTest {
         override suspend fun getTimeOffEntry(entryId: String): MutationResult<TimeOffEntryRecord> =
             throw UnsupportedOperationException()
 
-        override suspend fun updateTimeOffEntry(entryId: String, draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
-            updateResult
+        override suspend fun updateTimeOffEntry(
+            entryId: String,
+            draft: TimeOffDraft
+        ): MutationResult<TimeOffEntryRecord> = updateResult
 
         override suspend fun deleteTimeOffEntry(entryId: String): MutationResult<Unit> = deleteResult
 
-        override suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse> = throw UnsupportedOperationException()
+        override suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse> =
+            throw UnsupportedOperationException()
 
         override suspend fun deleteAccount(): MutationResult<Unit> = throw UnsupportedOperationException()
 

--- a/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
@@ -12,6 +12,7 @@ import com.worktime.android.data.repository.DashboardLoadResult
 import com.worktime.android.data.repository.DashboardRepository
 import com.worktime.android.data.repository.MutationResult
 import com.worktime.android.data.repository.TimeOffDraft
+import com.worktime.android.data.repository.WorkLocationPreferences
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -173,6 +174,14 @@ class TimeOffViewModelTest {
             throw UnsupportedOperationException()
 
         override suspend fun deleteWorkLocation(date: LocalDate) = throw UnsupportedOperationException()
+
+        override suspend fun loadWorkLocationPreferences(): MutationResult<WorkLocationPreferences> =
+            throw UnsupportedOperationException()
+
+        override suspend fun updateWorkLocationPreferences(
+            homeCountry: String?,
+            officeCountry: String?
+        ): MutationResult<WorkLocationPreferences> = throw UnsupportedOperationException()
 
         override suspend fun createLabel(name: String, color: String): MutationResult<LabelRecord> =
             throw UnsupportedOperationException()

--- a/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
@@ -1,0 +1,238 @@
+package com.worktime.android.feature.timeoff
+
+import app.cash.turbine.test
+import com.worktime.android.core.auth.SessionState
+import com.worktime.android.data.model.LabelRecord
+import com.worktime.android.data.model.SyncStatusResponse
+import com.worktime.android.data.model.TaskRecord
+import com.worktime.android.data.model.TemplateRecord
+import com.worktime.android.data.model.TimeOffEntryRecord
+import com.worktime.android.data.model.WorkLocationRecord
+import com.worktime.android.data.repository.DashboardLoadResult
+import com.worktime.android.data.repository.DashboardRepository
+import com.worktime.android.data.repository.MutationResult
+import com.worktime.android.data.repository.TimeOffDraft
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimeOffViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        kotlinx.coroutines.Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        kotlinx.coroutines.Dispatchers.resetMain()
+    }
+
+    @Test
+    fun startsInLoadingAndThenPublishesSuccess() = runTest(dispatcher) {
+        val repository = FakeRepository(listResult = MutationResult.Success(listOf(sampleEntry())))
+
+        val viewModel = TimeOffViewModel(repository)
+        viewModel.uiState.test {
+            assertEquals(TimeOffUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertTrue(awaitItem() is TimeOffUiState.Success)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun publishesLoggedOutStateFromRepository() = runTest(dispatcher) {
+        val repository = FakeRepository(listResult = MutationResult.LoggedOut)
+
+        val viewModel = TimeOffViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals(TimeOffUiState.LoggedOut, viewModel.uiState.value)
+    }
+
+    @Test
+    fun publishesErrorState() = runTest(dispatcher) {
+        val repository = FakeRepository(listResult = MutationResult.Error("Request failed (500)"))
+
+        val viewModel = TimeOffViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals(TimeOffUiState.Error("Request failed (500)"), viewModel.uiState.value)
+    }
+
+    @Test
+    fun submitSuccessTriggersRefreshAndClosesForm() = runTest(dispatcher) {
+        val repository =
+            FakeRepository(
+                listResult = MutationResult.Success(listOf(sampleEntry())),
+                createResult = MutationResult.Success(sampleEntry())
+            )
+        val viewModel = TimeOffViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.openCreateForm()
+        viewModel.submit(
+            TimeOffDraft.SingleDate(date = LocalDate.parse("2026-06-01"), entryType = "vacation", entryFlag = "full_day")
+        )
+        advanceUntilIdle()
+
+        assertNull(viewModel.formState.value.target)
+        assertTrue(viewModel.uiState.value is TimeOffUiState.Success)
+    }
+
+    @Test
+    fun submitValidationErrorKeepsFormOpenAndSurfacesMessage() = runTest(dispatcher) {
+        val repository =
+            FakeRepository(
+                listResult = MutationResult.Success(emptyList()),
+                createResult = MutationResult.ValidationError("end_date must be after start_date")
+            )
+        val viewModel = TimeOffViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.openCreateForm()
+        viewModel.submit(
+            TimeOffDraft.SingleDate(date = LocalDate.parse("2026-06-01"), entryType = "vacation", entryFlag = "full_day")
+        )
+        advanceUntilIdle()
+
+        assertEquals(TimeOffFormTarget.Create, viewModel.formState.value.target)
+        assertEquals("end_date must be after start_date", viewModel.formState.value.message)
+    }
+
+    @Test
+    fun deleteSuccessRefreshesList() = runTest(dispatcher) {
+        val repository =
+            FakeRepository(
+                listResult = MutationResult.Success(listOf(sampleEntry())),
+                deleteResult = MutationResult.Success(Unit)
+            )
+        val viewModel = TimeOffViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.delete("entry-1")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value is TimeOffUiState.Success)
+        assertNull(viewModel.formState.value.target)
+    }
+
+    private class FakeRepository(
+        private val listResult: MutationResult<List<TimeOffEntryRecord>> = MutationResult.Success(emptyList()),
+        private val createResult: MutationResult<TimeOffEntryRecord> = MutationResult.Success(sampleEntry()),
+        private val updateResult: MutationResult<TimeOffEntryRecord> = MutationResult.Success(sampleEntry()),
+        private val deleteResult: MutationResult<Unit> = MutationResult.Success(Unit)
+    ) : DashboardRepository {
+        override val sessionState = MutableStateFlow<SessionState>(SessionState.Authenticated(hasRefreshToken = true))
+
+        override suspend fun loadDashboard(): DashboardLoadResult = throw UnsupportedOperationException()
+
+        override suspend fun startTimeTracking(text: String, labelId: String?) = throw UnsupportedOperationException()
+
+        override suspend fun stopTimeTracking(taskId: String) = throw UnsupportedOperationException()
+
+        override suspend fun updateTask(taskId: String, text: String?, labelId: String?) =
+            throw UnsupportedOperationException()
+
+        override suspend fun getRunningTask(): MutationResult<TaskRecord?> = throw UnsupportedOperationException()
+
+        override suspend fun listTasks(startDate: LocalDate?, endDate: LocalDate?) =
+            throw UnsupportedOperationException()
+
+        override suspend fun deleteTask(taskId: String) = throw UnsupportedOperationException()
+
+        override suspend fun setWorkLocation(date: LocalDate, countryCode: String, label: String?) =
+            throw UnsupportedOperationException()
+
+        override suspend fun loadWeeklyWorkLocations(until: LocalDate) = throw UnsupportedOperationException()
+
+        override suspend fun getWorkLocation(date: LocalDate): MutationResult<WorkLocationRecord?> =
+            throw UnsupportedOperationException()
+
+        override suspend fun deleteWorkLocation(date: LocalDate) = throw UnsupportedOperationException()
+
+        override suspend fun createLabel(name: String, color: String): MutationResult<LabelRecord> =
+            throw UnsupportedOperationException()
+
+        override suspend fun listLabels() = throw UnsupportedOperationException()
+
+        override suspend fun updateLabel(labelId: String, name: String?, color: String?) =
+            throw UnsupportedOperationException()
+
+        override suspend fun deleteLabel(labelId: String) = throw UnsupportedOperationException()
+
+        override suspend fun createTemplate(
+            text: String,
+            labelId: String?,
+            startTime: LocalTime,
+            stopTime: LocalTime
+        ): MutationResult<TemplateRecord> = throw UnsupportedOperationException()
+
+        override suspend fun listTemplates() = throw UnsupportedOperationException()
+
+        override suspend fun updateTemplate(
+            templateId: String,
+            text: String?,
+            labelId: String?,
+            startTime: LocalTime?,
+            stopTime: LocalTime?
+        ) = throw UnsupportedOperationException()
+
+        override suspend fun deleteTemplate(templateId: String) = throw UnsupportedOperationException()
+
+        override suspend fun createTimeOffEntry(draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
+            createResult
+
+        override suspend fun listTimeOffEntries(
+            startDate: LocalDate?,
+            endDate: LocalDate?
+        ): MutationResult<List<TimeOffEntryRecord>> = listResult
+
+        override suspend fun getTimeOffEntry(entryId: String): MutationResult<TimeOffEntryRecord> =
+            throw UnsupportedOperationException()
+
+        override suspend fun updateTimeOffEntry(entryId: String, draft: TimeOffDraft): MutationResult<TimeOffEntryRecord> =
+            updateResult
+
+        override suspend fun deleteTimeOffEntry(entryId: String): MutationResult<Unit> = deleteResult
+
+        override suspend fun loadSyncStatus(): MutationResult<SyncStatusResponse> = throw UnsupportedOperationException()
+
+        override suspend fun deleteAccount(): MutationResult<Unit> = throw UnsupportedOperationException()
+
+        override fun logout() {
+            sessionState.value = SessionState.LoggedOut
+        }
+    }
+}
+
+private fun sampleEntry(): TimeOffEntryRecord = TimeOffEntryRecord(
+    id = 1,
+    entryId = "entry-1",
+    userId = 1,
+    entryKind = "date",
+    date = "2026-06-01",
+    startDate = null,
+    endDate = null,
+    weekday = null,
+    entryType = "vacation",
+    entryFlag = "full_day",
+    note = null,
+    createdAt = "2026-05-26T12:00:00Z",
+    updatedAt = "2026-05-26T12:00:00Z"
+)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "androidx-biometric" }


### PR DESCRIPTION
## Summary

The Android app was read-only for time off and used raw, error-prone text fields for time tracking (typed label IDs, hand-typed work-location dates), even though the backend already fully supports CRUD for time-off entries, labels, and templates. This closes both gaps:

- **Time-off self-service**: new `TimeOffViewModel` + rebuilt Time Off tab as a list with add/edit/delete, backed by a form dialog supporting single-date, date-range, and weekly entries (proper date pickers, type/flag dropdowns, client-side shape validation mirroring the backend's `entry_kind` rules).
- **Time-tracking UX**: `TodayScreen`'s typed label-ID field is now a label picker (fed by `GET /api/time-tracking/labels`, with inline "+ New label" creation), the work-location date field is now a real Material3 date picker, and a quick-apply template chip row lets you prefill task text/label from a saved template.
- **API/repository layer**: added Retrofit endpoints, DTOs, and `DashboardRepository` methods for time-off CRUD, label CRUD, template CRUD, task list/delete, and work-location get/delete — correctly reflecting that time-off endpoints resolve the user from the bearer token only (no `user_id` param), unlike time-tracking/work-location endpoints.

## Test plan

- [x] Added/extended unit tests: `WorktimeApiTest`, `WorktimeRepositoryTest`, `DashboardViewModelTest`, new `TimeOffViewModelTest` (success/401/400/404/409 mappings, auth-shape assertions for token-only vs `user_id`-scoped endpoints).
- [ ] `./gradlew ktlintCheck detekt testDebugUnitTest` — **could not be run in this sandbox**: the project requires Gradle 9.4.1+ (AGP 9.2.1), but `services.gradle.org` and `github.com` are blocked by this environment's egress policy (403), and the only available system Gradle is 8.14.3. The repo's `Android CI` GitHub Actions workflow should validate this on push.
- [ ] Manual verification in the app (create/edit/delete each time-off entry kind, create a label from the picker, apply a template, set a work location via the date picker) — not done here for the same reason; recommend running through this checklist locally or via CI before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UTQ7mhHrhi8dWR3GVHDwB

---
_Generated by [Claude Code](https://claude.ai/code/session_014UTQ7mhHrhi8dWR3GVHDwB)_