### PR TITLE
Add AuthCallbackPage and register /auth/callback route

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1125,5 +1125,8 @@
   "gantt_logged_empty": "No time has been logged for this task yet.",
   "gantt_logged_minutes": "{minutes} min",
   "gantt_logged_hours": "{hours} h",
-  "gantt_logged_hours_minutes": "{hours} h {minutes} min"
+  "gantt_logged_hours_minutes": "{hours} h {minutes} min",
+  "auth_callback_spinner": "Completing sign-in...",
+  "auth_callback_title": "Completing sign-in",
+  "auth_callback_description": "Please wait while Worktime finishes connecting your account."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -1105,5 +1105,8 @@
   "gantt_logged_empty": "Er is nog geen tijd gelogd voor deze taak.",
   "gantt_logged_minutes": "{minutes} min",
   "gantt_logged_hours": "{hours} u",
-  "gantt_logged_hours_minutes": "{hours} u {minutes} min"
+  "gantt_logged_hours_minutes": "{hours} u {minutes} min",
+  "auth_callback_spinner": "Aanmelden afronden...",
+  "auth_callback_title": "Aanmelden afronden",
+  "auth_callback_description": "Even geduld terwijl Worktime klaar is met het verbinden van uw account."
 }

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,15 +1,28 @@
+import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import Spinner from "react-bootstrap/Spinner";
+import { useAuth } from "@/contexts/AuthContext";
+import * as m from "@/paraglide/messages.js";
 
 export function AuthCallbackPage() {
+  const { isValidating } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isValidating) {
+      navigate({ to: "/", replace: true });
+    }
+  }, [isValidating, navigate]);
+
   return (
     <main className="container py-5 text-center" aria-labelledby="auth-callback-title">
       <Spinner animation="border" role="status" className="mb-3">
-        <span className="visually-hidden">Completing sign-in...</span>
+        <span className="visually-hidden">{m.auth_callback_spinner()}</span>
       </Spinner>
       <h1 id="auth-callback-title" className="h4 mb-2">
-        Completing sign-in
+        {m.auth_callback_title()}
       </h1>
-      <p className="text-muted mb-0">Please wait while Worktime finishes connecting your account.</p>
+      <p className="text-muted mb-0">{m.auth_callback_description()}</p>
     </main>
   );
 }

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,15 @@
+import Spinner from "react-bootstrap/Spinner";
+
+export function AuthCallbackPage() {
+  return (
+    <main className="container py-5 text-center" aria-labelledby="auth-callback-title">
+      <Spinner animation="border" role="status" className="mb-3">
+        <span className="visually-hidden">Completing sign-in...</span>
+      </Spinner>
+      <h1 id="auth-callback-title" className="h4 mb-2">
+        Completing sign-in
+      </h1>
+      <p className="text-muted mb-0">Please wait while Worktime finishes connecting your account.</p>
+    </main>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, createRoute, createRouter } from "@tanstack/react-router";
 import { AppLayout } from "@/components/AppLayout";
+import { AuthCallbackPage } from "@/pages/AuthCallbackPage";
 import { HomePage } from "@/pages/HomePage";
 import { PrivacyPage } from "@/pages/PrivacyPage";
 import { SettingsPage } from "@/pages/SettingsPage";
@@ -42,7 +43,13 @@ const privacyRoute = createRoute({
   component: PrivacyPage,
 });
 
-const routeTree = rootRoute.addChildren([homeRoute, settingsRoute, privacyRoute]);
+const authCallbackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/auth/callback",
+  component: AuthCallbackPage,
+});
+
+const routeTree = rootRoute.addChildren([homeRoute, settingsRoute, privacyRoute, authCallbackRoute]);
 
 export const router = createRouter({
   routeTree,


### PR DESCRIPTION
### Motivation
- OIDC provider redirects land on `/auth/callback` which previously had no dedicated route and could render a router fallback (poor UX), so provide a lightweight loading page while sign-in completes.

### Description
- Add `frontend/src/pages/AuthCallbackPage.tsx` which renders an accessible loading state with a spinner and message.
- Register a new `authCallbackRoute` at path `/auth/callback` in `frontend/src/router.tsx` and include it in the route tree so provider redirects resolve to the page instead of a 404.
- The commit includes the two frontend files; a pre-existing unstaged change to `frontend/public/mockServiceWorker.js` was detected but intentionally not included in this change.

### Testing
- Ran `cd frontend && pnpm lint` which completed successfully with existing lint warnings reported.
- Ran `cd frontend && pnpm typecheck` which completed successfully.
- Ran `cd frontend && pnpm build` which completed successfully with a chunk-size warning from the bundler.
- Ran `cd frontend && pnpm test -- --runInBand` which hung and was aborted, so the test suite did not complete.
- Attach screenshots of the new callback page in the PR comments as required for UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52ae422dcc832e98d5cf08711d8db5)