### PR TITLE
Fix nested duplicate main landmarks on the home route

### DIFF
--- a/frontend/src/components/MainTabs.tsx
+++ b/frontend/src/components/MainTabs.tsx
@@ -154,7 +154,7 @@ export function MainTabs({
 
   return (
     <>
-      <main id="main-content">
+      <div>
         <Tabs
           activeKey={activeKey}
           onSelect={(k) => {
@@ -277,7 +277,7 @@ export function MainTabs({
             </Tab>
           )}
         </Tabs>
-      </main>
+      </div>
 
       {/* Schedule Detail Modal */}
       {selectedScheduleForDetail && (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -15,7 +15,7 @@ export function HomePage() {
   } = useAppShellContext();
 
   return (
-    <main id="main-content" role="main">
+    <main id="main-content">
       <ErrorBoundary>
         <CurrentStatus
           myTeam={myTeam}

--- a/frontend/tests/components/HomePage.test.tsx
+++ b/frontend/tests/components/HomePage.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import App from "@/App";
+
+describe("HomePage", () => {
+  it("renders exactly one main landmark on the home route", async () => {
+    localStorage.setItem(
+      "worktime_user_state",
+      JSON.stringify({
+        hasCompletedOnboarding: true,
+        scheduleType: "5-shift",
+        myTeam: 1,
+      }),
+    );
+    window.history.pushState(null, "", "/");
+
+    render(<App />);
+
+    expect(await screen.findAllByRole("main")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `HomePage.tsx` and `MainTabs.tsx` both rendered a `<main id="main-content">`, with `MainTabs`'s nested inside `HomePage`'s — invalid HTML and two ambiguous "main" landmarks/duplicate IDs for screen readers and the skip link.
- `MainTabs` now renders a plain `<div>` instead of a `<main>`, so each route has exactly one `main` landmark.
- Dropped the redundant `role="main"` on `HomePage`'s `<main>` (implicit already).
- Verified `/`, `/settings`, and `/privacy` each render exactly one `#main-content` element, so the skip link in `Header.tsx` targets an unambiguous element on every route.
- Added `HomePage.test.tsx`, which asserts a single `main` landmark is rendered on the home route.

Fixes #951

## Test plan

- [x] `pnpm test` (full suite, 1484 tests passing)
- [x] `pnpm typecheck`
- [x] `pnpm lint`


---
_Generated by [Claude Code](https://claude.ai/code/session_013QT3Xuyc1MP45c4epTPWHX)_