### PR TITLE
Surface linked Gantt task on time-tracking entries; gate picker on task existence

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1140,6 +1140,7 @@
   "dev_hday_helper_failed": "✗ Could not connect to .hday helper — check URL and ensure it is running",
   "tt_gantt_task": "Gantt task",
   "tt_no_gantt_task": "No Gantt task",
+  "tt_gantt_task_badge": "Gantt: {name}",
   "gantt_logged_time_heading": "Logged time",
   "gantt_logged_total": "{duration} logged",
   "gantt_logged_empty": "No time has been logged for this task yet.",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -1120,6 +1120,7 @@
   "dev_hday_helper_failed": "✗ Kan geen verbinding maken met .hday-helper — controleer de URL en zorg dat deze actief is",
   "tt_gantt_task": "Gantt-taak",
   "tt_no_gantt_task": "Geen Gantt-taak",
+  "tt_gantt_task_badge": "Gantt: {name}",
   "gantt_logged_time_heading": "Gelogde tijd",
   "gantt_logged_total": "{duration} gelogd",
   "gantt_logged_empty": "Er is nog geen tijd gelogd voor deze taak.",

--- a/frontend/src/components/timeTracking/DailyTaskList.tsx
+++ b/frontend/src/components/timeTracking/DailyTaskList.tsx
@@ -90,7 +90,14 @@ function GapIndicator({ durationMinutes }: { durationMinutes: number }) {
         placement="top"
         overlay={<Tooltip id={tooltipId}>{m.tt_gap_aria({ minutes: durationMinutes })}</Tooltip>}
       >
-        <Badge bg="warning" text="dark" pill className="flex-shrink-0" style={{ fontSize: "0.75rem" }} tabIndex={0}>
+        <Badge
+          bg="warning"
+          text="dark"
+          pill
+          className="flex-shrink-0"
+          style={{ fontSize: "0.75rem" }}
+          tabIndex={0}
+        >
           <i className="bi bi-hourglass-split me-1" aria-hidden="true" />
           {m.tt_gap_label({ minutes: durationMinutes })}
         </Badge>
@@ -156,6 +163,14 @@ export function DailyTaskList({
     [labels],
   );
   const labelNameById = useMemo(() => buildLabelNameMap(labels), [labels]);
+  const ganttTaskNameById = useMemo(
+    () =>
+      ganttTasks.reduce<Record<string, string>>((map, task) => {
+        map[task.id] = task.name;
+        return map;
+      }, {}),
+    [ganttTasks],
+  );
 
   const editingTask = editingTaskId
     ? (tasks.find((task) => task.id === editingTaskId) ?? externalEditingTask)
@@ -208,7 +223,14 @@ export function DailyTaskList({
   const closeEditModal = useCallback(() => {
     setEditingTaskId(null);
     setExternalEditingTask(null);
-    setEditForm({ text: "", label: "", start: "", stop: "", includesBreak: false, ganttTaskId: "" });
+    setEditForm({
+      text: "",
+      label: "",
+      start: "",
+      stop: "",
+      includesBreak: false,
+      ganttTaskId: "",
+    });
     setEditError("");
     setEditInfo("");
   }, []);
@@ -437,6 +459,9 @@ export function DailyTaskList({
             const labelTextColor = getContrastingTextColor(labelBackground);
             const isCurrentTask = nowPosition?.type === "within" && nowPosition.taskIndex === index;
             const gap = gapAfter[index] ?? null;
+            const ganttTaskName = task.ganttTaskId
+              ? ganttTaskNameById[task.ganttTaskId]
+              : undefined;
             return (
               <Fragment key={task.id}>
                 <ListGroup.Item
@@ -479,6 +504,26 @@ export function DailyTaskList({
                             >
                               <i className="bi bi-cup-hot me-1" aria-hidden="true"></i>-
                               {BREAK_DURATION_MINUTES}min
+                            </Badge>
+                          </OverlayTrigger>
+                        )}
+                        {ganttTaskName && (
+                          <OverlayTrigger
+                            placement="top"
+                            overlay={
+                              <Tooltip id={`gantt-badge-${task.id}`}>
+                                {m.tt_gantt_task_badge({ name: ganttTaskName })}
+                              </Tooltip>
+                            }
+                          >
+                            <Badge
+                              bg="info"
+                              className="ms-2"
+                              aria-label={m.tt_gantt_task_badge({ name: ganttTaskName })}
+                              tabIndex={0}
+                            >
+                              <i className="bi bi-bar-chart-steps me-1" aria-hidden="true"></i>
+                              {ganttTaskName}
                             </Badge>
                           </OverlayTrigger>
                         )}
@@ -550,4 +595,3 @@ export function DailyTaskList({
     </>
   );
 }
-

--- a/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
+++ b/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
@@ -70,6 +70,7 @@ export function TimeTrackingDailyView({
   const [error, setError] = useState("");
   const { settings } = useSettings();
   const { tasks: ganttTasks } = useGanttTasks();
+  const showGanttPicker = settings.enableGantt && ganttTasks.length > 0;
   const toast = useToast();
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const liveTime = useLiveTime({ precision: "second" });
@@ -348,7 +349,7 @@ export function TimeTrackingDailyView({
           ganttTasks={ganttTasks}
           ganttTaskId={selectedGanttTaskId}
           onGanttTaskChange={setSelectedGanttTaskId}
-          showGanttPicker={settings.enableGantt}
+          showGanttPicker={showGanttPicker}
           start={start}
           onStartChange={setStart}
           stop={stop}
@@ -372,7 +373,7 @@ export function TimeTrackingDailyView({
           tasks={dailyTasks}
           labels={labels}
           ganttTasks={ganttTasks}
-          showGanttPicker={settings.enableGantt}
+          showGanttPicker={showGanttPicker}
           editRequest={editRequest}
           onEditRequestHandled={() => setEditRequest(null)}
           onUpdateTask={handleUpdateTask}

--- a/frontend/tests/components/timeTracking/DailyTaskList.test.tsx
+++ b/frontend/tests/components/timeTracking/DailyTaskList.test.tsx
@@ -5,6 +5,7 @@ import "@testing-library/jest-dom";
 import { DailyTaskList } from "@/components/timeTracking/DailyTaskList";
 import type { StoredTimeTrackingTask } from "@/components/timeTracking/types";
 import type { TimeTrackingLabel } from "@/components/timeTracking/constants";
+import type { GanttTask } from "@/types/gantt";
 import { dayjs } from "@/utils/dateTimeUtils";
 
 const TEST_LABELS: TimeTrackingLabel[] = [
@@ -37,12 +38,19 @@ describe("DailyTaskList", () => {
   const renderList = (
     tasks: StoredTimeTrackingTask[],
     labels = TEST_LABELS,
-    opts: { liveTime?: ReturnType<typeof dayjs>; isToday?: boolean } = {},
+    opts: {
+      liveTime?: ReturnType<typeof dayjs>;
+      isToday?: boolean;
+      ganttTasks?: GanttTask[];
+      showGanttPicker?: boolean;
+    } = {},
   ) =>
     render(
       <DailyTaskList
         tasks={tasks}
         labels={labels}
+        ganttTasks={opts.ganttTasks ?? []}
+        showGanttPicker={opts.showGanttPicker ?? false}
         onUpdateTask={onUpdateTask}
         onRemoveTask={onRemoveTask}
         onToggleBreak={onToggleBreak}
@@ -63,6 +71,35 @@ describe("DailyTaskList", () => {
       renderList([makeTask()]);
 
       expect(screen.queryByText("-30min")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Gantt task badge", () => {
+    const GANTT_TASKS: GanttTask[] = [
+      { id: "gantt-1", name: "Plan release", start: "2026-02-01", end: "2026-02-10", progress: 0 },
+    ];
+
+    it("renders a badge with the linked Gantt task's name", () => {
+      renderList([makeTask({ ganttTaskId: "gantt-1" })], TEST_LABELS, {
+        ganttTasks: GANTT_TASKS,
+      });
+
+      expect(screen.getByText("Plan release")).toBeInTheDocument();
+      expect(screen.getByLabelText("Gantt: Plan release")).toBeInTheDocument();
+    });
+
+    it("does not render a badge when the task has no linked Gantt task", () => {
+      renderList([makeTask()], TEST_LABELS, { ganttTasks: GANTT_TASKS });
+
+      expect(screen.queryByLabelText(/^Gantt:/)).not.toBeInTheDocument();
+    });
+
+    it("does not render a badge when the linked Gantt task no longer exists", () => {
+      renderList([makeTask({ ganttTaskId: "missing-task" })], TEST_LABELS, {
+        ganttTasks: GANTT_TASKS,
+      });
+
+      expect(screen.queryByLabelText(/^Gantt:/)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/components/timeTracking/TimeTrackingDailyView.test.tsx
+++ b/frontend/tests/components/timeTracking/TimeTrackingDailyView.test.tsx
@@ -4,9 +4,11 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { TimeTrackingDailyView } from "@/components/timeTracking/TimeTrackingDailyView";
 import { ToastProvider } from "@/contexts/ToastContext";
-import { SettingsProvider } from "@/contexts/SettingsContext";
+import { SettingsProvider, defaultSettings } from "@/contexts/SettingsContext";
 import type { StoredTimeTrackingTask, TimeTrackingTemplate } from "@/components/timeTracking/types";
 import { dayjs } from "@/utils/dateTimeUtils";
+import { ganttTasksCollection } from "@/db/collections";
+import { USER_STATE_STORAGE_KEY } from "@/constants/storageKeys";
 
 const TEST_LABELS = [
   { id: "Development", name: "Development", color: "#198754" },
@@ -490,6 +492,49 @@ describe("TimeTrackingDailyView", () => {
         newStartTime: `${today}T09:00`,
         newStopTime: `${today}T11:00`,
       });
+    });
+  });
+
+  describe("Gantt picker visibility", () => {
+    afterEach(() => {
+      window.localStorage.clear();
+    });
+
+    const enableGantt = () => {
+      window.localStorage.setItem(
+        USER_STATE_STORAGE_KEY,
+        JSON.stringify({ settings: { ...defaultSettings, enableGantt: true } }),
+      );
+    };
+
+    it("hides the Gantt task picker when the feature is disabled", () => {
+      renderView();
+
+      expect(screen.queryByLabelText(/^Gantt task$/i)).not.toBeInTheDocument();
+    });
+
+    it("hides the Gantt task picker when enabled but no Gantt tasks exist", () => {
+      enableGantt();
+      renderView();
+
+      expect(screen.queryByLabelText(/^Gantt task$/i)).not.toBeInTheDocument();
+    });
+
+    it("shows the Gantt task picker when enabled and Gantt tasks exist", () => {
+      enableGantt();
+      ganttTasksCollection.utils.writeUpsert([
+        {
+          id: "gantt-1",
+          name: "Plan release",
+          start: "2026-03-01",
+          end: "2026-03-05",
+          progress: 0,
+        },
+      ]);
+
+      renderView();
+
+      expect(screen.getByLabelText(/^Gantt task$/i)).toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/components/timeTracking/TimeTrackingDailyView.test.tsx
+++ b/frontend/tests/components/timeTracking/TimeTrackingDailyView.test.tsx
@@ -496,10 +496,6 @@ describe("TimeTrackingDailyView", () => {
   });
 
   describe("Gantt picker visibility", () => {
-    afterEach(() => {
-      window.localStorage.clear();
-    });
-
     const enableGantt = () => {
       window.localStorage.setItem(
         USER_STATE_STORAGE_KEY,


### PR DESCRIPTION
## Summary

- `DailyTaskList` now renders a badge (icon + Gantt task name) on any row whose `ganttTaskId` is set, so the link is visible without reopening the edit modal.
- `showGanttPicker` in `TimeTrackingDailyView` is now gated on `settings.enableGantt && ganttTasks.length > 0` (previously just the feature flag), for both the `TaskEntryForm` and `TaskEditModal`/`DailyTaskList` call sites. This hides the picker until there's at least one Gantt task to select.
- Added a new `tt_gantt_task_badge` message ("Gantt: {name}") in `en.json`/`nl.json`.

The weekly view (`WeeklyDataView`/`WeeklyCells`) only renders aggregated hour totals, not individual task rows, so there's nothing to add a per-task badge to there.

Fixes #960

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run` (full suite, 1514 tests passing)
- [x] Added tests: `DailyTaskList.test.tsx` (badge shows/hides correctly, including a stale `ganttTaskId` pointing at a deleted task) and `TimeTrackingDailyView.test.tsx` (picker hidden when disabled, hidden when enabled with zero tasks, shown when enabled with tasks)


---
_Generated by [Claude Code](https://claude.ai/code/session_014FqUW5FMeMJWarEx3vn1Nz)_