### PR TITLE
Improve Android auth error messages

### DIFF
--- a/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
@@ -36,6 +36,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.worktime.android.app.navigation.WorktimeDestination
+import com.worktime.android.core.auth.AuthErrorMessages
 import com.worktime.android.core.auth.BiometricAuthenticator
 import com.worktime.android.core.auth.SessionState
 import com.worktime.android.core.notifications.WorktimeNotifications
@@ -174,7 +175,7 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                         dashboardViewModel.refresh()
                         timeOffViewModel.refresh()
                     }.onFailure {
-                        loginError = it.message ?: "Unable to complete sign-in"
+                        loginError = it.message ?: AuthErrorMessages.completeSignInError(context)
                     }
             }
         }
@@ -221,7 +222,7 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                                 .onSuccess(loginLauncher::launch)
                                 .onFailure {
                                     loginInFlight = false
-                                    loginError = it.message ?: "Unable to start sign-in"
+                                    loginError = AuthErrorMessages.startSignInError(context)
                                 }
                         }
                     }

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
@@ -175,7 +175,7 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                         dashboardViewModel.refresh()
                         timeOffViewModel.refresh()
                     }.onFailure {
-                        loginError = it.message ?: AuthErrorMessages.completeSignInError(context)
+                        loginError = (it as? IllegalStateException)?.message ?: AuthErrorMessages.completeSignInError(context)
                     }
             }
         }

--- a/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
+++ b/android/app/src/main/java/com/worktime/android/app/WorktimeApp.kt
@@ -175,7 +175,9 @@ fun WorktimeApp(container: WorktimeAppContainer, initialDestination: String = Wo
                         dashboardViewModel.refresh()
                         timeOffViewModel.refresh()
                     }.onFailure {
-                        loginError = (it as? IllegalStateException)?.message ?: AuthErrorMessages.completeSignInError(context)
+                        loginError =
+                            (it as? IllegalStateException)?.message
+                                ?: AuthErrorMessages.completeSignInError(context)
                     }
             }
         }

--- a/android/app/src/main/java/com/worktime/android/core/auth/AuthErrorMessages.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/AuthErrorMessages.kt
@@ -1,0 +1,47 @@
+package com.worktime.android.core.auth
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.worktime.android.R
+import net.openid.appauth.AuthorizationException
+
+internal object AuthErrorMessages {
+    fun authorizationResponseError(context: Context, exception: AuthorizationException?): String =
+        context.getString(messageRes(exception, R.string.auth_error_sign_in_cancelled))
+
+    fun tokenExchangeError(context: Context, exception: AuthorizationException?): String =
+        context.getString(messageRes(exception, R.string.auth_error_token_exchange_failed))
+
+    fun startSignInError(context: Context): String = context.getString(R.string.auth_error_start_sign_in)
+
+    fun completeSignInError(context: Context): String = context.getString(R.string.auth_error_complete_sign_in)
+
+    @StringRes
+    private fun messageRes(exception: AuthorizationException?, @StringRes fallback: Int): Int {
+        if (exception == null) return fallback
+        return when {
+            hasSameCategory(exception, AuthorizationException.GeneralErrors.NETWORK_ERROR) ->
+                R.string.auth_error_network
+
+            hasSameCategory(exception, AuthorizationException.GeneralErrors.SERVER_ERROR) ->
+                R.string.auth_error_provider_unavailable
+
+            hasSameCategory(exception, AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW) ->
+                R.string.auth_error_sign_in_cancelled
+
+            exception.type == AuthorizationException.TYPE_OAUTH_AUTHORIZATION_ERROR &&
+                exception.error == "access_denied" -> R.string.auth_error_access_denied
+
+            exception.type == AuthorizationException.TYPE_OAUTH_AUTHORIZATION_ERROR ->
+                R.string.auth_error_authorization_failed
+
+            exception.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR ->
+                R.string.auth_error_token_exchange_failed
+
+            else -> fallback
+        }
+    }
+
+    private fun hasSameCategory(actual: AuthorizationException, expected: AuthorizationException): Boolean =
+        actual.type == expected.type && actual.code == expected.code
+}

--- a/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/OidcSessionManager.kt
@@ -2,6 +2,7 @@ package com.worktime.android.core.auth
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.worktime.android.core.config.AppConfig
 import com.worktime.android.core.storage.ApiBaseUrlOverrideStore
 import com.worktime.android.core.storage.SecureSessionStore
@@ -85,7 +86,8 @@ class OidcSessionManager @Inject constructor(
         val newState = AuthState(response, exception)
 
         if (response == null) {
-            val message = exception?.errorDescription ?: "Sign-in was cancelled"
+            exception?.let { Log.w(TAG, "Authorization response failed", it) }
+            val message = AuthErrorMessages.authorizationResponseError(context, exception)
             _sessionState.value = SessionState.Error(message)
             throw IllegalStateException(message)
         }
@@ -93,7 +95,8 @@ class OidcSessionManager @Inject constructor(
         val (tokenResponse, tokenException) = performTokenRequest(response.createTokenExchangeRequest())
         newState.update(tokenResponse, tokenException)
         if (tokenException != null || tokenResponse?.accessToken.isNullOrBlank()) {
-            val message = tokenException?.errorDescription ?: "Missing access token"
+            tokenException?.let { Log.w(TAG, "Token exchange failed", it) }
+            val message = AuthErrorMessages.tokenExchangeError(context, tokenException)
             _sessionState.value = SessionState.Error(message)
             throw IllegalStateException(message)
         }
@@ -170,5 +173,9 @@ class OidcSessionManager @Inject constructor(
 
     private fun publishState(state: AuthState) {
         _sessionState.value = SessionState.Authenticated(hasRefreshToken = !state.refreshToken.isNullOrBlank())
+    }
+
+    private companion object {
+        const val TAG = "OidcSessionManager"
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,11 @@
 <resources>
     <string name="app_name">Worktime</string>
+    <string name="auth_error_access_denied">Sign-in was denied. Please try again or contact your administrator.</string>
+    <string name="auth_error_authorization_failed">Unable to complete sign-in. Please try again.</string>
+    <string name="auth_error_complete_sign_in">Unable to complete sign-in. Please try again.</string>
+    <string name="auth_error_network">Unable to reach the sign-in service. Check your connection and try again.</string>
+    <string name="auth_error_provider_unavailable">The sign-in service is unavailable. Please try again later.</string>
+    <string name="auth_error_sign_in_cancelled">Sign-in was cancelled.</string>
+    <string name="auth_error_start_sign_in">Unable to start sign-in. Please try again.</string>
+    <string name="auth_error_token_exchange_failed">Unable to finish sign-in. Please try again.</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Replace raw AppAuth exception text shown to users with friendly, localized messages to avoid leaking low-level error details and provide clearer guidance.
- Centralize auth error mapping so sign-in launch/completion fallbacks and session manager use consistent messages.
- Log AppAuth exceptions from the session manager for diagnostics while keeping UI text user-friendly.
- Add string resources for the new user-facing error states so messages are localizable.

### Description
- Added `AuthErrorMessages` helper that maps `AuthorizationException` categories (network, server, cancelled, access_denied, authorization/token errors) to Android string resources.
- Updated `OidcSessionManager` to log AppAuth exceptions (`Log.w(TAG, ...)`) and to use `AuthErrorMessages` for the message shown via `SessionState.Error` instead of raw exception descriptions.
- Updated `WorktimeApp` sign-in fallbacks to use `AuthErrorMessages.startSignInError` and `AuthErrorMessages.completeSignInError` for user-visible fallback messages.
- Added new strings in `android/app/src/main/res/values/strings.xml` for the various auth error messages.

### Testing
- Attempted to compile the Android app with `cd android && ./gradlew :app:compileDebugKotlin`, which failed due to missing Android SDK configuration (`SDK location not found`), so build/CI validation could not be completed in this environment.
- Local static/compile steps inside the environment ran partially (Gradle tasks for `buildSrc` executed) but overall app compilation failed as above.
- No automated unit/instrumentation tests were executed here; UI screenshots and runtime verification will be attached to the PR comments after a CI/build with a configured Android SDK succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a536e0415d4832ebc2e9c11c5826703)