### PR TITLE
Show calendar add button on touch devices

### DIFF
--- a/frontend/src/styles/_calendar.scss
+++ b/frontend/src/styles/_calendar.scss
@@ -153,9 +153,20 @@
 
 @media (hover: none), (pointer: coarse) {
   .month-calendar-add-btn {
+    position: relative;
     opacity: 0.7;
     visibility: visible;
     pointer-events: auto;
+  }
+
+  .month-calendar-add-btn::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
   }
 
   .month-calendar-add-btn:active,

--- a/frontend/src/styles/_calendar.scss
+++ b/frontend/src/styles/_calendar.scss
@@ -151,6 +151,19 @@
   pointer-events: auto;
 }
 
+@media (hover: none), (pointer: coarse) {
+  .month-calendar-add-btn {
+    opacity: 0.7;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .month-calendar-add-btn:active,
+  .month-calendar-add-btn:focus-visible {
+    opacity: 1;
+  }
+}
+
 .month-calendar-day-header {
   border: none;
   background: transparent;


### PR DESCRIPTION
### Motivation
- Make the month-calendar “+” add-event affordance accessible and tappable on touch / coarse-pointer devices while keeping the existing hover/focus reveal for pointer devices; screenshots could not be attached from this environment.

### Description
- Add a `@media (hover: none), (pointer: coarse)` block in `frontend/src/styles/_calendar.scss` to set `.month-calendar-add-btn` to visible and tappable on touch devices and add `:active`/`:focus-visible` rules to raise opacity during press or keyboard focus.

### Testing
- Ran `pnpm lint`, `pnpm typecheck`, and `pnpm build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5233e85d20832ea051cc33370c836d)