### PR TITLE
Handle OIDC silent-renew failures

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -956,6 +956,8 @@
   "login_error_rate_limited": "Too many login attempts. Please try again later.",
   "login_error_generic": "Login failed. Please try again.",
   "auth_session_expired": "Your session has expired. Please sign in again.",
+  "auth_access_token_expiring": "Your session will expire soon. Please save your work and sign in again if prompted.",
+  "auth_silent_renew_failed": "Your session could not be refreshed. Please sign in again to keep syncing changes.",
   "auth_error_forbidden": "Access denied. You do not have permission to perform this action.",
   "auth_error_oidc": "Sign-in failed: {message}",
   "auth_error_unknown": "Unknown authentication error",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -949,6 +949,8 @@
   "login_error_rate_limited": "Te veel aanmeldpogingen. Probeer het later opnieuw.",
   "login_error_generic": "Aanmelden mislukt. Probeer het opnieuw.",
   "auth_session_expired": "Uw sessie is verlopen. Meld u opnieuw aan.",
+  "auth_access_token_expiring": "Uw sessie verloopt binnenkort. Sla uw werk op en meld u opnieuw aan als daarom wordt gevraagd.",
+  "auth_silent_renew_failed": "Uw sessie kon niet worden vernieuwd. Meld u opnieuw aan om wijzigingen te blijven synchroniseren.",
   "auth_error_forbidden": "Toegang geweigerd. U heeft geen rechten om deze actie uit te voeren.",
   "auth_error_oidc": "Aanmelden mislukt: {message}",
   "auth_error_unknown": "Onbekende authenticatiefout",

--- a/frontend/src/config/oidc.ts
+++ b/frontend/src/config/oidc.ts
@@ -4,7 +4,8 @@
  * Environment variables (all optional):
  *   VITE_OIDC_AUTHORITY     — OIDC provider base URL
  *   VITE_OIDC_CLIENT_ID     — Client identifier registered with the provider
- *   VITE_OIDC_REDIRECT_URI  — Callback URL after successful login (defaults to /auth/callback)
+ *   VITE_OIDC_REDIRECT_URI         — Callback URL after successful login (defaults to /auth/callback)
+ *   VITE_OIDC_SILENT_REDIRECT_URI  — Hidden iframe callback URL for silent renew (defaults to /auth/silent-callback)
  *   VITE_OIDC_SCOPE         — Requested OAuth scopes (default: openid profile email)
  */
 
@@ -15,12 +16,15 @@ const OIDC_AUTHORITY =
 const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID ?? "worktime";
 const OIDC_REDIRECT_URI =
   import.meta.env.VITE_OIDC_REDIRECT_URI ?? `${window.location.origin}/auth/callback`;
+const OIDC_SILENT_REDIRECT_URI =
+  import.meta.env.VITE_OIDC_SILENT_REDIRECT_URI ?? `${window.location.origin}/auth/silent-callback`;
 const OIDC_SCOPE = import.meta.env.VITE_OIDC_SCOPE ?? "openid profile email";
 
 export const oidcConfig: AuthProviderProps = {
   authority: OIDC_AUTHORITY,
   client_id: OIDC_CLIENT_ID,
   redirect_uri: OIDC_REDIRECT_URI,
+  silent_redirect_uri: OIDC_SILENT_REDIRECT_URI,
   scope: OIDC_SCOPE,
   post_logout_redirect_uri: window.location.origin,
   /**

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -60,7 +60,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     (oidcAuth.user?.profile.preferred_username as string | undefined) ??
     null;
 
-  const { showError } = useToast();
+  const { showError, showWarning } = useToast();
   const lastDisplayedOidcErrorRef = useRef<unknown>(null);
 
   useEffect(() => {
@@ -81,6 +81,30 @@ export function AuthProvider({ children }: AuthProviderProps) {
         : m.auth_error_unknown();
     showError(m.auth_error_oidc({ message: errorMessage }));
   }, [oidcAuth.error, showError]);
+
+  useEffect(() => {
+    if (!oidcAuth.events) {
+      return;
+    }
+
+    const handleAccessTokenExpiring = () => {
+      logger.warn("OIDC access token is expiring soon.");
+      showWarning(m.auth_access_token_expiring());
+    };
+
+    const handleSilentRenewError = (error: Error) => {
+      logger.error("OIDC silent renew failed:", error);
+      showError(m.auth_silent_renew_failed());
+    };
+
+    oidcAuth.events.addAccessTokenExpiring(handleAccessTokenExpiring);
+    oidcAuth.events.addSilentRenewError(handleSilentRenewError);
+
+    return () => {
+      oidcAuth.events?.removeAccessTokenExpiring(handleAccessTokenExpiring);
+      oidcAuth.events?.removeSilentRenewError(handleSilentRenewError);
+    };
+  }, [oidcAuth.events, showError, showWarning]);
 
   const getAccessToken = useCallback((): string | null => {
     return oidcAuth.user?.access_token ?? null;

--- a/frontend/src/pages/SilentRenewCallbackPage.tsx
+++ b/frontend/src/pages/SilentRenewCallbackPage.tsx
@@ -1,0 +1,10 @@
+/**
+ * Blank OIDC silent-renew callback page.
+ *
+ * react-oidc-context processes the iframe callback before rendering the routed
+ * app. Keeping this route intentionally empty avoids showing sign-in UI inside
+ * the hidden iframe used for automatic token renewal.
+ */
+export function SilentRenewCallbackPage() {
+  return null;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,6 +4,7 @@ import { AuthCallbackPage } from "@/pages/AuthCallbackPage";
 import { HomePage } from "@/pages/HomePage";
 import { PrivacyPage } from "@/pages/PrivacyPage";
 import { SettingsPage } from "@/pages/SettingsPage";
+import { SilentRenewCallbackPage } from "@/pages/SilentRenewCallbackPage";
 
 const rootRoute = createRootRoute({
   component: AppLayout,
@@ -49,7 +50,19 @@ const authCallbackRoute = createRoute({
   component: AuthCallbackPage,
 });
 
-const routeTree = rootRoute.addChildren([homeRoute, settingsRoute, privacyRoute, authCallbackRoute]);
+const silentRenewCallbackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/auth/silent-callback",
+  component: SilentRenewCallbackPage,
+});
+
+const routeTree = rootRoute.addChildren([
+  homeRoute,
+  settingsRoute,
+  privacyRoute,
+  authCallbackRoute,
+  silentRenewCallbackRoute,
+]);
 
 export const router = createRouter({
   routeTree,

--- a/frontend/tests/contexts/AuthContext.test.tsx
+++ b/frontend/tests/contexts/AuthContext.test.tsx
@@ -9,6 +9,10 @@ import { ToastProvider } from "@/contexts/ToastContext";
 const mockSigninRedirect = vi.fn().mockResolvedValue(undefined);
 const mockRemoveUser = vi.fn().mockResolvedValue(undefined);
 const mockSignoutRedirect = vi.fn().mockResolvedValue(undefined);
+const mockAddAccessTokenExpiring = vi.fn();
+const mockRemoveAccessTokenExpiring = vi.fn();
+const mockAddSilentRenewError = vi.fn();
+const mockRemoveSilentRenewError = vi.fn();
 let mockOidcAuth: Record<string, unknown> = {
   isAuthenticated: false,
   isLoading: true,
@@ -16,6 +20,12 @@ let mockOidcAuth: Record<string, unknown> = {
   signinRedirect: mockSigninRedirect,
   removeUser: mockRemoveUser,
   signoutRedirect: mockSignoutRedirect,
+  events: {
+    addAccessTokenExpiring: mockAddAccessTokenExpiring,
+    removeAccessTokenExpiring: mockRemoveAccessTokenExpiring,
+    addSilentRenewError: mockAddSilentRenewError,
+    removeSilentRenewError: mockRemoveSilentRenewError,
+  },
 };
 
 vi.mock("react-oidc-context", () => ({
@@ -65,6 +75,12 @@ describe("AuthContext", () => {
       signinRedirect: mockSigninRedirect,
       removeUser: mockRemoveUser,
       signoutRedirect: mockSignoutRedirect,
+      events: {
+        addAccessTokenExpiring: mockAddAccessTokenExpiring,
+        removeAccessTokenExpiring: mockRemoveAccessTokenExpiring,
+        addSilentRenewError: mockAddSilentRenewError,
+        removeSilentRenewError: mockRemoveSilentRenewError,
+      },
     };
   });
 
@@ -206,6 +222,47 @@ describe("AuthContext", () => {
       );
 
       expect(screen.getAllByText("Sign-in failed: Silent renew failed")).toHaveLength(2);
+    });
+
+    it("warns when the access token is about to expire", async () => {
+      mockOidcAuth = { ...mockOidcAuth, isLoading: false, isAuthenticated: true };
+
+      renderWithProviders(<AuthStatusDisplay />);
+
+      const handler = mockAddAccessTokenExpiring.mock.calls.at(-1)?.[0];
+      expect(handler).toBeTypeOf("function");
+      handler();
+
+      expect(
+        await screen.findByText("Your session will expire soon. Please save your work and sign in again if prompted."),
+      ).toBeInTheDocument();
+    });
+
+    it("shows an error when silent token renewal fails", async () => {
+      mockOidcAuth = { ...mockOidcAuth, isLoading: false, isAuthenticated: true };
+
+      renderWithProviders(<AuthStatusDisplay />);
+
+      const handler = mockAddSilentRenewError.mock.calls.at(-1)?.[0];
+      expect(handler).toBeTypeOf("function");
+      handler(new Error("login_required"));
+
+      expect(
+        await screen.findByText("Your session could not be refreshed. Please sign in again to keep syncing changes."),
+      ).toBeInTheDocument();
+    });
+
+    it("unsubscribes from OIDC session lifecycle events on unmount", () => {
+      mockOidcAuth = { ...mockOidcAuth, isLoading: false, isAuthenticated: true };
+
+      const { unmount } = renderWithProviders(<AuthStatusDisplay />);
+      const expiringHandler = mockAddAccessTokenExpiring.mock.calls.at(-1)?.[0];
+      const renewErrorHandler = mockAddSilentRenewError.mock.calls.at(-1)?.[0];
+
+      unmount();
+
+      expect(mockRemoveAccessTokenExpiring).toHaveBeenCalledWith(expiringHandler);
+      expect(mockRemoveSilentRenewError).toHaveBeenCalledWith(renewErrorHandler);
     });
   });
 


### PR DESCRIPTION
### Motivation

- Improve the user experience around OIDC silent token renewal by surfacing proactive warnings and clear errors when background refresh fails. 
- Prevent the normal sign-in callback UI from being rendered inside the hidden iframe used for silent renew. 

### Description

- Add `VITE_OIDC_SILENT_REDIRECT_URI` support and set `silent_redirect_uri` on the `oidcConfig` exported from `frontend/src/config/oidc.ts` so silent-iframe callbacks can be routed separately. 
- Introduce a minimal `SilentRenewCallbackPage` and register the `/auth/silent-callback` route in the app router to keep the hidden iframe blank during silent renew. 
- Subscribe to the OIDC `events` (`addAccessTokenExpiring` and `addSilentRenewError`) in `AuthContext` to show a warning toast before expiry and an error toast when silent renew fails, and remove the listeners on unmount. 
- Add localized messages in `frontend/messages/en.json` and `frontend/messages/nl.json` for the new warning/error text, and extend `frontend/tests/contexts/AuthContext.test.tsx` to cover the new event handlers and unsubscription behavior. 

### Testing

- Ran `pnpm paraglide:compile` (succeeded). 
- Ran `pnpm vitest run tests/contexts/AuthContext.test.tsx` and the test file passed (`1 test file, 15 tests, all passed`). 
- Ran `pnpm typecheck` (succeeded). 
- Ran `pnpm lint` (succeeded; existing React hook dependency warnings were reported but lint completed). 
- Note: an earlier attempt to run Vitest with `--runInBand` failed because that option is not supported by Vitest 4; the tests were run without that flag and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52d1916d5c832eac251fb8781fd264)