### PR TITLE
Allow one-tap quick timer start

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -168,6 +168,7 @@
   "tt_use_template": "Use Template",
   "tt_select_label": "Select a label",
   "tt_unknown_label": "Unknown label",
+  "tt_default_task_name": "Untitled task",
   "tt_enter_task_hint": "Enter task details below, then start live tracking or add a completed time range.",
   "tt_task_updated": "Task updated successfully.",
   "tt_task_discarded": "Task discarded.",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -161,6 +161,7 @@
   "tt_use_template": "Sjabloon gebruiken",
   "tt_select_label": "Selecteer een label",
   "tt_unknown_label": "Onbekend label",
+  "tt_default_task_name": "Naamloze taak",
   "tt_enter_task_hint": "Vul hieronder taakdetails in en start live bijhouden of voeg een voltooid tijdsbereik toe.",
   "tt_task_updated": "Taak succesvol bijgewerkt.",
   "tt_task_discarded": "Taak verwijderd.",

--- a/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
+++ b/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
@@ -105,7 +105,7 @@ export function TimeTrackingDailyView({
   const canStartNow = !runningTask && selectedLabel.trim().length > 0;
   const startDisabledReason = runningTask
     ? m.tt_reason_stopwatch_running()
-    : !selectedLabel
+    : !selectedLabel.trim()
       ? m.tt_reason_select_label()
       : undefined;
   const addDisabledReason = !text.trim()
@@ -122,7 +122,7 @@ export function TimeTrackingDailyView({
       setError(m.tt_error_fill_all_fields());
       return;
     }
-    if (!selectedLabel) {
+    if (!selectedLabel.trim()) {
       setError(m.tt_error_configure_label());
       return;
     }
@@ -164,7 +164,7 @@ export function TimeTrackingDailyView({
       setError(m.tt_error_task_already_running_start());
       return;
     }
-    if (!selectedLabel) {
+    if (!selectedLabel.trim()) {
       setError(m.tt_error_configure_label());
       return;
     }

--- a/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
+++ b/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
@@ -102,14 +102,12 @@ export function TimeTrackingDailyView({
   const hasTaskDetails = text.trim().length > 0 && selectedLabel.trim().length > 0;
   const hasCompletedRange = hasTaskDetails && start.trim().length > 0 && stop.trim().length > 0;
   const canAddCompletedTask = hasCompletedRange && isValidRange(start, stop);
-  const canStartNow = !runningTask && hasTaskDetails;
+  const canStartNow = !runningTask && selectedLabel.trim().length > 0;
   const startDisabledReason = runningTask
     ? m.tt_reason_stopwatch_running()
-    : !text.trim()
-      ? m.tt_reason_enter_task_name()
-      : !selectedLabel
-        ? m.tt_reason_select_label()
-        : undefined;
+    : !selectedLabel
+      ? m.tt_reason_select_label()
+      : undefined;
   const addDisabledReason = !text.trim()
     ? m.tt_reason_enter_task_name()
     : !start.trim() || !stop.trim()
@@ -166,10 +164,6 @@ export function TimeTrackingDailyView({
       setError(m.tt_error_task_already_running_start());
       return;
     }
-    if (!text.trim()) {
-      setError(m.tt_error_enter_task_name());
-      return;
-    }
     if (!selectedLabel) {
       setError(m.tt_error_configure_label());
       return;
@@ -179,7 +173,7 @@ export function TimeTrackingDailyView({
     const startDate = now.format("YYYY-MM-DD");
     const added = await onAddTask({
       id: crypto.randomUUID(),
-      text: text.trim(),
+      text: text.trim() || m.tt_default_task_name(),
       label: selectedLabel,
       ganttTaskId: selectedGanttTaskId || undefined,
       startTime,

--- a/frontend/tests/components/timeTracking/TimeTrackingDailyView.test.tsx
+++ b/frontend/tests/components/timeTracking/TimeTrackingDailyView.test.tsx
@@ -95,14 +95,26 @@ describe("TimeTrackingDailyView", () => {
       );
     });
 
-    it("disables start-now until task details are entered", async () => {
-      renderView();
+    it("starts a timer with a default task name when task is blank", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T10:15:30"));
+      vi.stubGlobal("crypto", { randomUUID: () => "task-123" } as unknown as Crypto);
+      const onAddTask = vi.fn().mockResolvedValue(true);
+
+      renderView({ onAddTask });
 
       const startNowButton = screen.getByRole("button", { name: /Start Now/i });
-      expect(startNowButton).toBeDisabled();
+      expect(startNowButton).toBeEnabled();
+      fireEvent.click(startNowButton);
 
-      fireEvent.change(screen.getByLabelText(/^Task$/i), { target: { value: "Focus work" } });
-      expect(screen.getByRole("button", { name: /Start Now/i })).toBeEnabled();
+      expect(onAddTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "task-123",
+          text: "Untitled task",
+          label: "Development",
+          startTime: "2025-01-01T10:15",
+        }),
+      );
     });
 
     it("renders the running task UI with elapsed time", () => {


### PR DESCRIPTION
### Motivation
- Enable the quick-start experience so a user can tap `Start Now` without typing a task name when a label is selected. 
- Provide a sensible, localizable fallback name for quick-started tasks so blank entries are still meaningful in the timeline. 
- Update tests to cover the new one-tap behavior and ensure no regressions in time-tracking flows.

### Description
- Relaxed the `Start Now` enablement logic in `TimeTrackingDailyView` so `canStartNow` is true when no other timer is running and a label is selected (`selectedLabel`), even if the task `text` is blank. 
- Removed the blocking validation that required a non-empty task name for the quick-start path and instead supply a fallback name using `m.tt_default_task_name()` when `text` is empty. 
- Added `tt_default_task_name` localization keys to `frontend/messages/en.json` and `frontend/messages/nl.json`. 
- Updated the Quick Timer unit test in `TimeTrackingDailyView.test.tsx` to assert that starting with an empty task produces a new task with the localized default name and selected label.

### Testing
- Ran the focused test file with Vitest: `pnpm vitest run tests/components/timeTracking/TimeTrackingDailyView.test.tsx`, and all tests in that file passed (22 passed). 
- Ran type checking with `pnpm typecheck`, which completed successfully. 
- Ran linter with `pnpm lint`, which completed successfully but reported pre-existing warnings unrelated to this change and an environment warning about Node version mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a869b2dc832e90268b3a6501b12e)