### PR TITLE
Fix invisible 0% progress bar and unlocalized dates in Gantt table view

### DIFF
--- a/frontend/src/components/gantt/GanttTableView.tsx
+++ b/frontend/src/components/gantt/GanttTableView.tsx
@@ -47,9 +47,10 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
     [sortColumn, sortDirection, tasks],
   );
 
+  const locale = getLocale();
   const dateFormatter = useMemo(
-    () => new Intl.DateTimeFormat(getLocale() === "nl" ? "nl-NL" : "en-US", { dateStyle: "medium" }),
-    [],
+    () => new Intl.DateTimeFormat(locale, { dateStyle: "medium" }),
+    [locale],
   );
   const formatDate = (isoDate: string) => dateFormatter.format(dayjs(isoDate).toDate());
 

--- a/frontend/src/components/gantt/GanttTableView.tsx
+++ b/frontend/src/components/gantt/GanttTableView.tsx
@@ -3,10 +3,12 @@ import Button from "react-bootstrap/Button";
 import ProgressBar from "react-bootstrap/ProgressBar";
 import Table from "react-bootstrap/Table";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
+import { dayjs } from "@/utils/dateTimeUtils";
 import { getGanttDeleteConfirmMessage } from "@/utils/ganttDeleteConfirm";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
 import type { GanttTask } from "@/types/gantt";
 import * as m from "@/paraglide/messages.js";
+import { getLocale } from "@/paraglide/runtime.js";
 
 type SortColumn = "name" | "start";
 type SortDirection = "asc" | "desc";
@@ -44,6 +46,12 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
       }),
     [sortColumn, sortDirection, tasks],
   );
+
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(getLocale() === "nl" ? "nl-NL" : "en-US", { dateStyle: "medium" }),
+    [],
+  );
+  const formatDate = (isoDate: string) => dateFormatter.format(dayjs(isoDate).toDate());
 
   const handleSort = (column: SortColumn) => {
     if (column === sortColumn) {
@@ -129,10 +137,13 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
                     {task.name}
                   </Button>
                 </td>
-                <td>{task.start}</td>
-                <td>{task.end}</td>
+                <td>{formatDate(task.start)}</td>
+                <td>{formatDate(task.end)}</td>
                 <td style={{ minWidth: "8rem" }}>
-                  <ProgressBar now={task.progress} label={`${task.progress}%`} />
+                  <div className="d-flex align-items-center gap-2">
+                    <ProgressBar now={task.progress} className="border flex-grow-1" />
+                    <span className="small text-muted text-nowrap">{task.progress}%</span>
+                  </div>
                 </td>
                 <td>{getDependencies(task.dependencies)}</td>
                 <td title={task.notes}>{task.notes || "—"}</td>

--- a/frontend/tests/components/gantt/GanttTableView.test.tsx
+++ b/frontend/tests/components/gantt/GanttTableView.test.tsx
@@ -53,6 +53,25 @@ describe("GanttTableView", () => {
     expect(rows[2]).toHaveTextContent("25%");
   });
 
+  it("formats start and end dates through locale-aware formatting instead of raw strings", () => {
+    render(<GanttTableView tasks={tasks} onTaskClick={vi.fn()} onDeleteTask={vi.fn()} />);
+
+    const rows = within(screen.getByRole("table", { name: "Gantt tasks" })).getAllByRole("row");
+    expect(rows[1]).not.toHaveTextContent("2026-06-01");
+    expect(rows[1]).toHaveTextContent("Jun 1, 2026");
+    expect(rows[2]).not.toHaveTextContent("2026-06-05");
+    expect(rows[2]).toHaveTextContent("Jun 5, 2026");
+  });
+
+  it("shows a visible label for tasks with 0% progress", () => {
+    const emptyProgressTask: GanttTask = { ...tasks[1], id: "task-empty", progress: 0 };
+    render(
+      <GanttTableView tasks={[emptyProgressTask]} onTaskClick={vi.fn()} onDeleteTask={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("table", { name: "Gantt tasks" })).toHaveTextContent("0%");
+  });
+
   it("renders malformed dependency data safely", () => {
     const malformedTask = { ...tasks[0], dependencies: ["task-earlier"] } as unknown as GanttTask;
 


### PR DESCRIPTION
## Summary

- Format `task.start` / `task.end` in `GanttTableView` through the same locale-aware `Intl.DateTimeFormat` pattern used elsewhere in the app (e.g. `SettingsAccountSection.tsx`, `LongWeekendModal.tsx`), using `getLocale()` from `@/paraglide/runtime.js` instead of rendering the raw stored `YYYY-MM-DD` string.
- Fix the near-invisible 0% progress bar by adding a bordered track (`className="border"`) so the track is visible even when empty, and by moving the percentage label out of the bar into a separate `<span>` next to it — previously the label text lived inside the 0%-wide bar and was therefore also invisible.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (full suite, 1519 tests passing)
- [x] Added targeted tests in `GanttTableView.test.tsx` covering locale-formatted dates and visible 0% progress label

Fixes #963

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzssF5pg86vehb8dpoMciy)_