### PR TITLE
Support OIDC end-session endpoint and implement Android AppAuth logout flow

### DIFF
--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscovery.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscovery.kt
@@ -33,7 +33,8 @@ class OidcServiceConfigurationDiscovery(private val client: OkHttpClient = OkHtt
         val json = JSONObject(body)
         AuthorizationServiceConfiguration(
             Uri.parse(json.getString("authorization_url")),
-            Uri.parse(json.getString("token_url"))
+            Uri.parse(json.getString("token_url")),
+            json.optString("end_session_url").takeIf { it.isNotBlank() }?.let(Uri::parse)
         )
     } catch (exception: JSONException) {
         throw IOException("Failed to parse OIDC config response", exception)

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscovery.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscovery.kt
@@ -34,6 +34,7 @@ class OidcServiceConfigurationDiscovery(private val client: OkHttpClient = OkHtt
         AuthorizationServiceConfiguration(
             Uri.parse(json.getString("authorization_url")),
             Uri.parse(json.getString("token_url")),
+            null,
             json.optString("end_session_url").takeIf { it.isNotBlank() }?.let(Uri::parse)
         )
     } catch (exception: JSONException) {

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -122,16 +122,10 @@ class OidcSessionManager @Inject constructor(
         val stateToEnd = authState
         runCatching {
             val configuration = fetchAuthorizationServiceConfiguration()
-            val endSessionEndpoint = configuration.endSessionEndpoint ?: return@runCatching
-            val endSessionConfig =
-                AuthorizationServiceConfiguration(
-                    configuration.authorizationEndpoint,
-                    configuration.tokenEndpoint,
-                    endSessionEndpoint
-                )
+            if (configuration.endSessionEndpoint == null) return@runCatching
             val builder =
                 EndSessionRequest
-                    .Builder(endSessionConfig)
+                    .Builder(configuration)
                     .setPostLogoutRedirectUri(oidcConfig.redirectUri)
             stateToEnd?.idToken?.let(builder::setIdTokenHint)
             val request = builder.build()

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -21,6 +21,7 @@ import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.EndSessionRequest
 import net.openid.appauth.ResponseTypeValues
 import net.openid.appauth.TokenRequest
 
@@ -107,7 +108,7 @@ class OidcSessionManager @Inject constructor(
             currentState.performActionWithFreshTokens(service) { accessToken, _, exception ->
                 service.dispose()
                 if (exception != null || accessToken.isNullOrBlank()) {
-                    logout()
+                    clearLocalSession()
                     continuation.resume(null)
                     return@performActionWithFreshTokens
                 }
@@ -117,7 +118,32 @@ class OidcSessionManager @Inject constructor(
         }
     }
 
-    override fun logout() {
+    override suspend fun logout() {
+        val stateToEnd = authState
+        runCatching {
+            val configuration = fetchAuthorizationServiceConfiguration()
+            val endSessionEndpoint = configuration.endSessionEndpoint ?: return@runCatching
+            val endSessionConfig =
+                AuthorizationServiceConfiguration(
+                    configuration.authorizationEndpoint,
+                    configuration.tokenEndpoint,
+                    endSessionEndpoint
+                )
+            val builder =
+                EndSessionRequest
+                    .Builder(endSessionConfig)
+                    .setPostLogoutRedirectUri(oidcConfig.redirectUri)
+            stateToEnd?.idToken?.let(builder::setIdTokenHint)
+            val request = builder.build()
+            val service = AuthorizationService(context)
+            val intent = service.getEndSessionRequestIntent(request).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            service.dispose()
+        }
+        clearLocalSession()
+    }
+
+    private fun clearLocalSession() {
         authState = null
         sessionStore.clear()
         _sessionState.value = SessionState.LoggedOut

--- a/android/app/src/main/java/com/worktime/android/core/auth/SessionState.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/SessionState.kt
@@ -19,5 +19,5 @@ interface SessionController {
 
     suspend fun getFreshAccessToken(): String?
 
-    fun logout()
+    suspend fun logout()
 }

--- a/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
+++ b/android/app/src/main/java/com/worktime/android/data/repository/WorktimeRepository.kt
@@ -166,7 +166,7 @@ interface DashboardRepository {
 
     suspend fun deleteAccount(): MutationResult<Unit>
 
-    fun logout()
+    suspend fun logout()
 }
 
 @Suppress("TooManyFunctions") // implements the single-facade DashboardRepository
@@ -479,7 +479,7 @@ class WorktimeRepository(private val api: WorktimeApi, private val sessionContro
         currentUserId = null
     }
 
-    override fun logout() {
+    override suspend fun logout() {
         sessionController.logout()
         currentUserId = null
     }

--- a/android/app/src/main/java/com/worktime/android/feature/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/worktime/android/feature/dashboard/DashboardViewModel.kt
@@ -208,8 +208,10 @@ class DashboardViewModel(private val repository: DashboardRepository) : ViewMode
     }
 
     fun logout() {
-        repository.logout()
-        _uiState.value = DashboardUiState.LoggedOut
+        viewModelScope.launch {
+            repository.logout()
+            _uiState.value = DashboardUiState.LoggedOut
+        }
     }
 
     fun deleteAccount() {

--- a/android/app/src/test/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscoveryTest.kt
+++ b/android/app/src/test/java/com/worktime/android/core/auth/OidcServiceConfigurationDiscoveryTest.kt
@@ -51,7 +51,8 @@ class OidcServiceConfigurationDiscoveryTest {
                     {
                       "issuer": "https://auth.example.test/realms/worktime",
                       "authorization_url": "https://auth.example.test/realms/worktime/protocol/openid-connect/auth",
-                      "token_url": "https://auth.example.test/realms/worktime/protocol/openid-connect/token"
+                      "token_url": "https://auth.example.test/realms/worktime/protocol/openid-connect/token",
+                      "end_session_url": "https://auth.example.test/realms/worktime/protocol/openid-connect/logout"
                     }
                     """.trimIndent()
                 ).build()
@@ -67,6 +68,10 @@ class OidcServiceConfigurationDiscoveryTest {
         assertEquals(
             "https://auth.example.test/realms/worktime/protocol/openid-connect/token",
             config.tokenEndpoint.toString()
+        )
+        assertEquals(
+            "https://auth.example.test/realms/worktime/protocol/openid-connect/logout",
+            config.endSessionEndpoint.toString()
         )
     }
 

--- a/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/repository/WorktimeRepositoryTest.kt
@@ -825,7 +825,7 @@ class WorktimeRepositoryTest {
 
         override suspend fun getFreshAccessToken(): String? = currentToken
 
-        override fun logout() {
+        override suspend fun logout() {
             currentToken = null
             sessionState.value = SessionState.LoggedOut
         }

--- a/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/dashboard/DashboardViewModelTest.kt
@@ -316,7 +316,7 @@ class DashboardViewModelTest {
             return result
         }
 
-        override fun logout() {
+        override suspend fun logout() {
             sessionState.value = SessionState.LoggedOut
         }
 

--- a/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
+++ b/android/app/src/test/java/com/worktime/android/feature/timeoff/TimeOffViewModelTest.kt
@@ -234,7 +234,7 @@ class TimeOffViewModelTest {
 
         override suspend fun deleteAccount(): MutationResult<Unit> = throw UnsupportedOperationException()
 
-        override fun logout() {
+        override suspend fun logout() {
             sessionState.value = SessionState.LoggedOut
         }
     }

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -53,6 +53,7 @@ async def _discover(issuer: str) -> OidcDiscoveryConfig:
         issuer=data.get("issuer", issuer),
         authorization_url=data["authorization_endpoint"],
         token_url=data["token_endpoint"],
+        end_session_url=data.get("end_session_endpoint"),
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -77,6 +77,7 @@ class OidcDiscoveryConfig(BaseModel):
     issuer: str
     authorization_url: str
     token_url: str
+    end_session_url: str | None = None
 
 
 def _validate_hex_color(value: str | None) -> str | None:

--- a/backend/tests/test_oidc_config.py
+++ b/backend/tests/test_oidc_config.py
@@ -115,6 +115,7 @@ async def test_oidc_config_endpoint_returns_discovered_provider_urls(monkeypatch
                 "issuer": issuer,
                 "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
                 "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+                "end_session_endpoint": f"{issuer}/protocol/openid-connect/logout",
             },
         )
 
@@ -128,6 +129,7 @@ async def test_oidc_config_endpoint_returns_discovered_provider_urls(monkeypatch
         "issuer": issuer,
         "authorization_url": f"{issuer}/protocol/openid-connect/auth",
         "token_url": f"{issuer}/protocol/openid-connect/token",
+        "end_session_url": f"{issuer}/protocol/openid-connect/logout",
     }
 
 
@@ -146,6 +148,7 @@ async def test_oidc_config_endpoint_caches_discovery(monkeypatch) -> None:
                 "issuer": issuer,
                 "authorization_endpoint": f"{issuer}/authorize/",
                 "token_endpoint": f"{issuer}/token/",
+                "end_session_endpoint": f"{issuer}/logout/",
             },
         )
 


### PR DESCRIPTION
### Motivation
- Native clients need the provider's end-session endpoint so the app can perform a proper OIDC logout (redirecting the user to the provider's logout flow) instead of only clearing local state.
- The Android app must be able to launch an AppAuth `EndSessionRequest` and only then clear the local session, which requires the native discovery response to include the end-session URL and the logout APIs to be suspendable.

### Description
- Add optional `end_session_url: str | None = None` to the backend `OidcDiscoveryConfig` schema and return `end_session_endpoint` from the server discovery response in `GET /api/auth/oidc-config`.
- Parse `end_session_url` in Android `OidcServiceConfigurationDiscovery` into AppAuth's `AuthorizationServiceConfiguration` so `endSessionEndpoint` is available on clients.
- Implement logout in Android `OidcSessionManager` as a suspend function that fetches the cached configuration, builds an AppAuth `EndSessionRequest` (with `id_token_hint` when available and `post_logout_redirect_uri`), launches the end-session intent, and then clears local session state.
- Make `SessionController.logout()` suspendable and propagate that change through `WorktimeRepository.logout()` (now `suspend`) and test fakes, and update `DashboardViewModel.logout()` to call the suspendable logout via `viewModelScope.launch { ... }`.
- Update unit tests to assert discovery returns the `end_session` URL and adapt other test stubs to the suspendable `logout` signature.

### Testing
- Ran backend discovery tests with `cd backend && uv run pytest tests/test_oidc_config.py` and all tests passed (`20 passed`).
- Ran linter checks with `cd backend && uv run ruff check app tests/test_oidc_config.py` and they passed.
- Attempted to run the Android unit test `OidcServiceConfigurationDiscoveryTest` with Gradle, but the run is blocked in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties`), so Android JVM tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535cc75630832ebeae73530ec9b19b)