### PR TITLE
Prevent background sync auth redirects

### DIFF
--- a/frontend/src/hooks/useApiClient.ts
+++ b/frontend/src/hooks/useApiClient.ts
@@ -4,6 +4,15 @@ import { useToast } from "@/contexts/ToastContext";
 import { apiFetch } from "@/utils/apiClient";
 import * as m from "@/paraglide/messages.js";
 
+export interface AuthenticatedRequestInit extends RequestInit {
+  /**
+   * When true, 401 responses show the session-expired warning without starting
+   * an OIDC redirect. Use this for passive/background work that must not yank
+   * the user away from unsaved edits.
+   */
+  suppressUnauthorizedRedirect?: boolean;
+}
+
 /**
  * Hook that returns an `apiFetch` function with standard error handling.
  *
@@ -22,22 +31,32 @@ export function useApiClient() {
   const { showError, showWarning } = useToast();
 
   const authenticatedFetch = useCallback(
-    async (url: string, init: RequestInit = {}): Promise<Response> => {
+    async (
+      url: string,
+      init: AuthenticatedRequestInit = {},
+    ): Promise<Response> => {
+      const { suppressUnauthorizedRedirect = false, ...requestInit } = init;
       const token = getAccessToken();
-      const headers = new Headers(init.headers);
+      const headers = new Headers(requestInit.headers);
       if (token) {
         headers.set("Authorization", `Bearer ${token}`);
       }
-      return apiFetch(url, { ...init, headers }, {
-        onUnauthorized: () => {
-          showWarning(m.auth_session_expired());
-          triggerLogin();
+      return apiFetch(
+        url,
+        { ...requestInit, headers },
+        {
+          onUnauthorized: () => {
+            showWarning(m.auth_session_expired());
+            if (!suppressUnauthorizedRedirect) {
+              triggerLogin();
+            }
+          },
+          onForbidden: () => {
+            logout();
+            showError(m.auth_error_forbidden());
+          },
         },
-        onForbidden: () => {
-          logout();
-          showError(m.auth_error_forbidden());
-        },
-      });
+      );
     },
     [triggerLogin, logout, getAccessToken, showError, showWarning],
   );

--- a/frontend/src/hooks/useOngoingSync.ts
+++ b/frontend/src/hooks/useOngoingSync.ts
@@ -49,7 +49,13 @@ import {
 import { getSyncCursorKey } from "@/constants/storageKeys";
 import { logger } from "@/utils/logger";
 
-type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+type BackgroundSafeRequestInit = RequestInit & {
+  suppressUnauthorizedRedirect?: boolean;
+};
+type FetchFn = (
+  url: string,
+  init?: BackgroundSafeRequestInit,
+) => Promise<Response>;
 
 /** Minimum delay (ms) for the first outbox flush retry after a failure. */
 export const INITIAL_BACK_OFF_MS = 1_000;
@@ -101,7 +107,9 @@ export type TriggerPullFn = () => void;
  * - `"keep-mine"`: re-push the conflicted local items with `client_updated_at = now()` so
  *   they win the last-write-wins check on the next push.
  */
-export type ResolveOngoingConflictsFn = (choice: "keep-server" | "keep-mine") => void;
+export type ResolveOngoingConflictsFn = (
+  choice: "keep-server" | "keep-mine",
+) => void;
 
 /** Stable no-op used by the inactive-mode return value to ensure consistent function identity. */
 const NOOP = () => {};
@@ -125,7 +133,11 @@ async function reconcilePreferences(fetchFn: FetchFn): Promise<string | null> {
   const serverMs = parseTimestampMs(serverTimestamp);
 
   if (localPrefs && (!serverPrefs || localMs > serverMs)) {
-    const pushed = await pushPreferences(fetchFn, localPrefs.data, localPrefs.clientUpdatedAt);
+    const pushed = await pushPreferences(
+      fetchFn,
+      localPrefs.data,
+      localPrefs.clientUpdatedAt,
+    );
     return pushed ? localPrefs.clientUpdatedAt : serverTimestamp;
   }
 
@@ -169,7 +181,8 @@ export function useOngoingSync(
   });
   const [hasSyncError, setHasSyncError] = useState(false);
   const [conflictCount, setConflictCount] = useState(0);
-  const [conflictedPayload, setConflictedPayload] = useState<SyncPushPayload | null>(null);
+  const [conflictedPayload, setConflictedPayload] =
+    useState<SyncPushPayload | null>(null);
   // Keep a stable ref to conflictedPayload for use inside callbacks without
   // creating stale closures.
   const conflictedPayloadRef = useRef<SyncPushPayload | null>(null);
@@ -230,15 +243,25 @@ export function useOngoingSync(
    *   the current back-off window.
    */
   const flushAndPull = useCallback(
-    async (force = false) => {
+    async (force = false, suppressUnauthorizedRedirect = false) => {
       if (!isActive || !userId || !fetchFn) return;
       if (isFlushingRef.current) return;
       // Respect back-off unless the caller explicitly forces a flush (e.g. the
       // `online` event after a real reconnect, or an SSE-triggered pull).
-      if (!force && retryAfterRef.current !== null && Date.now() < retryAfterRef.current) return;
+      if (
+        !force &&
+        retryAfterRef.current !== null &&
+        Date.now() < retryAfterRef.current
+      )
+        return;
       isFlushingRef.current = true;
       setIsSyncing(true);
       try {
+        const syncFetch: FetchFn = suppressUnauthorizedRedirect
+          ? (url, init = {}) =>
+              fetchFn(url, { ...init, suppressUnauthorizedRedirect: true })
+          : fetchFn;
+
         // --- Flush outbox ---
         let flushConflicts = 0;
         const dequeued = dequeueAndMergeSyncOutbox(userId);
@@ -246,7 +269,7 @@ export function useOngoingSync(
           const { merged, commit } = dequeued;
           let pushResult: SyncPushResponse | null;
           try {
-            pushResult = await pushSyncPayload(fetchFn, merged);
+            pushResult = await pushSyncPayload(syncFetch, merged);
           } catch (err) {
             // Push threw (e.g. network error) — outbox stays intact for next retry.
             logger.error("useOngoingSync: outbox push threw:", err);
@@ -272,7 +295,8 @@ export function useOngoingSync(
           if (flushConflicts > 0) {
             const extracted = extractConflictedItems(merged, pushResult);
             conflictedPayloadRef.current = extracted;
-            conflictServerTimestampRef.current = maxConflictServerTimestamp(pushResult);
+            conflictServerTimestampRef.current =
+              maxConflictServerTimestamp(pushResult);
             setConflictedPayload(extracted);
             setConflictCount(flushConflicts);
           }
@@ -286,11 +310,11 @@ export function useOngoingSync(
           flushConflicts > 0 || conflictCount > 0
             ? undefined
             : (localStorage.getItem(getSyncCursorKey(userId)) ?? undefined);
-        const pullResult = await pullSyncData(fetchFn, cursor);
+        const pullResult = await pullSyncData(syncFetch, cursor);
         if (!mountedRef.current) return;
         if (pullResult) {
           onIncrementalPullRef.current?.(pullResult);
-          await reconcilePreferences(fetchFn);
+          await reconcilePreferences(syncFetch);
           if (!mountedRef.current) return;
           storeSyncCursor(userId, pullResult.server_timestamp);
           setLastSyncedAt(pullResult.server_timestamp);
@@ -324,7 +348,7 @@ export function useOngoingSync(
     const handleOnline = () => {
       // The `online` event fires after a real reconnect — always attempt a
       // flush immediately, bypassing any active back-off window.
-      flushAndPull(true).catch((err: unknown) => {
+      flushAndPull(true, true).catch((err: unknown) => {
         logger.error("useOngoingSync: flush on online event failed:", err);
       });
     };
@@ -332,8 +356,11 @@ export function useOngoingSync(
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         // Passive trigger — respect the current back-off window.
-        flushAndPull(false).catch((err: unknown) => {
-          logger.error("useOngoingSync: flush on visibility change failed:", err);
+        flushAndPull(false, true).catch((err: unknown) => {
+          logger.error(
+            "useOngoingSync: flush on visibility change failed:",
+            err,
+          );
         });
       }
     };
@@ -356,7 +383,9 @@ export function useOngoingSync(
   // once on mount, so without this effect they would serve stale data for the
   // new user.
   useEffect(() => {
-    setLastSyncedAt(userId ? localStorage.getItem(getSyncCursorKey(userId)) : null);
+    setLastSyncedAt(
+      userId ? localStorage.getItem(getSyncCursorKey(userId)) : null,
+    );
     setOutboxCount(userId ? getSyncOutboxSize(userId) : 0);
     setHasSyncError(false);
     setConflictCount(0);
@@ -375,7 +404,7 @@ export function useOngoingSync(
     // Only run the initial flush if we are currently online.
     if (!navigator.onLine) return;
     hasRunInitialFlushRef.current = true;
-    flushAndPull(true).catch((err: unknown) => {
+    flushAndPull(true, true).catch((err: unknown) => {
       logger.error("useOngoingSync: initial flush on mount failed:", err);
     });
   }, [isActive, flushAndPull]);
@@ -388,7 +417,7 @@ export function useOngoingSync(
   const triggerPull: TriggerPullFn = useCallback(() => {
     // Explicit external trigger (e.g. SSE signal) — bypass back-off so that
     // real server-push notifications are never silently dropped.
-    flushAndPull(true).catch((err: unknown) => {
+    flushAndPull(true, true).catch((err: unknown) => {
       logger.error("useOngoingSync: triggerPull failed:", err);
     });
   }, [flushAndPull]);
@@ -413,7 +442,8 @@ export function useOngoingSync(
           if (conflicts > 0) {
             const extracted = extractConflictedItems(change, result);
             conflictedPayloadRef.current = extracted;
-            conflictServerTimestampRef.current = maxConflictServerTimestamp(result);
+            conflictServerTimestampRef.current =
+              maxConflictServerTimestamp(result);
             setConflictedPayload(extracted);
             setConflictCount(conflicts);
             let pullResult: SyncPullResponse | null = null;
@@ -439,7 +469,10 @@ export function useOngoingSync(
                 setHasSyncError(false);
               } catch (err) {
                 // Post-success callback threw — log but do NOT requeue the change.
-                logger.error("useOngoingSync: post-reconciliation callback threw:", err);
+                logger.error(
+                  "useOngoingSync: post-reconciliation callback threw:",
+                  err,
+                );
                 if (mountedRef.current) {
                   setHasSyncError(true);
                 }

--- a/frontend/tests/hooks/useApiClient.test.ts
+++ b/frontend/tests/hooks/useApiClient.test.ts
@@ -58,6 +58,24 @@ describe("useApiClient", () => {
     expect(auth.logout).not.toHaveBeenCalled();
   });
 
+  it("can show an unauthorized warning without starting a login redirect", async () => {
+    vi.mocked(apiFetch).mockImplementation(async (_url, _init, options) => {
+      options.onUnauthorized();
+      throw new Error("Unauthorized");
+    });
+    const { result } = renderHook(() => useApiClient());
+
+    await expect(
+      result.current("/api/data", { suppressUnauthorizedRedirect: true }),
+    ).rejects.toThrow("Unauthorized");
+
+    const [, init] = vi.mocked(apiFetch).mock.calls[0];
+    expect("suppressUnauthorizedRedirect" in (init ?? {})).toBe(false);
+    expect(toast.showWarning).toHaveBeenCalledOnce();
+    expect(auth.triggerLogin).not.toHaveBeenCalled();
+    expect(auth.logout).not.toHaveBeenCalled();
+  });
+
   it("logs out and shows an error when a request is forbidden", async () => {
     vi.mocked(apiFetch).mockImplementation(async (_url, _init, options) => {
       options.onForbidden();

--- a/frontend/tests/hooks/useOngoingSync.test.ts
+++ b/frontend/tests/hooks/useOngoingSync.test.ts
@@ -778,6 +778,20 @@ describe("useOngoingSync", () => {
       });
     });
 
+    it("marks automatic pull requests as safe from unauthorized redirects", async () => {
+      storeSyncCursor("user-1", "2026-01-01T00:00:00.000Z");
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => incrementalPullResponse });
+
+      renderHook(() => useOngoingSync(true, "user-1", mockFetch));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled();
+      });
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init).toMatchObject({ suppressUnauthorizedRedirect: true });
+    });
+
     it("does not make network calls when sync is not established", () => {
       const { result } = renderHook(() => useOngoingSync(false, "user-1", mockFetch));
 


### PR DESCRIPTION
### Motivation

- Background sync (visibility/online/SSE-triggered) used the same authenticated fetch path that immediately starts an OIDC redirect on a 401, which can yank users away mid-edit; the intention is to avoid automatic full-page navigations for passive background failures.  
- The change aims to allow the app to surface the existing session-expired warning while letting users choose when to re-authenticate instead of forcing an immediate redirect.

### Description

- Added a typed `suppressUnauthorizedRedirect` option (`AuthenticatedRequestInit`) to the authenticated fetch wrapper so callers can request that 401s show the session-expired warning but not start `triggerLogin()` automatically.  
- Updated `useApiClient` to respect `suppressUnauthorizedRedirect` and only call `triggerLogin()` when it is not set.  
- Updated `useOngoingSync` to mark automatic sync flows (push, pull, preferences reconciliation) as redirect-suppressed by wrapping the provided `fetchFn` into a `syncFetch` that forwards `suppressUnauthorizedRedirect: true`, and invoked `flushAndPull` with the suppress flag for online, visibility, initial, and external trigger paths.  
- Added regression tests for the new behavior in `tests/hooks/useApiClient.test.ts` and `tests/hooks/useOngoingSync.test.ts` to assert suppressed unauthorized handling and that automatic sync requests include the suppress flag.

### Testing

- Ran unit tests with `pnpm --dir frontend exec vitest run tests/hooks/useApiClient.test.ts tests/hooks/useOngoingSync.test.ts` and all relevant tests passed (`35` tests in the affected suites passed).  
- Ran lint with `pnpm --dir frontend lint`, which completed with unrelated hook-deps warnings but no errors.  
- Ran type checks with `pnpm --dir frontend typecheck` (paraglide compile + `tsc`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52d7735d04832ebc21608f1513b2ca)