### PR TITLE
Replace bare native select with react-select for Gantt task picker

### DIFF
--- a/frontend/src/components/timeTracking/TaskEditModal.tsx
+++ b/frontend/src/components/timeTracking/TaskEditModal.tsx
@@ -63,6 +63,10 @@ export function TaskEditModal({
 
   const selectedLabelOption = useSelectedLabelOption(labels, value.label);
   const selectedGanttTaskOption = useSelectedGanttTaskOption(ganttTasks, value.ganttTaskId);
+  const ganttTaskOptions = useMemo(
+    () => ganttTasks.map((task) => ({ value: task.id, label: task.name })),
+    [ganttTasks],
+  );
 
   return (
     <Modal show={show} onHide={onClose} centered>
@@ -118,9 +122,9 @@ export function TaskEditModal({
                 isSearchable
                 inputId="editTaskGanttTask"
                 placeholder={m.tt_no_gantt_task()}
-                options={ganttTasks.map((task) => ({ value: task.id, label: task.name }))}
+                options={ganttTaskOptions}
                 value={selectedGanttTaskOption}
-                onChange={(selected) => onChange({ ...value, ganttTaskId: selected?.value ?? "" })}
+                onChange={(selected) => onChange({ ...value, ganttTaskId: selected?.value })}
                 classNames={bootstrapSelectClassNames}
               />
             </Form.Group>

--- a/frontend/src/components/timeTracking/TaskEditModal.tsx
+++ b/frontend/src/components/timeTracking/TaskEditModal.tsx
@@ -9,6 +9,10 @@ import type { TimeTrackingLabel } from "./constants";
 import { BREAK_DURATION_MINUTES } from "./timeUtils";
 import { bootstrapSelectClassNames } from "@/utils/reactSelectStyles";
 import { useSelectedLabelOption, type LabelOption } from "@/hooks/useSelectedLabelOption";
+import {
+  useSelectedGanttTaskOption,
+  type GanttTaskOption,
+} from "@/hooks/useSelectedGanttTaskOption";
 import * as m from "@/paraglide/messages.js";
 import type { GanttTask } from "@/types/gantt";
 
@@ -58,6 +62,7 @@ export function TaskEditModal({
   }, [value.start, value.stop]);
 
   const selectedLabelOption = useSelectedLabelOption(labels, value.label);
+  const selectedGanttTaskOption = useSelectedGanttTaskOption(ganttTasks, value.ganttTaskId);
 
   return (
     <Modal show={show} onHide={onClose} centered>
@@ -107,17 +112,17 @@ export function TaskEditModal({
           {showGanttPicker && (
             <Form.Group controlId="editTaskGanttTask" className="mb-3">
               <Form.Label>{m.tt_gantt_task()}</Form.Label>
-              <Form.Select
-                value={value.ganttTaskId ?? ""}
-                onChange={(event) => onChange({ ...value, ganttTaskId: event.target.value })}
-              >
-                <option value="">{m.tt_no_gantt_task()}</option>
-                {ganttTasks.map((task) => (
-                  <option key={task.id} value={task.id}>
-                    {task.name}
-                  </option>
-                ))}
-              </Form.Select>
+              <ReactSelect<GanttTaskOption>
+                unstyled
+                isClearable
+                isSearchable
+                inputId="editTaskGanttTask"
+                placeholder={m.tt_no_gantt_task()}
+                options={ganttTasks.map((task) => ({ value: task.id, label: task.name }))}
+                value={selectedGanttTaskOption}
+                onChange={(selected) => onChange({ ...value, ganttTaskId: selected?.value ?? "" })}
+                classNames={bootstrapSelectClassNames}
+              />
             </Form.Group>
           )}
           <div className="d-flex gap-3 mb-3">

--- a/frontend/src/components/timeTracking/TaskEntryForm.tsx
+++ b/frontend/src/components/timeTracking/TaskEntryForm.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
@@ -61,6 +62,10 @@ export function TaskEntryForm({
 }: TaskEntryFormProps) {
   const selectedLabelOption = useSelectedLabelOption(labels, label);
   const selectedGanttTaskOption = useSelectedGanttTaskOption(ganttTasks, ganttTaskId);
+  const ganttTaskOptions = useMemo(
+    () => ganttTasks.map((task) => ({ value: task.id, label: task.name })),
+    [ganttTasks],
+  );
   const primaryFieldWidth = showGanttPicker ? 2 : 3;
 
   const renderDisabledTooltipButton = (
@@ -124,7 +129,7 @@ export function TaskEntryForm({
               isSearchable
               inputId="timeTrackerGanttTask"
               placeholder={m.tt_no_gantt_task()}
-              options={ganttTasks.map((task) => ({ value: task.id, label: task.name }))}
+              options={ganttTaskOptions}
               value={selectedGanttTaskOption}
               onChange={(selected) => onGanttTaskChange(selected?.value ?? "")}
               classNames={bootstrapSelectClassNames}

--- a/frontend/src/components/timeTracking/TaskEntryForm.tsx
+++ b/frontend/src/components/timeTracking/TaskEntryForm.tsx
@@ -10,6 +10,10 @@ import type { TimeTrackingLabel } from "./constants";
 import type { GanttTask } from "@/types/gantt";
 import { bootstrapSelectClassNames } from "@/utils/reactSelectStyles";
 import { useSelectedLabelOption, type LabelOption } from "@/hooks/useSelectedLabelOption";
+import {
+  useSelectedGanttTaskOption,
+  type GanttTaskOption,
+} from "@/hooks/useSelectedGanttTaskOption";
 import * as m from "@/paraglide/messages.js";
 
 type TaskEntryFormProps = {
@@ -56,6 +60,7 @@ export function TaskEntryForm({
   onStartNow,
 }: TaskEntryFormProps) {
   const selectedLabelOption = useSelectedLabelOption(labels, label);
+  const selectedGanttTaskOption = useSelectedGanttTaskOption(ganttTasks, ganttTaskId);
   const primaryFieldWidth = showGanttPicker ? 2 : 3;
 
   const renderDisabledTooltipButton = (
@@ -113,14 +118,17 @@ export function TaskEntryForm({
         <Col md={primaryFieldWidth}>
           <Form.Group controlId="timeTrackerGanttTask">
             <Form.Label>{m.tt_gantt_task()}</Form.Label>
-            <Form.Select value={ganttTaskId} onChange={(event) => onGanttTaskChange(event.target.value)}>
-              <option value="">{m.tt_no_gantt_task()}</option>
-              {ganttTasks.map((task) => (
-                <option key={task.id} value={task.id}>
-                  {task.name}
-                </option>
-              ))}
-            </Form.Select>
+            <ReactSelect<GanttTaskOption>
+              unstyled
+              isClearable
+              isSearchable
+              inputId="timeTrackerGanttTask"
+              placeholder={m.tt_no_gantt_task()}
+              options={ganttTasks.map((task) => ({ value: task.id, label: task.name }))}
+              value={selectedGanttTaskOption}
+              onChange={(selected) => onGanttTaskChange(selected?.value ?? "")}
+              classNames={bootstrapSelectClassNames}
+            />
           </Form.Group>
         </Col>
       )}

--- a/frontend/src/hooks/useSelectedGanttTaskOption.ts
+++ b/frontend/src/hooks/useSelectedGanttTaskOption.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import type { GanttTask } from "@/types/gantt";
+
+export type GanttTaskOption = { value: string; label: string };
+
+export function useSelectedGanttTaskOption(
+  ganttTasks: GanttTask[],
+  ganttTaskId: string | undefined | null,
+): GanttTaskOption | null {
+  return useMemo(() => {
+    if (!ganttTaskId) {
+      return null;
+    }
+
+    const selected = ganttTasks.find((task) => task.id === ganttTaskId);
+    return selected ? { value: selected.id, label: selected.name } : null;
+  }, [ganttTasks, ganttTaskId]);
+}


### PR DESCRIPTION
## Summary
- Replace the bare Bootstrap `<Form.Select>` used for the Gantt task picker in `TaskEntryForm.tsx` and `TaskEditModal.tsx` with a styled, searchable `react-select`, matching the existing Label picker (`bootstrapSelectClassNames` pattern).
- Add a `useSelectedGanttTaskOption` hook mirroring the existing `useSelectedLabelOption` hook to compute the selected `{ value, label }` option for the Gantt task react-select.

Fixes #961

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (full suite, 1514 tests passed)
- [x] Manually drove the app (dev server + headless Chromium): enabled the Gantt feature, added a Gantt task, and verified the Gantt task picker in both the daily time-tracking entry form and the edit-task modal now renders as a searchable react-select consistent with the Label field, in both closed and open (dropdown) states.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjGLwyea9B8V8WyFSU1GPn)_