### PR TITLE
Improve calendar add affordance on touch devices

### DIFF
--- a/frontend/src/components/calendar/DayCell.tsx
+++ b/frontend/src/components/calendar/DayCell.tsx
@@ -160,7 +160,7 @@ function openMenuFromElement(el: HTMLElement, handler: (x: number, y: number) =>
  * - Click-to-view existing events, right-click context menu for actions
  * - Keyboard accessible: Enter/Shift+F10 opens context menu
  * - Touch accessible: long-press opens context menu
- * - "+" add button visible on hover/focus-within
+ * - "+" add button visible on hover/focus-within and persistently discoverable on touch devices
  *
  * Accessibility:
  * - role="gridcell" for ARIA grid semantics

--- a/frontend/src/styles/_calendar.scss
+++ b/frontend/src/styles/_calendar.scss
@@ -156,6 +156,7 @@
     position: relative;
     opacity: 0.8;
     visibility: visible;
+    box-shadow: 0 0 0 1px var(--wt-month-calendar-focus-outline);
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--wt-month-calendar-focus-outline) 35%, transparent);
     pointer-events: auto;
   }

--- a/frontend/src/styles/_calendar.scss
+++ b/frontend/src/styles/_calendar.scss
@@ -116,7 +116,7 @@
   outline-offset: -1px;
 }
 
-/* "+" add button — visible on hover or when cell/children have focus */
+/* "+" add button — visible on hover/focus, with a persistent touch affordance below */
 
 .month-calendar-add-btn {
   display: inline-flex;
@@ -154,8 +154,9 @@
 @media (hover: none), (pointer: coarse) {
   .month-calendar-add-btn {
     position: relative;
-    opacity: 0.7;
+    opacity: 0.8;
     visibility: visible;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--wt-month-calendar-focus-outline) 35%, transparent);
     pointer-events: auto;
   }
 


### PR DESCRIPTION
### Motivation
- Make the calendar day “+” add-event affordance easier to discover on coarse-pointer/touch devices by increasing its default visibility and adding a subtle focus-colored ring.
- Reflect the UX change in the `DayCell` documentation so the behaviour is clear to future maintainers.

### Description
- Update `frontend/src/styles/_calendar.scss` to keep `.month-calendar-add-btn` visible on touch devices by setting `opacity: 0.8`, `visibility: visible`, and adding a subtle `box-shadow` ring in the `@media (hover: none), (pointer: coarse)` block.
- Update `frontend/src/components/calendar/DayCell.tsx` docs to note that the add button is persistently discoverable on touch devices.

### Testing
- Ran `pnpm lint` in `frontend` which completed successfully but reported existing React hook warnings and a Node engine warning about the local Node version.
- Ran `pnpm typecheck` in `frontend` which completed successfully (including `paraglide-js` compilation) with the same Node engine warning.
- Note: per repository guidelines in `AGENTS.md`, screenshots should be attached to the PR comment for the UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a529fbcf0dc832e9f42c09161490a69)