### PR TITLE
Sanitize team schedule fetch errors

### DIFF
--- a/frontend/src/components/TeamScheduleView.tsx
+++ b/frontend/src/components/TeamScheduleView.tsx
@@ -40,6 +40,24 @@ interface TeamHdayResponse {
   members: TeamMemberHdayData[]; // Flat list for backward compatibility
 }
 
+async function getTeamFetchErrorMessage(response: Response): Promise<string> {
+  try {
+    const body: unknown = await response.json();
+
+    if (body && typeof body === "object" && "detail" in body) {
+      const { detail } = body as { detail: unknown };
+
+      if (typeof detail === "string" && detail.trim()) {
+        return detail;
+      }
+    }
+  } catch {
+    // Fall back to a generic user-facing message when the error body is not JSON.
+  }
+
+  return m.team_unknown_error();
+}
+
 /**
  * Check if a date has an event for a member
  */
@@ -147,8 +165,8 @@ export function TeamScheduleView() {
       });
 
       if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(m.team_fetch_failed({ error: errorText }));
+        const errorMessage = await getTeamFetchErrorMessage(response);
+        throw new Error(m.team_fetch_failed({ error: errorMessage }));
       }
 
       const data: TeamHdayResponse = await response.json();

--- a/frontend/src/components/TeamScheduleView.tsx
+++ b/frontend/src/components/TeamScheduleView.tsx
@@ -41,18 +41,22 @@ interface TeamHdayResponse {
 }
 
 async function getTeamFetchErrorMessage(response: Response): Promise<string> {
-  try {
-    const body: unknown = await response.json();
+  const contentType = response.headers.get("content-type");
 
-    if (body && typeof body === "object" && "detail" in body) {
-      const { detail } = body as { detail: unknown };
+  if (contentType?.includes("application/json")) {
+    try {
+      const body: unknown = await response.json();
 
-      if (typeof detail === "string" && detail.trim()) {
-        return detail;
+      if (body && typeof body === "object" && "detail" in body) {
+        const { detail } = body as { detail: unknown };
+
+        if (typeof detail === "string" && detail.trim()) {
+          return detail;
+        }
       }
+    } catch {
+      // Fall back to a generic user-facing message when parsing fails.
     }
-  } catch {
-    // Fall back to a generic user-facing message when the error body is not JSON.
   }
 
   return m.team_unknown_error();


### PR DESCRIPTION
### Motivation
- Prevent raw JSON error bodies from leaking into the UI by extracting a user-facing message from backend error responses for the team schedule view.
- Make the localized `team_fetch_failed` message show a concise FastAPI `detail` string when available and otherwise fall back to a generic message.

### Description
- Added `getTeamFetchErrorMessage(response: Response)` to `frontend/src/components/TeamScheduleView.tsx` which attempts to parse a JSON error body and return the `detail` string when present.
- Replaced the previous use of `response.text()` with `getTeamFetchErrorMessage` before constructing the localized `m.team_fetch_failed` error.
- Kept behavior that falls back to the generic `m.team_unknown_error()` when the body is not JSON or does not contain a usable `detail`.

### Testing
- Ran `pnpm lint` which completed with warnings but no failures.
- Ran `pnpm typecheck` which completed successfully.
- Ran `pnpm test` (Vitest) and observed all tests pass: `Test Files 90 passed` and `Tests 1468 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a522e308c04832e8889dd5064dcfe1c)