### PR TITLE
feat(shortcuts): add global ? shortcut to open keyboard shortcuts overlay

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -670,6 +670,7 @@
   "shortcuts_gantt_tab": "Gantt tab",
   "shortcuts_prev_next_date": "Previous / next date",
   "shortcuts_open_settings": "Open settings",
+  "shortcuts_show_shortcuts": "Show keyboard shortcuts",
   "shortcuts_timeoff_category": "Time Off",
   "shortcuts_import_hday": "Import .hday file",
   "shortcuts_export_hday": "Export .hday file",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -663,6 +663,7 @@
   "shortcuts_gantt_tab": "Tabblad Gantt",
   "shortcuts_prev_next_date": "Vorige / volgende datum",
   "shortcuts_open_settings": "Instellingen openen",
+  "shortcuts_show_shortcuts": "Sneltoetsen tonen",
   "shortcuts_timeoff_category": "Verlof",
   "shortcuts_import_hday": ".hday-bestand importeren",
   "shortcuts_export_hday": ".hday-bestand exporteren",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,6 +130,7 @@ function AppContent() {
     : [];
   const [activeTab, setActiveTab] = useState<TabKey>(lastUsed.activeTab);
   const [showAbout, setShowAbout] = useState(false);
+  const [showShortcuts, setShowShortcuts] = useState(false);
   const { currentDate, setCurrentDate } = useShiftCalculation();
 
   const handleTabChange = useCallback(
@@ -267,6 +268,9 @@ function AppContent() {
             showAbout,
             openAbout: () => setShowAbout(true),
             closeAbout: () => setShowAbout(false),
+            showShortcuts,
+            openShortcuts: () => setShowShortcuts(true),
+            closeShortcuts: () => setShowShortcuts(false),
             myTeam,
             currentDate,
             setCurrentDate,

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -4,10 +4,12 @@ import { AboutModal } from "@/components/AboutModal";
 import { FeatureIntroAlert } from "@/components/FeatureIntroAlert";
 import { FirstSyncConflictDialog } from "@/components/FirstSyncConflictDialog";
 import { Header } from "@/components/Header";
+import { KeyboardShortcutsModal } from "@/components/KeyboardShortcutsModal";
 import { WelcomeWizard } from "@/components/WelcomeWizard";
 import { OngoingConflictDialog } from "@/components/sync/OngoingConflictDialog";
 import { useAppShellContext } from "@/contexts/AppShellContext";
 import { useOngoingSyncContext } from "@/contexts/OngoingSyncContext";
+import { useSettings } from "@/contexts/SettingsContext";
 
 /**
  * Root layout for all app routes.
@@ -18,6 +20,7 @@ import { useOngoingSyncContext } from "@/contexts/OngoingSyncContext";
  */
 export function AppLayout() {
   const shell = useAppShellContext();
+  const { settings } = useSettings();
   const { conflictCount, conflictedPayload, resolveOngoingConflicts } = useOngoingSyncContext();
 
   return (
@@ -32,6 +35,13 @@ export function AppLayout() {
         )}
         <Outlet />
         <AboutModal show={shell.showAbout} onHide={shell.closeAbout} />
+        <KeyboardShortcutsModal
+          show={shell.showShortcuts}
+          onHide={shell.closeShortcuts}
+          enableTimeOff={settings.enableTimeOff}
+          enableTimeTracking={settings.enableTimeTracking}
+          enableGantt={settings.enableGantt}
+        />
         <WelcomeWizard
           show={shell.showTeamModal}
           onTeamSelect={shell.onTeamSelect}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,6 +4,7 @@ import Container from "react-bootstrap/Container";
 import Navbar from "react-bootstrap/Navbar";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useAppShellContext } from "@/contexts/AppShellContext";
 import { SyncStatusIndicator } from "@/components/sync/SyncStatusIndicator";
 import * as m from "@/paraglide/messages.js";
 
@@ -17,6 +18,7 @@ export function Header() {
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const isSettingsPage = pathname === "/settings";
+  const { openShortcuts } = useAppShellContext();
 
   const handleToggleSettings = useCallback(() => {
     void navigate({ to: isSettingsPage ? "/" : "/settings" });
@@ -29,8 +31,9 @@ export function Header() {
   const shortcuts = useMemo(
     () => ({
       onToggleSettings: handleToggleSettings,
+      onShowShortcuts: openShortcuts,
     }),
-    [handleToggleSettings],
+    [handleToggleSettings, openShortcuts],
   );
 
   useKeyboardShortcuts(shortcuts);

--- a/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -28,6 +28,7 @@ export function KeyboardShortcutsModal({
     ...(enableGantt ? [{ keys: ["G"], description: m.shortcuts_gantt_tab() }] : []),
     { keys: ["←", "→"], description: m.shortcuts_prev_next_date() },
     { keys: ["Ctrl", ","], description: m.shortcuts_open_settings() },
+    { keys: ["?"], description: m.shortcuts_show_shortcuts() },
   ];
 
   const categories = [{ category: m.shortcuts_nav_category(), items: navigationItems }];

--- a/frontend/src/contexts/AppShellContext.tsx
+++ b/frontend/src/contexts/AppShellContext.tsx
@@ -18,6 +18,9 @@ export interface AppShellContextType {
   showAbout: boolean;
   openAbout: () => void;
   closeAbout: () => void;
+  showShortcuts: boolean;
+  openShortcuts: () => void;
+  closeShortcuts: () => void;
   myTeam: number | null;
   currentDate: Dayjs;
   setCurrentDate: (date: Dayjs) => void;

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -96,10 +96,12 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcuts) {
       switch (event.key) {
         case "?":
           // "?" (Shift+/) opens the keyboard shortcuts overlay from anywhere.
-          if (!event.ctrlKey && !event.metaKey && !event.altKey) {
+          // Only intercept when a handler is registered so consumers that don't
+          // provide onShowShortcuts don't swallow the browser's default behavior.
+          if (shortcuts.onShowShortcuts && !event.ctrlKey && !event.metaKey && !event.altKey) {
             event.preventDefault?.();
             try {
-              shortcuts.onShowShortcuts?.();
+              shortcuts.onShowShortcuts();
             } catch (error) {
               logger.error("Error in onShowShortcuts callback:", error);
             }

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -12,6 +12,7 @@ interface KeyboardShortcuts {
   onTabTimeTracking?: () => void;
   onTabGantt?: () => void;
   onToggleSettings?: () => void;
+  onShowShortcuts?: () => void;
 }
 
 /**
@@ -93,6 +94,17 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcuts) {
 
       // Handle single keys
       switch (event.key) {
+        case "?":
+          // "?" (Shift+/) opens the keyboard shortcuts overlay from anywhere.
+          if (!event.ctrlKey && !event.metaKey && !event.altKey) {
+            event.preventDefault?.();
+            try {
+              shortcuts.onShowShortcuts?.();
+            } catch (error) {
+              logger.error("Error in onShowShortcuts callback:", error);
+            }
+          }
+          break;
         case "ArrowLeft":
           if (!event.ctrlKey && !event.metaKey && !event.altKey) {
             event.preventDefault?.();

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,7 +16,6 @@ import { hasMultipleTeams } from "@/utils/scheduleUtils";
 import { type ScheduleOption } from "@/data/rosters";
 import { shareApp } from "@/utils/share";
 import { ChangelogModal } from "@/components/ChangelogModal";
-import { KeyboardShortcutsModal } from "@/components/KeyboardShortcutsModal";
 import { DevOptionsPanel } from "@/components/DevOptionsPanel";
 import { ResetSettingsModal } from "@/components/settings/data/ResetSettingsModal";
 import { SettingsAccountSection } from "@/components/settings/account/SettingsAccountSection";
@@ -49,7 +48,7 @@ const SETTINGS_SECTIONS: Array<{
 export function SettingsPage() {
   const navigate = useNavigate();
   const search = useSearch({ from: "/settings" });
-  const { openAbout } = useAppShellContext();
+  const { openAbout, openShortcuts } = useAppShellContext();
   const activeSection = search.section ?? "general";
 
   const sectionMeta = useMemo(() => {
@@ -113,6 +112,7 @@ export function SettingsPage() {
               activeSection={activeSection}
               onHide={() => void navigate({ to: "/" })}
               onShowAbout={openAbout}
+              onShowShortcuts={openShortcuts}
             />
           </div>
         </div>
@@ -134,20 +134,22 @@ export type SettingsSection =
  *
  * @param onHide - Callback invoked when a settings action should close the page
  * @param onShowAbout - Optional callback invoked to open the global About experience
+ * @param onShowShortcuts - Optional callback invoked to open the global keyboard shortcuts overlay
  * @param activeSection - Active settings section key; defaults to "general" when unset
  * @returns Rendered settings page content
  */
 export function SettingsContent({
   onHide,
   onShowAbout,
+  onShowShortcuts,
   activeSection = "general",
 }: {
   onHide: () => void;
   onShowAbout?: () => void;
+  onShowShortcuts?: () => void;
   activeSection?: SettingsSection;
 }) {
   const [showChangelog, setShowChangelog] = useState(false);
-  const [showShortcuts, setShowShortcuts] = useState(false);
   const [showDevOptions, setShowDevOptions] = useState(false);
   const [showBackupDialog, setShowBackupDialog] = useState(false);
   const restoreFileInputRef = useRef<HTMLInputElement>(null);
@@ -353,7 +355,7 @@ export function SettingsContent({
         isDevMode={isDevMode}
         onShowChangelog={() => setShowChangelog(true)}
         onShowAboutHelp={() => onShowAbout?.()}
-        onShowShortcuts={() => setShowShortcuts(true)}
+        onShowShortcuts={() => onShowShortcuts?.()}
         onShowDevOptions={() => setShowDevOptions(true)}
       />
     ),
@@ -393,15 +395,6 @@ export function SettingsContent({
 
       {/* Changelog Modal */}
       <ChangelogModal show={showChangelog} onHide={() => setShowChangelog(false)} />
-
-      {/* Keyboard Shortcuts Modal */}
-      <KeyboardShortcutsModal
-        show={showShortcuts}
-        onHide={() => setShowShortcuts(false)}
-        enableTimeOff={settings.enableTimeOff}
-        enableTimeTracking={settings.enableTimeTracking}
-        enableGantt={settings.enableGantt}
-      />
 
       {/* Developer Options Modal */}
       <DevOptionsPanel show={showDevOptions} onHide={() => setShowDevOptions(false)} />

--- a/frontend/tests/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/tests/hooks/useKeyboardShortcuts.test.ts
@@ -10,6 +10,7 @@ describe("useKeyboardShortcuts", () => {
     onTeamSelect: vi.fn(),
     onTabTimeTracking: vi.fn(),
     onTabGantt: vi.fn(),
+    onShowShortcuts: vi.fn(),
   };
 
   beforeEach(() => {
@@ -124,5 +125,41 @@ describe("useKeyboardShortcuts", () => {
     document.dispatchEvent(event);
 
     expect(mockShortcuts.onTabGantt).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers onShowShortcuts when ? (Shift+/) is pressed", () => {
+    renderHook(() => useKeyboardShortcuts(mockShortcuts));
+
+    const event = new KeyboardEvent("keydown", { key: "?", shiftKey: true });
+    document.dispatchEvent(event);
+
+    expect(mockShortcuts.onShowShortcuts).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger onShowShortcuts when typing ? in an input", () => {
+    renderHook(() => useKeyboardShortcuts(mockShortcuts));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    const event = new KeyboardEvent("keydown", { key: "?", shiftKey: true });
+    Object.defineProperty(event, "target", { value: input });
+    document.dispatchEvent(event);
+
+    expect(mockShortcuts.onShowShortcuts).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it("does not trigger onShowShortcuts when ? is combined with Ctrl/Meta/Alt", () => {
+    renderHook(() => useKeyboardShortcuts(mockShortcuts));
+
+    for (const modifier of ["ctrlKey", "metaKey", "altKey"] as const) {
+      const event = new KeyboardEvent("keydown", { key: "?", [modifier]: true });
+      document.dispatchEvent(event);
+    }
+
+    expect(mockShortcuts.onShowShortcuts).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes #954.

Adds the de-facto keyboard-driven-app convention of pressing `?` (Shift+/) to open the keyboard shortcuts overlay from anywhere, so users discover shortcuts without digging through Settings.

## Changes

- **Register `?` in `useKeyboardShortcuts.ts`** — new optional `onShowShortcuts` callback fires on `?`, guarded so it's ignored when typing in inputs/textareas/selects/contentEditable and when combined with Ctrl/Meta/Alt.
- **Lift modal state into `AppShellContext`** — added `showShortcuts` / `openShortcuts` / `closeShortcuts`, wired the state in `App.tsx`, and render a single `KeyboardShortcutsModal` in `AppLayout` (feature flags sourced from `useSettings`). Since every route renders under `AppLayout` and `Header` is always mounted, the shortcut works globally, including on the Settings page.
- **Header** — wires the `?` shortcut to `openShortcuts`.
- **Settings → About entry point preserved** — `SettingsPage` now passes the shared `openShortcuts` down to `SettingsContent`; the local modal state and render were removed in favor of the global one.
- **List `?` in the modal** — new `shortcuts_show_shortcuts` message (en/nl) shown in the Navigation section.

## Testing

- Added tests for the `?` binding: fires `onShowShortcuts`, is ignored while typing in an input, and is ignored when combined with Ctrl/Meta/Alt.
- `pnpm typecheck`, `pnpm lint` (only pre-existing warnings), and `pnpm test` (1497 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHFbA91KjAneXHHCYn61qF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHFbA91KjAneXHHCYn61qF)_