### PR TITLE
ci: tighten CodeQL Kotlin gate to 2.4.9 — CodeQL supports below 2.4.10

### DIFF
--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -37,7 +37,11 @@ jobs:
         run: |
           set -euo pipefail
           kotlin_version="$(awk -F '"' '/^kotlin = / { print $2 }' android/gradle/libs.versions.toml)"
-          max_supported="2.4.29"
+          # CodeQL 2.26.x supports Kotlin below 2.4.10 (2.4.0x only, not the
+          # whole 2.4.x series). Verify the exact bound in the CodeQL docs
+          # before raising this:
+          # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
+          max_supported="2.4.9"
           if printf '%s\n%s\n' "${kotlin_version}" "${max_supported}" | sort -V -C; then
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Why

The `Analyze (java-kotlin)` CodeQL job fails on #947 (Dependabot's Kotlin 2.4.0 → 2.4.10 bump) with:

> Kotlin version 2.4.10 is too recent. CodeQL currently supports versions below 2.4.10

The workflow already has a gate that skips CodeQL analysis when the project's Kotlin version outpaces CodeQL's Kotlin support — but #931 set the gate to `2.4.29`, assuming CodeQL 2.26.x covers the whole 2.4.x series (as it did for 2.3.x). It only supports 2.4.0x, so 2.4.10 passed the gate and then failed the build.

Bumping the `codeql-action` pin wouldn't help: the [CodeQL supported-versions docs](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/) confirm the latest release still tops out at Kotlin 2.4.0x.

## What

- Tighten `max_supported` from `2.4.29` to `2.4.9` in `.github/workflows/codeql-android.yml`, so 2.4.0 is still analyzed while 2.4.10+ skips with the existing `::warning::` annotation instead of failing.
- Add a comment documenting the actual bound and pointing to the CodeQL docs, so the next raise verifies the exact supported range first.

Gate behavior verified with `sort -V`: 2.4.0 and 2.4.9 → analyzed; 2.4.10 and 2.5.0 → skipped.

## Notes

Once this merges to `main`, re-running the `CodeQL Android` check on #947 will pick up the updated gate (pull_request runs use the merge commit) and go green. When CodeQL adds Kotlin 2.4.10+ support, raise the gate again as #931 did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FpUNt3ujDreDPuJYNHtGL

---
_Generated by [Claude Code](https://claude.ai/code/session_014FpUNt3ujDreDPuJYNHtGL)_