### PR TITLE
Surface OIDC authentication errors

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -957,6 +957,8 @@
   "login_error_generic": "Login failed. Please try again.",
   "auth_session_expired": "Your session has expired. Please sign in again.",
   "auth_error_forbidden": "Access denied. You do not have permission to perform this action.",
+  "auth_error_oidc": "Sign-in failed: {message}",
+  "auth_error_unknown": "Unknown authentication error",
   "auth_error_redirect_signin": "Failed to redirect to the login page. Please refresh and try again.",
   "auth_error_redirect_signup": "Failed to redirect to the sign-up page. Please refresh and try again.",
   "auth_error_signout": "Sign out failed. Please refresh the page.",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -950,6 +950,8 @@
   "login_error_generic": "Aanmelden mislukt. Probeer het opnieuw.",
   "auth_session_expired": "Uw sessie is verlopen. Meld u opnieuw aan.",
   "auth_error_forbidden": "Toegang geweigerd. U heeft geen rechten om deze actie uit te voeren.",
+  "auth_error_oidc": "Aanmelden mislukt: {message}",
+  "auth_error_unknown": "Onbekende authenticatiefout",
   "auth_error_redirect_signin": "Doorsturen naar de aanmeldpagina mislukt. Vernieuw de pagina en probeer het opnieuw.",
   "auth_error_redirect_signup": "Doorsturen naar de registratiepagina mislukt. Vernieuw de pagina en probeer het opnieuw.",
   "auth_error_signout": "Afmelden mislukt. Vernieuw de pagina en probeer het opnieuw.",

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -64,7 +64,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const lastDisplayedOidcErrorRef = useRef<unknown>(null);
 
   useEffect(() => {
-    if (!oidcAuth.error || lastDisplayedOidcErrorRef.current === oidcAuth.error) {
+    if (!oidcAuth.error) {
+      lastDisplayedOidcErrorRef.current = null;
+      return;
+    }
+
+    if (lastDisplayedOidcErrorRef.current === oidcAuth.error) {
       return;
     }
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { useAuth as useOidcAuth } from "react-oidc-context";
 import * as m from "@/paraglide/messages.js";
 import { useToast } from "./ToastContext";
@@ -61,6 +61,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     null;
 
   const { showError } = useToast();
+  const lastDisplayedOidcErrorRef = useRef<unknown>(null);
+
+  useEffect(() => {
+    if (!oidcAuth.error || lastDisplayedOidcErrorRef.current === oidcAuth.error) {
+      return;
+    }
+
+    lastDisplayedOidcErrorRef.current = oidcAuth.error;
+    logger.error("OIDC authentication error:", oidcAuth.error);
+    const errorMessage =
+      oidcAuth.error instanceof Error && oidcAuth.error.message.trim() !== ""
+        ? oidcAuth.error.message
+        : m.auth_error_unknown();
+    showError(m.auth_error_oidc({ message: errorMessage }));
+  }, [oidcAuth.error, showError]);
 
   const getAccessToken = useCallback((): string | null => {
     return oidcAuth.user?.access_token ?? null;

--- a/frontend/tests/contexts/AuthContext.test.tsx
+++ b/frontend/tests/contexts/AuthContext.test.tsx
@@ -173,6 +173,40 @@ describe("AuthContext", () => {
 
       expect(screen.getAllByText("Sign-in failed: Consent was denied")).toHaveLength(1);
     });
+
+    it("shows a toast again when the same OIDC error object recurs after being cleared", async () => {
+      const error = new Error("Silent renew failed");
+      mockOidcAuth = {
+        ...mockOidcAuth,
+        isLoading: false,
+        isAuthenticated: false,
+        user: null,
+        error,
+      };
+
+      const { rerender } = renderWithProviders(<AuthStatusDisplay />);
+      expect(await screen.findByText("Sign-in failed: Silent renew failed")).toBeInTheDocument();
+
+      mockOidcAuth = { ...mockOidcAuth, error: null };
+      rerender(
+        <ToastProvider>
+          <AuthProvider>
+            <AuthStatusDisplay />
+          </AuthProvider>
+        </ToastProvider>,
+      );
+
+      mockOidcAuth = { ...mockOidcAuth, error };
+      rerender(
+        <ToastProvider>
+          <AuthProvider>
+            <AuthStatusDisplay />
+          </AuthProvider>
+        </ToastProvider>,
+      );
+
+      expect(screen.getAllByText("Sign-in failed: Silent renew failed")).toHaveLength(2);
+    });
   });
 
   describe("triggerLogin", () => {

--- a/frontend/tests/contexts/AuthContext.test.tsx
+++ b/frontend/tests/contexts/AuthContext.test.tsx
@@ -135,6 +135,44 @@ describe("AuthContext", () => {
       expect(screen.getByTestId("is-authenticated")).toHaveTextContent("true");
       expect(screen.getByTestId("display-name")).toHaveTextContent("null");
     });
+
+    it("shows a toast when OIDC reports an authentication error", async () => {
+      mockOidcAuth = {
+        ...mockOidcAuth,
+        isLoading: false,
+        isAuthenticated: false,
+        user: null,
+        error: new Error("Invalid state parameter"),
+      };
+
+      renderWithProviders(<AuthStatusDisplay />);
+
+      expect(await screen.findByText("Sign-in failed: Invalid state parameter")).toBeInTheDocument();
+    });
+
+    it("does not show duplicate toasts for the same OIDC error object", async () => {
+      const error = new Error("Consent was denied");
+      mockOidcAuth = {
+        ...mockOidcAuth,
+        isLoading: false,
+        isAuthenticated: false,
+        user: null,
+        error,
+      };
+
+      const { rerender } = renderWithProviders(<AuthStatusDisplay />);
+      expect(await screen.findByText("Sign-in failed: Consent was denied")).toBeInTheDocument();
+
+      rerender(
+        <ToastProvider>
+          <AuthProvider>
+            <AuthStatusDisplay />
+          </AuthProvider>
+        </ToastProvider>,
+      );
+
+      expect(screen.getAllByText("Sign-in failed: Consent was denied")).toHaveLength(1);
+    });
   });
 
   describe("triggerLogin", () => {


### PR DESCRIPTION
### Motivation

- Ensure errors produced by `react-oidc-context` (callback / silent-renew) are visible to users and logged for diagnostics.

### Description

- Add an effect in `AuthProvider` (`frontend/src/contexts/AuthContext.tsx`) that logs `oidcAuth.error` and displays a localized error toast, deduplicating repeated toasts using a `useRef` guard.  
- Add localized messages `auth_error_oidc` and `auth_error_unknown` to `frontend/messages/en.json` and `frontend/messages/nl.json`.  
- Add unit tests (`frontend/tests/contexts/AuthContext.test.tsx`) that verify the OIDC error toast is shown and that duplicate toasts are not emitted for the same error object.  
- Note: an unrelated local change to `frontend/public/mockServiceWorker.js` was present but not included in this PR.

### Testing

- Ran the targeted unit tests: `cd frontend && pnpm paraglide:compile && pnpm test tests/contexts/AuthContext.test.tsx`, and the test file passed (`1 file, 11 tests` all passed).  
- Ran lint: `cd frontend && pnpm lint`, which completed with warnings but no failure.  
- Ran typecheck: `cd frontend && pnpm typecheck`, which compiled the inlang messages and completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b3c04ba0832ead6ab046c039de04)