### PR TITLE
fix(toast): announce toasts to screen readers and allow manual dismissal

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -128,6 +128,7 @@
   "loading": "Loading...",
   "error": "Error",
   "close": "Close",
+  "toast_close_aria": "Close notification",
   "save": "Save",
   "back": "Back",
   "next": "Next",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -121,6 +121,7 @@
   "loading": "Laden...",
   "error": "Fout",
   "close": "Sluiten",
+  "toast_close_aria": "Melding sluiten",
   "save": "Opslaan",
   "back": "Terug",
   "next": "Volgende",

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -142,7 +142,9 @@ export function ToastProvider({ children }: ToastProviderProps) {
             >
               <Toast.Body className="d-flex align-items-center">
                 {toast.icon && <i className={`bi ${toast.icon} me-2`} aria-hidden="true"></i>}
-                <span className={isLight ? "text-dark" : "text-white"}>{toast.message}</span>
+                <span className={`${isLight ? "text-dark" : "text-white"} me-2`}>
+                  {toast.message}
+                </span>
                 <CloseButton
                   className="ms-auto"
                   variant={isLight ? undefined : "white"}

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,6 +1,13 @@
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import CloseButton from "react-bootstrap/CloseButton";
 import Toast from "react-bootstrap/Toast";
 import ToastContainer from "react-bootstrap/ToastContainer";
+import * as m from "@/paraglide/messages.js";
+
+/** Default autohide delay for info/success/warning toasts (ms). */
+const DEFAULT_TOAST_DELAY = 4000;
+/** Longer autohide delay for error toasts so failures aren't missed (ms). */
+const ERROR_TOAST_DELAY = 10000;
 
 export interface ToastMessage {
   id: string;
@@ -57,7 +64,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
     const id = crypto.randomUUID();
     const newToast: ToastMessage = {
       id,
-      delay: 4000,
+      delay: DEFAULT_TOAST_DELAY,
       autohide: true,
       variant: "info",
       ...toast,
@@ -78,7 +85,12 @@ export function ToastProvider({ children }: ToastProviderProps) {
 
   const showError = useCallback(
     (message: string, icon?: string) => {
-      addToast({ message, variant: "danger", icon: icon ?? "bi-x-circle-fill" });
+      addToast({
+        message,
+        variant: "danger",
+        icon: icon ?? "bi-x-circle-fill",
+        delay: ERROR_TOAST_DELAY,
+      });
     },
     [addToast],
   );
@@ -113,23 +125,34 @@ export function ToastProvider({ children }: ToastProviderProps) {
     <ToastContext.Provider value={contextValue}>
       {children}
       <ToastContainer position="top-end" className="p-3 position-fixed" style={{ zIndex: 1100 }}>
-        {toasts.map((toast) => (
-          <Toast
-            key={toast.id}
-            onClose={() => removeToast(toast.id)}
-            show={true}
-            autohide={toast.autohide}
-            delay={toast.delay}
-            bg={toast.variant}
-          >
-            <Toast.Body className="d-flex align-items-center">
-              {toast.icon && <i className={`bi ${toast.icon} me-2`} aria-hidden="true"></i>}
-              <span className={toast.variant === "warning" ? "text-dark" : "text-white"}>
-                {toast.message}
-              </span>
-            </Toast.Body>
-          </Toast>
-        ))}
+        {toasts.map((toast) => {
+          const isError = toast.variant === "danger";
+          const isLight = toast.variant === "warning";
+          return (
+            <Toast
+              key={toast.id}
+              onClose={() => removeToast(toast.id)}
+              show={true}
+              autohide={toast.autohide}
+              delay={toast.delay}
+              bg={toast.variant}
+              // Errors interrupt (assertive); other toasts announce politely.
+              role={isError ? "alert" : "status"}
+              aria-live={isError ? "assertive" : "polite"}
+            >
+              <Toast.Body className="d-flex align-items-center">
+                {toast.icon && <i className={`bi ${toast.icon} me-2`} aria-hidden="true"></i>}
+                <span className={isLight ? "text-dark" : "text-white"}>{toast.message}</span>
+                <CloseButton
+                  className="ms-auto"
+                  variant={isLight ? undefined : "white"}
+                  onClick={() => removeToast(toast.id)}
+                  aria-label={m.toast_close_aria()}
+                />
+              </Toast.Body>
+            </Toast>
+          );
+        })}
       </ToastContainer>
     </ToastContext.Provider>
   );

--- a/frontend/tests/contexts/ToastContext.test.tsx
+++ b/frontend/tests/contexts/ToastContext.test.tsx
@@ -172,6 +172,59 @@ describe("ToastContext", () => {
     expect(screen.getByText("Error message")).toBeInTheDocument();
   });
 
+  it("should announce non-error toasts politely with role=status", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      screen.getByText("Show Success").click();
+    });
+
+    const toast = screen.getByRole("status");
+    expect(toast).toHaveTextContent("Success message");
+    expect(toast).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("should announce error toasts assertively with role=alert", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      screen.getByText("Show Error").click();
+    });
+
+    const toast = screen.getByRole("alert");
+    expect(toast).toHaveTextContent("Error message");
+    expect(toast).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("should dismiss a toast when the close button is clicked", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      screen.getByText("Show Success").click();
+    });
+
+    expect(screen.getByText("Success message")).toBeInTheDocument();
+
+    const closeButton = screen.getByRole("button", { name: "Close notification" });
+    act(() => {
+      closeButton.click();
+    });
+
+    expect(screen.queryByText("Success message")).not.toBeInTheDocument();
+  });
+
   it("should render toast container with correct positioning", () => {
     render(
       <ToastProvider>


### PR DESCRIPTION
## Summary

Fixes #952. Toasts rendered without live-region semantics and could only disappear via the 4-second autohide, making feedback invisible to screen reader users and impossible to dismiss or linger on manually.

## Changes

- **Screen reader announcements** — non-error toasts (info/success/warning) now use `role="status"` / `aria-live="polite"`; error toasts use `role="alert"` / `aria-live="assertive"`. (react-bootstrap's `Toast` defaults to assertive `alert`; we override it for the non-error variants.)
- **Manual dismiss** — every toast now renders a labeled `CloseButton` (`variant="white"` on colored backgrounds, default on the light warning background) so users can dismiss it themselves. This addresses WCAG 2.2.1 (Timing Adjustable). The accessible label is localized (`toast_close_aria`, added to `en.json` and `nl.json`).
- **Longer error delay** — error toasts now autohide after 10s instead of 4s so failures aren't missed. Delays are named constants (`DEFAULT_TOAST_DELAY`, `ERROR_TOAST_DELAY`).
- **Tests** — added coverage for `role=status`/`aria-live=polite` on non-error toasts, `role=alert`/`aria-live=assertive` on error toasts, and dismissal via the close button.

## Verification

- `pnpm test` — all suites pass (new ToastContext tests included)
- `pnpm typecheck` — clean
- `pnpm lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtsUshPrpX4qFboqZ3zjHB)_