### PR TITLE
fix(time-tracking): re-balance TaskEntryForm columns when Gantt picker shown

### DIFF
--- a/frontend/src/components/timeTracking/TaskEntryForm.tsx
+++ b/frontend/src/components/timeTracking/TaskEntryForm.tsx
@@ -56,6 +56,7 @@ export function TaskEntryForm({
   onStartNow,
 }: TaskEntryFormProps) {
   const selectedLabelOption = useSelectedLabelOption(labels, label);
+  const primaryFieldWidth = showGanttPicker ? 2 : 3;
 
   const renderDisabledTooltipButton = (
     buttonKey: string,
@@ -81,7 +82,7 @@ export function TaskEntryForm({
 
   return (
     <Row className="g-3 align-items-end">
-      <Col md={3}>
+      <Col md={primaryFieldWidth}>
         <Form.Group controlId="timeTrackerTask">
           <Form.Label>{m.form_task()}</Form.Label>
           <Form.Control
@@ -91,7 +92,7 @@ export function TaskEntryForm({
           />
         </Form.Group>
       </Col>
-      <Col md={3}>
+      <Col md={primaryFieldWidth}>
         <Form.Group controlId="timeTrackerLabel">
           <Form.Label>{m.form_label()}</Form.Label>
           <ReactSelect<LabelOption>
@@ -109,7 +110,7 @@ export function TaskEntryForm({
         </Form.Group>
       </Col>
       {showGanttPicker && (
-        <Col md={3}>
+        <Col md={primaryFieldWidth}>
           <Form.Group controlId="timeTrackerGanttTask">
             <Form.Label>{m.tt_gantt_task()}</Form.Label>
             <Form.Select value={ganttTaskId} onChange={(event) => onGanttTaskChange(event.target.value)}>


### PR DESCRIPTION
## Summary

- Fixes #959: `TaskEntryForm`'s field row overflowed Bootstrap's 12-column grid (summed to 15) whenever the Gantt task picker was shown, causing it to wrap onto a visually disconnected second line.
- Task and Label columns now shrink from `md={3}` to `md={2}` whenever the Gantt column is present, keeping the row at exactly 12 columns in both states (with and without `enableGantt`).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (1508 tests passed)
- [x] Verified visually in-browser at 1280px width with `enableGantt` on and off — row no longer wraps in either state
