### PR TITLE
Fix duplicated holiday flag in Time Off table

### DIFF
--- a/frontend/src/lib/hday/flags.ts
+++ b/frontend/src/lib/hday/flags.ts
@@ -101,7 +101,7 @@ export function normalizeEventFlags(flags: EventFlag[]): EventFlag[] {
     );
   }
 
-  if (!normalized.some((flag) => TYPE_FLAGS_SET.has(flag))) {
+  if (!normalized.some((flag) => TYPE_FLAGS_SET.has(flag) || flag === "holiday")) {
     return [...normalized, "holiday"];
   }
 

--- a/frontend/tests/lib/hday.test.ts
+++ b/frontend/tests/lib/hday.test.ts
@@ -429,6 +429,16 @@ describe("normalizeEventFlags", () => {
     const result = normalizeEventFlags(["business", "half_am"]);
     expect(result).toEqual(["business", "half_am"]);
   });
+
+  it("does not duplicate holiday when already present", () => {
+    const result = normalizeEventFlags(["holiday"]);
+    expect(result).toEqual(["holiday"]);
+  });
+
+  it("does not duplicate holiday when already present alongside a half-day flag", () => {
+    const result = normalizeEventFlags(["holiday", "half_am"]);
+    expect(result).toEqual(["holiday", "half_am"]);
+  });
 });
 
 describe("EVENT_COLORS constants", () => {


### PR DESCRIPTION
## Summary

- `normalizeEventFlags` in `frontend/src/lib/hday/flags.ts` checked `TYPE_FLAGS_SET`, which deliberately excludes `"holiday"` (it's the implicit default type flag). When a resolved `"holiday"` flag was already passed in (as `getEntryFlags` in `codecs.ts` always does for default-type entries), the check missed it and appended a second `"holiday"`.
- The Flags column in `TimeOffTableView.tsx` then rendered `holiday, holiday` (or `holiday, half_am, holiday`) instead of just `holiday` (or `holiday, half_am`).
- Updated the check to also treat an already-present `"holiday"` flag as satisfying "a type flag is present."

## Test plan

- [x] Added unit tests in `frontend/tests/lib/hday.test.ts` covering `normalizeEventFlags(["holiday"])` and `normalizeEventFlags(["holiday", "half_am"])` to assert no duplication.
- [x] `pnpm test` — all 1536 tests pass.
- [x] `pnpm lint` — no new warnings.
- [x] `pnpm typecheck` — passes.

Fixes #966


---
_Generated by [Claude Code](https://claude.ai/code/session_01HBGBGHp4QLYsVEBi5g6QSD)_