### PR TITLE
Make main tab navigation icon-only on phone widths

### DIFF
--- a/frontend/src/components/MainTabs.tsx
+++ b/frontend/src/components/MainTabs.tsx
@@ -163,15 +163,17 @@ export function MainTabs({
             setActiveTab(newKey);
           }}
           id={tabsId}
+          className="main-tabs"
         >
           <Tab
             eventKey="calendar"
             title={
               <>
-                <i className="bi bi-calendar3 me-1" aria-hidden="true"></i>
-                {m.tab_calendar()}
+                <i className="bi bi-calendar3" aria-hidden="true"></i>
+                <span className="main-tab-label">{m.tab_calendar()}</span>
               </>
             }
+            tabAttrs={{ "aria-label": m.tab_calendar() }}
           >
             {activeKey === "calendar" && (
               <Suspense fallback={loadingFallback}>
@@ -190,10 +192,11 @@ export function MainTabs({
               eventKey="unified-calendar"
               title={
                 <>
-                  <i className="bi bi-calendar-range me-1" aria-hidden="true"></i>
-                  {m.tab_unified_calendar()}
+                  <i className="bi bi-calendar-range" aria-hidden="true"></i>
+                  <span className="main-tab-label">{m.tab_unified_calendar()}</span>
                 </>
               }
+              tabAttrs={{ "aria-label": m.tab_unified_calendar() }}
             >
               {activeKey === "unified-calendar" && (
                 <Suspense fallback={loadingFallback}>
@@ -210,10 +213,11 @@ export function MainTabs({
             eventKey="schedule"
             title={
               <>
-                <i className="bi bi-calendar-week me-1" aria-hidden="true"></i>
-                {m.tab_schedule()}
+                <i className="bi bi-calendar-week" aria-hidden="true"></i>
+                <span className="main-tab-label">{m.tab_schedule()}</span>
               </>
             }
+            tabAttrs={{ "aria-label": m.tab_schedule() }}
           >
             <ScheduleTabView
               myTeam={myTeam}
@@ -231,10 +235,11 @@ export function MainTabs({
               eventKey="timeoff"
               title={
                 <>
-                  <i className="bi bi-calendar-check me-1" aria-hidden="true"></i>
-                  {m.tab_time_off()}
+                  <i className="bi bi-calendar-check" aria-hidden="true"></i>
+                  <span className="main-tab-label">{m.tab_time_off()}</span>
                 </>
               }
+              tabAttrs={{ "aria-label": m.tab_time_off() }}
             >
               <Suspense fallback={loadingFallback}>
                 <TimeOffView isActive={activeKey === "timeoff"} />
@@ -247,10 +252,11 @@ export function MainTabs({
               eventKey="timetracking"
               title={
                 <>
-                  <i className="bi bi-stopwatch me-1" aria-hidden="true"></i>
-                  {m.tab_time_tracking()}
+                  <i className="bi bi-stopwatch" aria-hidden="true"></i>
+                  <span className="main-tab-label">{m.tab_time_tracking()}</span>
                 </>
               }
+              tabAttrs={{ "aria-label": m.tab_time_tracking() }}
             >
               {activeKey === "timetracking" && (
                 <Suspense fallback={loadingFallback}>
@@ -265,10 +271,11 @@ export function MainTabs({
               eventKey="gantt"
               title={
                 <>
-                  <i className="bi bi-bar-chart-steps me-1" aria-hidden="true"></i>
-                  {m.tab_gantt()}
+                  <i className="bi bi-bar-chart-steps" aria-hidden="true"></i>
+                  <span className="main-tab-label">{m.tab_gantt()}</span>
                 </>
               }
+              tabAttrs={{ "aria-label": m.tab_gantt() }}
             >
               {activeKey === "gantt" && (
                 <Suspense fallback={loadingFallback}>

--- a/frontend/src/styles/_utilities.scss
+++ b/frontend/src/styles/_utilities.scss
@@ -148,6 +148,36 @@ body {
 }
 
 /* ============================================================================
+   MAIN TAB NAVIGATION
+   ========================================================================= */
+
+/* Scroll instead of wrap so the bar never breaks into a cramped second row */
+.main-tabs {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+
+  .nav-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    min-height: 44px;
+    white-space: nowrap;
+  }
+}
+
+/* Icon-only tabs below `sm` keep the bar to a single row on phone widths;
+   the accessible name is preserved via `aria-label` on the nav link. */
+@media (width <= 575.98px) {
+  .main-tab-label {
+    display: none;
+  }
+}
+
+/* ============================================================================
    SYNC STATUS INDICATOR
    ========================================================================= */
 

--- a/frontend/src/styles/_utilities.scss
+++ b/frontend/src/styles/_utilities.scss
@@ -159,6 +159,10 @@ body {
   scrollbar-width: thin;
   -webkit-overflow-scrolling: touch;
 
+  .nav-item {
+    flex-shrink: 0;
+  }
+
   .nav-link {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary

- `MainTabs` renders up to 6 top-level tabs, each with an icon and an always-visible text label. Bootstrap `nav-tabs` wrap by default, so below ~576px the bar wrapped into a cramped multi-row layout.
- Wrap each tab's label text in a `.main-tab-label` span that's hidden below the `sm` breakpoint (≤575.98px), leaving icon-only tabs on phone widths. The accessible name is preserved via `aria-label` (set through react-bootstrap's `tabAttrs`) regardless of whether the label text is visible.
- The nav is switched from wrap to `flex-nowrap` + horizontal `overflow-x: auto` as a safety net, so it scrolls instead of wrapping if labels/tab count ever exceed the available width again (e.g. longer translated strings).
- Nav links get `min-height: 44px` and use flex `gap` for icon/label spacing (instead of a fixed margin) so the icon stays centered whether or not the label is visible.

## Testing

- `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass.
- Verified manually with all optional tabs enabled (Unified Calendar, Time Off, Time Tracking, Gantt → 6 tabs total):
  - At 360px: tab bar is icon-only and fits in a single row (previously wrapped into 3 rows of 2).
  - At 1280px: unchanged, tabs still show icon + label.

Closes #955

---
_Generated by [Claude Code](https://claude.ai/code/session_013s4xe8GDRGgsa2ZMfopzvu)_