### PR TITLE
feat(gantt): surface logged time in table column and chart popup

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -776,6 +776,7 @@
   "gantt_table_start": "Start",
   "gantt_table_end": "End",
   "gantt_table_progress": "Progress",
+  "gantt_table_logged": "Logged",
   "gantt_table_dependencies": "Dependencies",
   "gantt_table_notes": "Notes",
   "gantt_table_actions": "Actions",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -769,6 +769,7 @@
   "gantt_table_start": "Start",
   "gantt_table_end": "Einde",
   "gantt_table_progress": "Voortgang",
+  "gantt_table_logged": "Gelogd",
   "gantt_table_dependencies": "Afhankelijkheden",
   "gantt_table_notes": "Notities",
   "gantt_table_actions": "Acties",

--- a/frontend/src/components/gantt/GanttChart.tsx
+++ b/frontend/src/components/gantt/GanttChart.tsx
@@ -3,10 +3,13 @@ import { dayjs } from "@/utils/dateTimeUtils";
 import type { GanttTask } from "@/types/gantt";
 import { EmptyState } from "@/components/shared/EmptyState";
 import type { GanttViewMode } from "@/contexts/SettingsContext";
+import { formatLoggedDuration } from "@/utils/ganttLoggedTime";
 import { getLocale } from "@/paraglide/runtime.js";
+import * as m from "@/paraglide/messages.js";
 
 const POPUP_DATE_FORMAT = "MMM D";
 const EMPTY_ARRAY: string[] = [];
+const EMPTY_MAP: Map<string, number> = new Map();
 
 const htmlEscapeMap: Record<string, string> = {
   "&": "&amp;",
@@ -25,6 +28,8 @@ interface GanttChartProps {
   initialViewMode?: GanttViewMode;
   holidays?: string[];
   timeOffDates?: string[];
+  /** Total logged time per task, in minutes. Shown as an extra detail in the hover popup. */
+  loggedMinutesByTaskId?: Map<string, number>;
   onTaskClick: (taskId: string) => void;
   onDateChange: (taskId: string, start: string, end: string) => void;
   onProgressChange: (taskId: string, progress: number) => void;
@@ -50,6 +55,7 @@ export function GanttChart({
   initialViewMode = "Day",
   holidays = EMPTY_ARRAY,
   timeOffDates = EMPTY_ARRAY,
+  loggedMinutesByTaskId = EMPTY_MAP,
   onTaskClick,
   onDateChange,
   onProgressChange,
@@ -60,6 +66,7 @@ export function GanttChart({
   const tasksRef = useRef(tasks);
   const prevTasksRef = useRef<GanttTask[]>([]);
   const initialViewModeRef = useRef(initialViewMode);
+  const loggedMinutesByTaskIdRef = useRef(loggedMinutesByTaskId);
   const onTaskClickRef = useRef(onTaskClick);
   const onDateChangeRef = useRef(onDateChange);
   const onProgressChangeRef = useRef(onProgressChange);
@@ -67,6 +74,7 @@ export function GanttChart({
 
   tasksRef.current = tasks;
   initialViewModeRef.current = initialViewMode;
+  loggedMinutesByTaskIdRef.current = loggedMinutesByTaskId;
   onTaskClickRef.current = onTaskClick;
   onDateChangeRef.current = onDateChange;
   onProgressChangeRef.current = onProgressChange;
@@ -132,7 +140,13 @@ export function GanttChart({
               : "";
           const progress =
             typeof ctx.task.progress === "number" ? `${Math.floor(ctx.task.progress)}%` : "";
-          const details = [dateRange, duration, progress].filter(Boolean).join(" · ");
+          const taskId = getTaskId(ctx.task);
+          const loggedMinutes = taskId ? loggedMinutesByTaskIdRef.current.get(taskId) : undefined;
+          const logged =
+            loggedMinutes != null && loggedMinutes > 0
+              ? m.gantt_logged_total({ duration: formatLoggedDuration(loggedMinutes) })
+              : "";
+          const details = [dateRange, duration, progress, logged].filter(Boolean).join(" · ");
 
           ctx.set_details(details);
         },

--- a/frontend/src/components/gantt/GanttTableView.tsx
+++ b/frontend/src/components/gantt/GanttTableView.tsx
@@ -5,7 +5,7 @@ import Table from "react-bootstrap/Table";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { dayjs } from "@/utils/dateTimeUtils";
 import { getGanttDeleteConfirmMessage } from "@/utils/ganttDeleteConfirm";
-import { formatLoggedDuration, getTotalLoggedMinutes } from "@/utils/ganttLoggedTime";
+import { formatLoggedDuration, getLoggedMinutesByTaskId } from "@/utils/ganttLoggedTime";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
 import type { GanttTask } from "@/types/gantt";
 import * as m from "@/paraglide/messages.js";
@@ -32,8 +32,8 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
   const { tasks: timeTrackingTasks } = useTimeTrackingStorage();
   const taskNames = useMemo(() => new Map(tasks.map((task) => [task.id, task.name])), [tasks]);
   const loggedMinutesByTaskId = useMemo(
-    () => new Map(tasks.map((task) => [task.id, getTotalLoggedMinutes(task.id, timeTrackingTasks)])),
-    [tasks, timeTrackingTasks],
+    () => getLoggedMinutesByTaskId(timeTrackingTasks),
+    [timeTrackingTasks],
   );
   const linkedEntryCount = useMemo(
     () =>

--- a/frontend/src/components/gantt/GanttTableView.tsx
+++ b/frontend/src/components/gantt/GanttTableView.tsx
@@ -5,6 +5,7 @@ import Table from "react-bootstrap/Table";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { dayjs } from "@/utils/dateTimeUtils";
 import { getGanttDeleteConfirmMessage } from "@/utils/ganttDeleteConfirm";
+import { formatLoggedDuration, getTotalLoggedMinutes } from "@/utils/ganttLoggedTime";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
 import type { GanttTask } from "@/types/gantt";
 import * as m from "@/paraglide/messages.js";
@@ -30,6 +31,10 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
   const [deletingTask, setDeletingTask] = useState<GanttTask | null>(null);
   const { tasks: timeTrackingTasks } = useTimeTrackingStorage();
   const taskNames = useMemo(() => new Map(tasks.map((task) => [task.id, task.name])), [tasks]);
+  const loggedMinutesByTaskId = useMemo(
+    () => new Map(tasks.map((task) => [task.id, getTotalLoggedMinutes(task.id, timeTrackingTasks)])),
+    [tasks, timeTrackingTasks],
+  );
   const linkedEntryCount = useMemo(
     () =>
       deletingTask
@@ -68,6 +73,11 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
     if (!deletingTask) return;
     onDeleteTask(deletingTask.id);
     setDeletingTask(null);
+  };
+
+  const getLoggedLabel = (taskId: string) => {
+    const minutes = loggedMinutesByTaskId.get(taskId) ?? 0;
+    return minutes > 0 ? formatLoggedDuration(minutes) : "—";
   };
 
   const getDependencies = (dependencies?: string) => {
@@ -112,6 +122,7 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
             </th>
             <th scope="col">{m.gantt_table_end()}</th>
             <th scope="col">{m.gantt_table_progress()}</th>
+            <th scope="col">{m.gantt_table_logged()}</th>
             <th scope="col">{m.gantt_table_dependencies()}</th>
             <th scope="col">{m.gantt_table_notes()}</th>
             <th scope="col" className="text-end">
@@ -122,7 +133,7 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
         <tbody>
           {sortedTasks.length === 0 ? (
             <tr>
-              <td colSpan={7} className="text-center text-muted py-4">
+              <td colSpan={8} className="text-center text-muted py-4">
                 {m.gantt_table_empty()}
               </td>
             </tr>
@@ -146,6 +157,7 @@ export function GanttTableView({ tasks, onTaskClick, onDeleteTask }: GanttTableV
                     <span className="small text-muted text-nowrap">{task.progress}%</span>
                   </div>
                 </td>
+                <td className="text-nowrap">{getLoggedLabel(task.id)}</td>
                 <td>{getDependencies(task.dependencies)}</td>
                 <td title={task.notes}>{task.notes || "—"}</td>
                 <td className="text-end text-nowrap">

--- a/frontend/src/components/gantt/GanttTaskModal.tsx
+++ b/frontend/src/components/gantt/GanttTaskModal.tsx
@@ -8,7 +8,7 @@ import { dayjs } from "@/utils/dateTimeUtils";
 import type { GanttTask, RawGanttTask } from "@/types/gantt";
 import { bootstrapSelectClassNames } from "@/utils/reactSelectStyles";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
-import { BREAK_DURATION_MINUTES } from "@/components/timeTracking/timeUtils";
+import { getLoggedMinutes, formatLoggedDuration } from "@/utils/ganttLoggedTime";
 import * as m from "@/paraglide/messages.js";
 
 type DepOption = { value: string; label: string };
@@ -51,20 +51,6 @@ function createInitialValue(task?: GanttTask): FormState {
   };
 }
 
-
-function getLoggedMinutes(startTime: string, stopTime: string | null | undefined, includesBreak?: boolean): number {
-  const stop = stopTime ? dayjs(stopTime) : dayjs();
-  const rawMinutes = Math.max(0, stop.diff(dayjs(startTime), "minute"));
-  return Math.max(0, rawMinutes - (includesBreak ? BREAK_DURATION_MINUTES : 0));
-}
-
-function formatLoggedDuration(minutes: number): string {
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  if (hours === 0) return m.gantt_logged_minutes({ minutes: remainingMinutes });
-  if (remainingMinutes === 0) return m.gantt_logged_hours({ hours });
-  return m.gantt_logged_hours_minutes({ hours, minutes: remainingMinutes });
-}
 
 function parseDeps(dependencies?: unknown): string[] {
   if (typeof dependencies === "string") {

--- a/frontend/src/components/gantt/GanttView.tsx
+++ b/frontend/src/components/gantt/GanttView.tsx
@@ -10,7 +10,7 @@ import { useLastUsed } from "@/contexts/LastUsedContext";
 import { useEventStore } from "@/contexts/EventStoreContext";
 import { getGanttTimeOffDates } from "@/utils/ganttTimeOff";
 import { getGanttDeleteConfirmMessage } from "@/utils/ganttDeleteConfirm";
-import { getTotalLoggedMinutes } from "@/utils/ganttLoggedTime";
+import { getLoggedMinutesByTaskId } from "@/utils/ganttLoggedTime";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { GanttChart } from "@/components/gantt/GanttChart";
@@ -43,8 +43,8 @@ export function GanttView({ onNavigateToEntry }: GanttViewProps = {}) {
   );
   const view = lastUsed.ganttView;
   const loggedMinutesByTaskId = useMemo(
-    () => new Map(tasks.map((task) => [task.id, getTotalLoggedMinutes(task.id, timeTrackingTasks)])),
-    [tasks, timeTrackingTasks],
+    () => getLoggedMinutesByTaskId(timeTrackingTasks),
+    [timeTrackingTasks],
   );
   const linkedEntryCount = useMemo(
     () =>

--- a/frontend/src/components/gantt/GanttView.tsx
+++ b/frontend/src/components/gantt/GanttView.tsx
@@ -10,6 +10,7 @@ import { useLastUsed } from "@/contexts/LastUsedContext";
 import { useEventStore } from "@/contexts/EventStoreContext";
 import { getGanttTimeOffDates } from "@/utils/ganttTimeOff";
 import { getGanttDeleteConfirmMessage } from "@/utils/ganttDeleteConfirm";
+import { getTotalLoggedMinutes } from "@/utils/ganttLoggedTime";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { GanttChart } from "@/components/gantt/GanttChart";
@@ -41,6 +42,10 @@ export function GanttView({ onNavigateToEntry }: GanttViewProps = {}) {
     [currentYear, settings.enableTimeOff, timeOffEntries],
   );
   const view = lastUsed.ganttView;
+  const loggedMinutesByTaskId = useMemo(
+    () => new Map(tasks.map((task) => [task.id, getTotalLoggedMinutes(task.id, timeTrackingTasks)])),
+    [tasks, timeTrackingTasks],
+  );
   const linkedEntryCount = useMemo(
     () =>
       editingTask
@@ -150,6 +155,7 @@ export function GanttView({ onNavigateToEntry }: GanttViewProps = {}) {
           initialViewMode={lastUsed.ganttViewMode}
           holidays={holidayDates}
           timeOffDates={timeOffDates}
+          loggedMinutesByTaskId={loggedMinutesByTaskId}
           onTaskClick={handleTaskClick}
           onDateChange={handleDateChange}
           onProgressChange={handleProgressChange}

--- a/frontend/src/utils/ganttLoggedTime.ts
+++ b/frontend/src/utils/ganttLoggedTime.ts
@@ -21,11 +21,13 @@ export function formatLoggedDuration(minutes: number): string {
   return m.gantt_logged_hours_minutes({ hours, minutes: remainingMinutes });
 }
 
-export function getTotalLoggedMinutes(taskId: string, entries: StoredTimeTrackingTask[]): number {
-  return entries
-    .filter((entry) => entry.ganttTaskId === taskId)
-    .reduce(
-      (total, entry) => total + getLoggedMinutes(entry.startTime, entry.stopTime, entry.includesBreak),
-      0,
-    );
+export function getLoggedMinutesByTaskId(entries: StoredTimeTrackingTask[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.ganttTaskId) {
+      const minutes = getLoggedMinutes(entry.startTime, entry.stopTime, entry.includesBreak);
+      map.set(entry.ganttTaskId, (map.get(entry.ganttTaskId) ?? 0) + minutes);
+    }
+  }
+  return map;
 }

--- a/frontend/src/utils/ganttLoggedTime.ts
+++ b/frontend/src/utils/ganttLoggedTime.ts
@@ -1,0 +1,31 @@
+import { dayjs } from "@/utils/dateTimeUtils";
+import { BREAK_DURATION_MINUTES } from "@/components/timeTracking/timeUtils";
+import type { StoredTimeTrackingTask } from "@/components/timeTracking/types";
+import * as m from "@/paraglide/messages.js";
+
+export function getLoggedMinutes(
+  startTime: string,
+  stopTime: string | null | undefined,
+  includesBreak?: boolean,
+): number {
+  const stop = stopTime ? dayjs(stopTime) : dayjs();
+  const rawMinutes = Math.max(0, stop.diff(dayjs(startTime), "minute"));
+  return Math.max(0, rawMinutes - (includesBreak ? BREAK_DURATION_MINUTES : 0));
+}
+
+export function formatLoggedDuration(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours === 0) return m.gantt_logged_minutes({ minutes: remainingMinutes });
+  if (remainingMinutes === 0) return m.gantt_logged_hours({ hours });
+  return m.gantt_logged_hours_minutes({ hours, minutes: remainingMinutes });
+}
+
+export function getTotalLoggedMinutes(taskId: string, entries: StoredTimeTrackingTask[]): number {
+  return entries
+    .filter((entry) => entry.ganttTaskId === taskId)
+    .reduce(
+      (total, entry) => total + getLoggedMinutes(entry.startTime, entry.stopTime, entry.includesBreak),
+      0,
+    );
+}

--- a/frontend/tests/components/gantt/GanttChart.test.tsx
+++ b/frontend/tests/components/gantt/GanttChart.test.tsx
@@ -225,6 +225,87 @@ describe("GanttChart", () => {
     expect(setDetails).toHaveBeenCalledWith("Mar 1 – Mar 5 · 4 days · 50%");
   });
 
+  it("popup function includes logged time when available for the task", async () => {
+    render(
+      <GanttChart
+        tasks={[
+          {
+            id: "task-1",
+            name: "My Task",
+            start: "2026-03-01",
+            end: "2026-03-05",
+            progress: 50,
+          },
+        ]}
+        initialViewMode="Day"
+        loggedMinutesByTaskId={new Map([["task-1", 90]])}
+        onTaskClick={vi.fn()}
+        onDateChange={vi.fn()}
+        onProgressChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockInstances).toHaveLength(1);
+    });
+
+    const [instance] = mockInstances;
+    const setDetails = vi.fn();
+
+    instance.options.popup?.({
+      task: {
+        id: "task-1",
+        name: "My Task",
+        progress: 50,
+        _start: new Date(2026, 2, 1),
+        _end: new Date(2026, 2, 5),
+        actual_duration: 4,
+      },
+      set_title: vi.fn(),
+      set_subtitle: vi.fn(),
+      set_details: setDetails,
+    });
+
+    expect(setDetails).toHaveBeenCalledWith("Mar 1 – Mar 5 · 4 days · 50% · 1 h 30 min logged");
+  });
+
+  it("popup function omits logged time when none has been recorded for the task", async () => {
+    render(
+      <GanttChart
+        tasks={[
+          { id: "task-1", name: "My Task", start: "2026-03-01", end: "2026-03-05", progress: 50 },
+        ]}
+        initialViewMode="Day"
+        onTaskClick={vi.fn()}
+        onDateChange={vi.fn()}
+        onProgressChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockInstances).toHaveLength(1);
+    });
+
+    const [instance] = mockInstances;
+    const setDetails = vi.fn();
+
+    instance.options.popup?.({
+      task: {
+        id: "task-1",
+        name: "My Task",
+        progress: 50,
+        _start: new Date(2026, 2, 1),
+        _end: new Date(2026, 2, 5),
+        actual_duration: 4,
+      },
+      set_title: vi.fn(),
+      set_subtitle: vi.fn(),
+      set_details: setDetails,
+    });
+
+    expect(setDetails).toHaveBeenCalledWith("Mar 1 – Mar 5 · 4 days · 50%");
+  });
+
   it("popup function pluralizes duration details", async () => {
     render(
       <GanttChart

--- a/frontend/tests/components/gantt/GanttTableView.test.tsx
+++ b/frontend/tests/components/gantt/GanttTableView.test.tsx
@@ -148,6 +148,23 @@ describe("GanttTableView", () => {
     );
   });
 
+  it("shows total logged time per task next to progress", () => {
+    tasksCollection.insert({
+      id: "entry-1",
+      text: "Built release",
+      label: "Support",
+      startTime: "2026-06-01T09:00",
+      stopTime: "2026-06-01T10:30",
+      ganttTaskId: "task-earlier",
+    });
+
+    render(<GanttTableView tasks={tasks} onTaskClick={vi.fn()} onDeleteTask={vi.fn()} />);
+
+    const rows = within(screen.getByRole("table", { name: "Gantt tasks" })).getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("1 h 30 min");
+    expect(rows[2]).toHaveTextContent("—");
+  });
+
   it("does not warn about unlinked entries when the task has no logged time", async () => {
     tasksCollection.insert({
       id: "entry-1",

--- a/frontend/tests/utils/ganttLoggedTime.test.ts
+++ b/frontend/tests/utils/ganttLoggedTime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatLoggedDuration,
   getLoggedMinutes,
-  getTotalLoggedMinutes,
+  getLoggedMinutesByTaskId,
 } from "@/utils/ganttLoggedTime";
 import type { StoredTimeTrackingTask } from "@/components/timeTracking/types";
 
@@ -35,7 +35,7 @@ describe("formatLoggedDuration", () => {
   });
 });
 
-describe("getTotalLoggedMinutes", () => {
+describe("getLoggedMinutesByTaskId", () => {
   const entries: StoredTimeTrackingTask[] = [
     {
       id: "entry-1",
@@ -61,13 +61,24 @@ describe("getTotalLoggedMinutes", () => {
       stopTime: "2026-06-03T10:00",
       ganttTaskId: "task-2",
     },
+    {
+      id: "entry-4",
+      text: "Not linked to any task",
+      label: "Support",
+      startTime: "2026-06-04T09:00",
+      stopTime: "2026-06-04T10:00",
+    },
   ];
 
-  it("sums logged minutes for entries linked to the given task", () => {
-    expect(getTotalLoggedMinutes("task-1", entries)).toBe(150);
+  it("returns a map of total logged minutes grouped by task ID", () => {
+    const map = getLoggedMinutesByTaskId(entries);
+    expect(map.get("task-1")).toBe(150);
+    expect(map.get("task-2")).toBe(60);
+    expect(map.get("task-3")).toBeUndefined();
   });
 
-  it("returns 0 when no entries are linked to the task", () => {
-    expect(getTotalLoggedMinutes("task-3", entries)).toBe(0);
+  it("ignores entries without a linked Gantt task", () => {
+    const map = getLoggedMinutesByTaskId(entries);
+    expect(map.size).toBe(2);
   });
 });

--- a/frontend/tests/utils/ganttLoggedTime.test.ts
+++ b/frontend/tests/utils/ganttLoggedTime.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatLoggedDuration,
+  getLoggedMinutes,
+  getTotalLoggedMinutes,
+} from "@/utils/ganttLoggedTime";
+import type { StoredTimeTrackingTask } from "@/components/timeTracking/types";
+
+describe("getLoggedMinutes", () => {
+  it("computes elapsed minutes between start and stop", () => {
+    expect(getLoggedMinutes("2026-06-01T09:00", "2026-06-01T10:30")).toBe(90);
+  });
+
+  it("deducts the break duration when includesBreak is set", () => {
+    expect(getLoggedMinutes("2026-06-01T09:00", "2026-06-01T10:30", true)).toBe(60);
+  });
+
+  it("never returns a negative duration", () => {
+    expect(getLoggedMinutes("2026-06-01T10:00", "2026-06-01T09:00")).toBe(0);
+    expect(getLoggedMinutes("2026-06-01T09:00", "2026-06-01T09:10", true)).toBe(0);
+  });
+});
+
+describe("formatLoggedDuration", () => {
+  it("formats minutes only", () => {
+    expect(formatLoggedDuration(45)).toBe("45 min");
+  });
+
+  it("formats whole hours", () => {
+    expect(formatLoggedDuration(120)).toBe("2 h");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatLoggedDuration(150)).toBe("2 h 30 min");
+  });
+});
+
+describe("getTotalLoggedMinutes", () => {
+  const entries: StoredTimeTrackingTask[] = [
+    {
+      id: "entry-1",
+      text: "Worked",
+      label: "Support",
+      startTime: "2026-06-01T09:00",
+      stopTime: "2026-06-01T10:00",
+      ganttTaskId: "task-1",
+    },
+    {
+      id: "entry-2",
+      text: "Worked more",
+      label: "Support",
+      startTime: "2026-06-02T09:00",
+      stopTime: "2026-06-02T10:30",
+      ganttTaskId: "task-1",
+    },
+    {
+      id: "entry-3",
+      text: "Unrelated",
+      label: "Support",
+      startTime: "2026-06-03T09:00",
+      stopTime: "2026-06-03T10:00",
+      ganttTaskId: "task-2",
+    },
+  ];
+
+  it("sums logged minutes for entries linked to the given task", () => {
+    expect(getTotalLoggedMinutes("task-1", entries)).toBe(150);
+  });
+
+  it("returns 0 when no entries are linked to the task", () => {
+    expect(getTotalLoggedMinutes("task-3", entries)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #965.

The issue's mechanical part: neither the Chart view nor the Table view surfaced logged time, even though `GanttTaskModal.tsx` already computes it. This addresses the low-ambiguity parts:

- **Table view**: adds a "Logged" column next to Progress, showing total logged time per task (or "—" if none logged).
- **Chart view**: adds the task's total logged time as an extra detail line in the existing hover popup (e.g. "Mar 1 – Mar 5 · 4 days · 50% · 1 h 30 min logged"), without altering the bar's progress rendering.
- Extracted `getLoggedMinutes`/`formatLoggedDuration`/`getTotalLoggedMinutes` into a new shared util (`frontend/src/utils/ganttLoggedTime.ts`), reused by `GanttTaskModal`, `GanttTableView`, `GanttChart`, and `GanttView`.

Per the issue, encoding logged time directly on the chart bar (secondary segment vs. tooltip vs. distinct visual encoding from manual progress) is a design question left open for discussion — not addressed here.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (full suite, 1534 tests passing)
- [x] Added unit tests for the new util (`ganttLoggedTime.test.ts`)
- [x] Added/updated tests for the table Logged column and chart popup detail


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hqy3uZHUd3RRSQVgi3U34K)_