### PR TITLE
ci: bump CodeQL Kotlin support gate to 2.4.x

### DIFF
--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -42,7 +42,7 @@ jobs:
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else
             echo "supported=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping CodeQL java-kotlin analysis: Kotlin ${kotlin_version} is newer than CodeQL's current Kotlin support."
+            echo "::warning::Skipping CodeQL java-kotlin analysis: Kotlin ${kotlin_version} is newer than CodeQL's current Kotlin support."
           fi
 
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           kotlin_version="$(awk -F '"' '/^kotlin = / { print $2 }' android/gradle/libs.versions.toml)"
-          max_supported="2.3.29"
+          max_supported="2.4.29"
           if printf '%s\n%s\n' "${kotlin_version}" "${max_supported}" | sort -V -C; then
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- CodeQL 2.26.0 adds support for Kotlin up to 2.4.0 (see [changelog](``https://github.blog/changelog/2026-07-10-codeql-2-26-0-adds-kotlin-2-4-0-support-and-ai-prompt-injection-detection/``))
- `codeql-action` is already pinned to `v4.37.0`, which bundles CodeQL CLI 2.26.0
- The Android workflow's Kotlin-version gate (`.github/workflows/codeql-android.yml`) was still capped at `2.3.29`, so the `java-kotlin` analysis was being skipped now that `android/gradle/libs.versions.toml` uses Kotlin `2.4.0`
- Raised `max_supported` to `2.4.29` so the analysis runs again

Closes #930

## Test plan
- [x] Validated YAML syntax
- [ ] Confirm the `Analyze (java-kotlin)` job runs (not skipped) on this PR's CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKVq5AtQJ5UYVDEibzt6Mf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKVq5AtQJ5UYVDEibzt6Mf)_