### PR TITLE
feat(gantt): allow editing and unlinking logged time entries from task modal

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1149,6 +1149,8 @@
   "gantt_logged_minutes": "{minutes} min",
   "gantt_logged_hours": "{hours} h",
   "gantt_logged_hours_minutes": "{hours} h {minutes} min",
+  "gantt_logged_edit_entry_aria": "Edit {name} in Time Tracking",
+  "gantt_logged_unlink_entry_aria": "Unlink {name} from this task",
   "auth_callback_spinner": "Completing sign-in...",
   "auth_callback_title": "Completing sign-in",
   "auth_callback_description": "Please wait while Worktime finishes connecting your account."

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,6 +133,7 @@ function AppContent() {
   const [showAbout, setShowAbout] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const { currentDate, setCurrentDate } = useShiftCalculation();
+  const [pendingTaskEditId, setPendingTaskEditId] = useState<string | null>(null);
 
   const handleTabChange = useCallback(
     (tab: TabKey) => {
@@ -280,6 +281,9 @@ function AppContent() {
             onTabChange: handleTabChange,
             onChangeSchedule: handleChangeSchedule,
             onChangeTeam: handleChangeTeam,
+            pendingTaskEditId,
+            requestTaskEdit: setPendingTaskEditId,
+            clearPendingTaskEdit: () => setPendingTaskEditId(null),
             showTeamModal,
             teamModalMode,
             teamWizardStartStep:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,6 +135,10 @@ function AppContent() {
   const { currentDate, setCurrentDate } = useShiftCalculation();
   const [pendingTaskEditId, setPendingTaskEditId] = useState<string | null>(null);
 
+  const handleClearPendingTaskEdit = useCallback(() => {
+    setPendingTaskEditId(null);
+  }, []);
+
   const handleTabChange = useCallback(
     (tab: TabKey) => {
       setActiveTab(tab);
@@ -283,7 +287,7 @@ function AppContent() {
             onChangeTeam: handleChangeTeam,
             pendingTaskEditId,
             requestTaskEdit: setPendingTaskEditId,
-            clearPendingTaskEdit: () => setPendingTaskEditId(null),
+            clearPendingTaskEdit: handleClearPendingTaskEdit,
             showTeamModal,
             teamModalMode,
             teamWizardStartStep:

--- a/frontend/src/components/MainTabs.tsx
+++ b/frontend/src/components/MainTabs.tsx
@@ -46,6 +46,11 @@ interface MainTabsProps {
   onTabChange?: (tab: TabKey) => void;
   onChangeSchedule?: () => void; // Callback to open schedule selector
   onChangeTeam?: () => void; // Callback to open team selector
+  // One-shot handoff for opening a specific time-tracking entry's edit modal from
+  // another tab (e.g. a Gantt task's linked entries list).
+  pendingTaskEditId?: string | null;
+  onRequestTaskEdit?: (taskId: string) => void;
+  onClearPendingTaskEdit?: () => void;
 }
 
 /**
@@ -72,6 +77,9 @@ export function MainTabs({
   onTabChange,
   onChangeSchedule,
   onChangeTeam,
+  pendingTaskEditId,
+  onRequestTaskEdit,
+  onClearPendingTaskEdit,
 }: MainTabsProps) {
   const tabsId = useId();
   const { settings } = useSettings();
@@ -102,6 +110,14 @@ export function MainTabs({
       onTabChange?.(tab);
     },
     [setActiveKey, onTabChange],
+  );
+
+  const handleNavigateToEntry = useCallback(
+    (entryId: string) => {
+      onRequestTaskEdit?.(entryId);
+      setActiveTab("timetracking");
+    },
+    [onRequestTaskEdit, setActiveTab],
   );
 
   const shortcuts = useMemo(() => {
@@ -260,7 +276,10 @@ export function MainTabs({
             >
               {activeKey === "timetracking" && (
                 <Suspense fallback={loadingFallback}>
-                  <TimeTrackingView />
+                  <TimeTrackingView
+                    pendingTaskEditId={pendingTaskEditId}
+                    onClearPendingTaskEdit={onClearPendingTaskEdit}
+                  />
                 </Suspense>
               )}
             </Tab>
@@ -279,7 +298,7 @@ export function MainTabs({
             >
               {activeKey === "gantt" && (
                 <Suspense fallback={loadingFallback}>
-                  <GanttView />
+                  <GanttView onNavigateToEntry={handleNavigateToEntry} />
                 </Suspense>
               )}
             </Tab>

--- a/frontend/src/components/gantt/GanttTaskModal.tsx
+++ b/frontend/src/components/gantt/GanttTaskModal.tsx
@@ -22,6 +22,8 @@ interface GanttTaskModalProps {
   task?: GanttTask;
   existingTasks: Array<Pick<GanttTask, "id" | "name">>;
   onDelete?: () => void;
+  /** Navigate to Time Tracking with the given logged entry pre-selected for editing. */
+  onNavigateToEntry?: (entryId: string) => void;
 }
 
 const DATE_FORMAT = "YYYY-MM-DD";
@@ -89,11 +91,16 @@ export function GanttTaskModal({
   task,
   existingTasks,
   onDelete,
+  onNavigateToEntry,
 }: GanttTaskModalProps) {
   const [form, setForm] = useState<FormState>(() => createInitialValue(task));
   const [selectedDeps, setSelectedDeps] = useState<string[]>(() => parseDeps(task?.dependencies));
   const [wasValidated, setWasValidated] = useState(false);
-  const { tasks: timeTrackingTasks, labels: timeTrackingLabels } = useTimeTrackingStorage();
+  const {
+    tasks: timeTrackingTasks,
+    labels: timeTrackingLabels,
+    updateTaskTimes,
+  } = useTimeTrackingStorage();
 
   useEffect(() => {
     setForm(createInitialValue(task));
@@ -156,6 +163,20 @@ export function GanttTaskModal({
     () => loggedEntries.reduce((total, entry) => total + entry.loggedMinutes, 0),
     [loggedEntries],
   );
+
+  const handleEditEntry = (entryId: string) => {
+    onNavigateToEntry?.(entryId);
+    onHide();
+  };
+
+  const handleUnlinkEntry = (entry: { id: string; startTime: string; stopTime?: string | null }) => {
+    updateTaskTimes({
+      id: entry.id,
+      newStartTime: entry.startTime,
+      newStopTime: entry.stopTime,
+      ganttTaskId: "",
+    });
+  };
 
   const handleSubmit: SubmitEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
@@ -281,14 +302,35 @@ export function GanttTaskModal({
             ) : (
               <ListGroup variant="flush">
                 {loggedEntries.map((entry) => (
-                  <ListGroup.Item key={entry.id} className="px-0 py-2 d-flex justify-content-between gap-3">
+                  <ListGroup.Item
+                    key={entry.id}
+                    className="px-0 py-2 d-flex justify-content-between align-items-center gap-3"
+                  >
                     <span>
                       <span className="d-block">{entry.text}</span>
                       <span className="text-muted small">
                         {timeTrackingLabelNames.get(entry.label) ?? m.tt_unknown_label()} · {dayjs(entry.startTime).format("YYYY-MM-DD")}
                       </span>
                     </span>
-                    <span className="text-nowrap">{formatLoggedDuration(entry.loggedMinutes)}</span>
+                    <span className="d-flex align-items-center gap-2 flex-shrink-0">
+                      <span className="text-nowrap">{formatLoggedDuration(entry.loggedMinutes)}</span>
+                      <Button
+                        variant="outline-secondary"
+                        size="sm"
+                        aria-label={m.gantt_logged_edit_entry_aria({ name: entry.text })}
+                        onClick={() => handleEditEntry(entry.id)}
+                      >
+                        <i className="bi bi-pencil" aria-hidden="true"></i>
+                      </Button>
+                      <Button
+                        variant="outline-secondary"
+                        size="sm"
+                        aria-label={m.gantt_logged_unlink_entry_aria({ name: entry.text })}
+                        onClick={() => handleUnlinkEntry(entry)}
+                      >
+                        <i className="bi bi-x-circle" aria-hidden="true"></i>
+                      </Button>
+                    </span>
                   </ListGroup.Item>
                 ))}
               </ListGroup>

--- a/frontend/src/components/gantt/GanttView.tsx
+++ b/frontend/src/components/gantt/GanttView.tsx
@@ -19,7 +19,12 @@ import * as m from "@/paraglide/messages.js";
 
 const EMPTY_ARRAY: string[] = [];
 
-export function GanttView() {
+interface GanttViewProps {
+  /** Navigate to Time Tracking with the given logged entry pre-selected for editing. */
+  onNavigateToEntry?: (entryId: string) => void;
+}
+
+export function GanttView({ onNavigateToEntry }: GanttViewProps = {}) {
   const { tasks, addTask, updateTask, removeTask } = useGanttTasks();
   const currentYear = dayjs().year();
   const { publicHolidayMap } = usePublicHolidays(currentYear);
@@ -165,6 +170,7 @@ export function GanttView() {
         task={editingTask ?? undefined}
         existingTasks={tasks}
         onDelete={editingTask ? () => setShowDeleteConfirm(true) : undefined}
+        onNavigateToEntry={onNavigateToEntry}
       />
 
       <ConfirmationDialog

--- a/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
+++ b/frontend/src/components/timeTracking/TimeTrackingDailyView.tsx
@@ -42,6 +42,9 @@ type TimeTrackingDailyViewProps = {
   }) => void;
   onRemoveTask: (id: string) => void;
   onToggleBreak: (taskId: string, includesBreak: boolean) => void;
+  /** One-shot request to open a specific entry's edit modal, e.g. from another tab. */
+  externalEditRequest?: EditRequest | null;
+  onExternalEditRequestHandled?: () => void;
 };
 
 function todayIso() {
@@ -58,9 +61,18 @@ export function TimeTrackingDailyView({
   onUpdateTaskTimes,
   onRemoveTask,
   onToggleBreak,
+  externalEditRequest,
+  onExternalEditRequestHandled,
 }: TimeTrackingDailyViewProps) {
   const date = selectedDate || todayIso();
   const [editRequest, setEditRequest] = useState<EditRequest | null>(null);
+
+  useEffect(() => {
+    if (externalEditRequest) {
+      setEditRequest(externalEditRequest);
+      onExternalEditRequestHandled?.();
+    }
+  }, [externalEditRequest, onExternalEditRequestHandled]);
   const [text, setText] = useState("");
   const [selectedLabel, setSelectedLabel] = useState<string>("");
   const [selectedGanttTaskId, setSelectedGanttTaskId] = useState("");

--- a/frontend/src/components/timeTracking/TimeTrackingView.tsx
+++ b/frontend/src/components/timeTracking/TimeTrackingView.tsx
@@ -24,7 +24,16 @@ const TIME_TRACKING_VIEWS = ["daily", "weekly", "config"] as const;
  */
 const DEFAULT_TIME_TRACKING_VIEW = TIME_TRACKING_VIEWS[0]; // "daily"
 
-export function TimeTrackingView() {
+interface TimeTrackingViewProps {
+  /** ID of a time-tracking entry to jump straight to the edit modal for, e.g. requested from the Gantt tab. */
+  pendingTaskEditId?: string | null;
+  onClearPendingTaskEdit?: () => void;
+}
+
+export function TimeTrackingView({
+  pendingTaskEditId,
+  onClearPendingTaskEdit,
+}: TimeTrackingViewProps = {}) {
   const { myTeam, scheduleType } = useSettings();
   const { lastUsed, updateLastTimeTrackingView } = useLastUsed();
   const toast = useToast();
@@ -64,6 +73,22 @@ export function TimeTrackingView() {
   useEffect(() => {
     updateLastTimeTrackingView(viewMode);
   }, [updateLastTimeTrackingView, viewMode]);
+
+  const pendingEditTask = useMemo(
+    () => (pendingTaskEditId ? (tasks.find((item) => item.id === pendingTaskEditId) ?? null) : null),
+    [pendingTaskEditId, tasks],
+  );
+
+  useEffect(() => {
+    if (!pendingTaskEditId) return;
+    if (!pendingEditTask) {
+      // Entry no longer exists (e.g. removed) — clear the request so it doesn't get stuck.
+      onClearPendingTaskEdit?.();
+      return;
+    }
+    setViewMode("daily");
+    setSelectedDailyDate(pendingEditTask.startTime.slice(0, 10));
+  }, [pendingTaskEditId, pendingEditTask, onClearPendingTaskEdit]);
 
   const effectiveTeam = useMemo(
     () => getEffectiveTeam(myTeam, scheduleType),
@@ -122,6 +147,8 @@ export function TimeTrackingView() {
           onUpdateTaskTimes={updateTaskTimes}
           onRemoveTask={handleRemoveTask}
           onToggleBreak={toggleBreak}
+          externalEditRequest={pendingEditTask ? { task: pendingEditTask } : null}
+          onExternalEditRequestHandled={onClearPendingTaskEdit}
         />
       )}
 

--- a/frontend/src/contexts/AppShellContext.tsx
+++ b/frontend/src/contexts/AppShellContext.tsx
@@ -28,6 +28,11 @@ export interface AppShellContextType {
   onTabChange: (tab: TabKey) => void;
   onChangeSchedule: () => void;
   onChangeTeam: () => void;
+  // One-shot handoff for opening a specific time-tracking entry's edit modal from
+  // another tab (e.g. a Gantt task's linked entries list).
+  pendingTaskEditId: string | null;
+  requestTaskEdit: (taskId: string) => void;
+  clearPendingTaskEdit: () => void;
   // WelcomeWizard state — lifted here so AppLayout can render the wizard outside the route outlet
   showTeamModal: boolean;
   teamModalMode: "onboarding" | "change-team" | "change-schedule";

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -12,6 +12,9 @@ export function HomePage() {
     onTabChange,
     onChangeSchedule,
     onChangeTeam,
+    pendingTaskEditId,
+    requestTaskEdit,
+    clearPendingTaskEdit,
   } = useAppShellContext();
 
   return (
@@ -32,6 +35,9 @@ export function HomePage() {
           onTabChange={onTabChange}
           onChangeSchedule={onChangeSchedule}
           onChangeTeam={onChangeTeam}
+          pendingTaskEditId={pendingTaskEditId}
+          onRequestTaskEdit={requestTaskEdit}
+          onClearPendingTaskEdit={clearPendingTaskEdit}
         />
       </ErrorBoundary>
     </main>

--- a/frontend/tests/components/gantt/GanttTaskModal.test.tsx
+++ b/frontend/tests/components/gantt/GanttTaskModal.test.tsx
@@ -92,6 +92,84 @@ describe("GanttTaskModal", () => {
     expect(screen.getByText("Client · 2026-03-01")).toBeInTheDocument();
   });
 
+  it("navigates to the entry in Time Tracking and closes the modal", async () => {
+    const user = userEvent.setup();
+    const onHide = vi.fn();
+    const onNavigateToEntry = vi.fn();
+    labelsCollection.insert({ id: "client-2", name: "Client", color: "#123456" });
+    tasksCollection.insert({
+      id: "logged-task-nav",
+      text: "Write spec",
+      label: "client-2",
+      ganttTaskId: "task-nav",
+      startTime: "2026-03-02T09:00",
+      stopTime: "2026-03-02T10:00",
+    });
+
+    render(
+      <GanttTaskModal
+        show
+        onHide={onHide}
+        onSave={vi.fn()}
+        existingTasks={[{ id: "task-nav", name: "Task Nav" }]}
+        task={{
+          id: "task-nav",
+          name: "Task Nav",
+          start: "2026-03-01",
+          end: "2026-03-03",
+          progress: 0,
+        }}
+        onNavigateToEntry={onNavigateToEntry}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Edit Write spec in Time Tracking" }),
+    );
+
+    expect(onNavigateToEntry).toHaveBeenCalledWith("logged-task-nav");
+    expect(onHide).toHaveBeenCalled();
+  });
+
+  it("unlinks a logged entry from the task without deleting it", async () => {
+    const user = userEvent.setup();
+    labelsCollection.insert({ id: "client-3", name: "Client", color: "#123456" });
+    tasksCollection.insert({
+      id: "logged-task-unlink",
+      text: "Review PR",
+      label: "client-3",
+      ganttTaskId: "task-unlink",
+      startTime: "2026-03-04T09:00",
+      stopTime: "2026-03-04T10:00",
+    });
+
+    render(
+      <GanttTaskModal
+        show
+        onHide={vi.fn()}
+        onSave={vi.fn()}
+        existingTasks={[{ id: "task-unlink", name: "Task Unlink" }]}
+        task={{
+          id: "task-unlink",
+          name: "Task Unlink",
+          start: "2026-03-01",
+          end: "2026-03-03",
+          progress: 0,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Review PR")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Unlink Review PR from this task" }));
+
+    expect(screen.getByText("No time has been logged for this task yet.")).toBeInTheDocument();
+    const stored = (tasksCollection.toArray as Array<{ id: string; ganttTaskId?: string }>).find(
+      (t) => t.id === "logged-task-unlink",
+    );
+    expect(stored?.ganttTaskId).toBeUndefined();
+  });
+
   it("shows edit mode title and delete action", () => {
     render(
       <GanttTaskModal

--- a/frontend/tests/components/timeTracking/TimeTrackingView.test.tsx
+++ b/frontend/tests/components/timeTracking/TimeTrackingView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { TimeTrackingView } from "@/components/timeTracking/TimeTrackingView";
 import { SettingsProvider } from "@/contexts/SettingsContext";
@@ -94,6 +94,78 @@ describe("TimeTrackingView", () => {
       expect(screen.getByRole("button", { name: /Go to previous day/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /^Go to today$/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /Go to next day/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("Cross-tab entry navigation", () => {
+    const renderWithPendingEdit = (
+      pendingTaskEditId: string | null,
+      onClearPendingTaskEdit = vi.fn(),
+    ) =>
+      render(
+        <SettingsProvider>
+          <ToastProvider>
+            <TimeTrackingView
+              pendingTaskEditId={pendingTaskEditId}
+              onClearPendingTaskEdit={onClearPendingTaskEdit}
+            />
+          </ToastProvider>
+        </SettingsProvider>,
+      );
+
+    it("switches to daily view, jumps to the entry's date, and opens its edit modal", () => {
+      window.localStorage.setItem(
+        "worktime_user_state",
+        JSON.stringify({
+          version: 2,
+          hasCompletedOnboarding: true,
+          myTeam: null,
+          scheduleType: "9-5",
+          settings: {
+            timeFormat: "24h",
+            theme: "auto",
+            notifications: "off",
+            vacationAllowance: { yearlyAmounts: {}, unit: "days", hoursPerDay: 8 },
+            enableTimeOff: false,
+            enableTimeTracking: true,
+          },
+          lastUsed: {
+            activeTab: "timetracking",
+            scheduleView: "today",
+            otherSchedule: null,
+            timeOffView: "table",
+            timeTrackingView: "weekly",
+            otherTeam: null,
+          },
+        }),
+      );
+      mockTasks = [
+        {
+          id: "task-a",
+          text: "Ship feature",
+          label: "Development",
+          startTime: "2025-01-03T09:00",
+          stopTime: "2025-01-03T10:00",
+        },
+      ];
+      const onClearPendingTaskEdit = vi.fn();
+
+      renderWithPendingEdit("task-a", onClearPendingTaskEdit);
+
+      expect(screen.getByText("Daily Time Tracking")).toBeInTheDocument();
+      const dialog = screen.getByRole("dialog");
+      expect(within(dialog).getByLabelText(/^Task$/i)).toHaveValue("Ship feature");
+      expect(onClearPendingTaskEdit).toHaveBeenCalled();
+    });
+
+    it("clears the pending request when the entry no longer exists", () => {
+      mockTasks = [];
+      const onClearPendingTaskEdit = vi.fn();
+
+      renderWithPendingEdit("missing-task", onClearPendingTaskEdit);
+
+      expect(onClearPendingTaskEdit).toHaveBeenCalled();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #964. The Gantt task modal's "Logged time" list was purely informational — no way to jump to an entry in Time Tracking to fix it, and no way to unlink it short of reopening that entry's edit modal in Time Tracking and clearing the picker there.

- Each logged entry now has an **Edit** button that switches to the Time Tracking tab, jumps to the entry's date in the Daily Log, and opens its edit modal directly.
- Each logged entry now has an **Unlink** button that clears the entry's `ganttTaskId` in place, without navigating away or deleting the entry.

### Implementation notes

- Cross-tab handoff is a one-shot request (`pendingTaskEditId` / `requestTaskEdit` / `clearPendingTaskEdit`) added to `AppShellContext`, prop-drilled through `HomePage` → `MainTabs` → `TimeTrackingView`, mirroring how `activeTab`/`onTabChange` already flow. `TimeTrackingView` resolves the pending ID against its own `tasks`, switches to the daily view on the right date, and feeds the existing one-shot `EditRequest` mechanism in `TimeTrackingDailyView` (used today for the cross-midnight stop-timer flow) via a new `externalEditRequest` bridge prop, so the internal cross-midnight behavior is untouched.
- Unlink reuses the existing `updateTaskTimes({ ganttTaskId: "" })` clear semantics already exercised by the picker in `TaskEditModal`, no new storage logic. No confirmation dialog — reversible via the picker, consistent with other quick toggles in this codebase.
- `GanttTaskModal` stays prop-driven (`onNavigateToEntry`) rather than reading `AppShellContext` directly, keeping it standalone/testable as before.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass
- [x] Full frontend test suite passes (`pnpm test`, 1523 tests), including new coverage for the unlink action, edit navigation, and the cross-tab pending-edit handoff (including the "entry no longer exists" cleanup path)
- [x] Manually verified in a running dev build: created a Gantt task, linked a time-tracking entry to it, clicked Edit (jumped to Time Tracking → correct date → edit modal open with right entry) and Unlink (entry disappears from "Logged time" but remains in Time Tracking, now unlinked)

Screenshots (before/after unlink, and the edit-navigation target) were captured during manual testing but there's no image-upload path available in this environment — happy to attach them if you'd like, or reproduce locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_0123YY54dPc2xVbd9w9yTN3w)_