### PR TITLE
Fix session expiry redirect race

### DIFF
--- a/frontend/src/hooks/useApiClient.ts
+++ b/frontend/src/hooks/useApiClient.ts
@@ -10,6 +10,7 @@ import * as m from "@/paraglide/messages.js";
  * The returned function automatically:
  * - Injects the OIDC Bearer token into the `Authorization` header.
  * - Redirects to the login page on 401 Unauthorized and shows a session-expired toast.
+ *   This avoids also starting logout, so only one OIDC navigation is triggered.
  * - Shows an error toast and clears auth on 403 Forbidden.
  *
  * Must be used inside AuthProvider and ToastProvider.
@@ -29,7 +30,6 @@ export function useApiClient() {
       }
       return apiFetch(url, { ...init, headers }, {
         onUnauthorized: () => {
-          logout();
           showWarning(m.auth_session_expired());
           triggerLogin();
         },

--- a/frontend/tests/hooks/useApiClient.test.ts
+++ b/frontend/tests/hooks/useApiClient.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useApiClient } from "@/hooks/useApiClient";
+import { apiFetch } from "@/utils/apiClient";
+
+const auth = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+  logout: vi.fn(),
+  triggerLogin: vi.fn(),
+}));
+
+const toast = vi.hoisted(() => ({
+  showError: vi.fn(),
+  showWarning: vi.fn(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => auth,
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => toast,
+}));
+
+vi.mock("@/utils/apiClient", () => ({
+  apiFetch: vi.fn(),
+}));
+
+describe("useApiClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.getAccessToken.mockReturnValue("token-123");
+    vi.mocked(apiFetch).mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  it("adds the current access token to requests", async () => {
+    const { result } = renderHook(() => useApiClient());
+
+    await result.current("/api/data", { headers: { "X-Test": "yes" } });
+
+    const [, init] = vi.mocked(apiFetch).mock.calls[0];
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer token-123");
+    expect(headers.get("X-Test")).toBe("yes");
+  });
+
+  it("starts only the login redirect when a request is unauthorized", async () => {
+    vi.mocked(apiFetch).mockImplementation(async (_url, _init, options) => {
+      options.onUnauthorized();
+      throw new Error("Unauthorized");
+    });
+    const { result } = renderHook(() => useApiClient());
+
+    await expect(result.current("/api/data")).rejects.toThrow("Unauthorized");
+
+    expect(toast.showWarning).toHaveBeenCalledOnce();
+    expect(auth.triggerLogin).toHaveBeenCalledOnce();
+    expect(auth.logout).not.toHaveBeenCalled();
+  });
+
+  it("logs out and shows an error when a request is forbidden", async () => {
+    vi.mocked(apiFetch).mockImplementation(async (_url, _init, options) => {
+      options.onForbidden();
+      throw new Error("Forbidden");
+    });
+    const { result } = renderHook(() => useApiClient());
+
+    await expect(result.current("/api/data")).rejects.toThrow("Forbidden");
+
+    expect(auth.logout).toHaveBeenCalledOnce();
+    expect(toast.showError).toHaveBeenCalledOnce();
+    expect(auth.triggerLogin).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/hooks/useApiClient.test.ts
+++ b/frontend/tests/hooks/useApiClient.test.ts
@@ -39,7 +39,7 @@ describe("useApiClient", () => {
     await result.current("/api/data", { headers: { "X-Test": "yes" } });
 
     const [, init] = vi.mocked(apiFetch).mock.calls[0];
-    const headers = new Headers(init.headers);
+    const headers = new Headers(init?.headers);
     expect(headers.get("Authorization")).toBe("Bearer token-123");
     expect(headers.get("X-Test")).toBe("yes");
   });


### PR DESCRIPTION
### Motivation
- Prevent a race where a 401 (session-expired) response could trigger both a logout and an immediate login redirect, causing competing OIDC navigations and broken UX. 
- Add targeted tests to assert the intended 401/403 behaviour and auth header injection.

### Description
- Remove the `logout()` call from the `onUnauthorized` callback in `useApiClient` so a 401 now only shows the session-expired warning and calls `triggerLogin()`.
- Clarify the 401 behaviour in the `useApiClient` doc comment to explain why only one OIDC navigation is started.
- Add `frontend/tests/hooks/useApiClient.test.ts` with tests that verify the access token is injected, the 401 path triggers only the login redirect (no logout), and the 403 path triggers logout and an error toast.

### Testing
- Ran `pnpm --dir frontend test tests/hooks/useApiClient.test.ts` and the new test file passed (3 tests passed).
- Ran `pnpm --dir frontend exec oxlint src/hooks/useApiClient.ts tests/hooks/useApiClient.test.ts` which completed successfully for the changed files.
- Ran `pnpm --dir frontend lint` which completed but reported unrelated pre-existing React hook dependency warnings, and ran `pnpm --dir frontend typecheck` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5222c9e100832e91e04461d2339017)