### PR TITLE
Harden sync correctness, account provisioning, and API safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Worktime uses a **notify-then-pull** pattern over SSE. The backend signals that 
 | Field | Value |
 |-------|-------|
 | Endpoint | `GET /api/sync/events` |
-| Auth | Session cookie required (`withCredentials: true`) |
+| Auth | Bearer token via `Authorization` header, same as every other endpoint — the client opens the stream with `fetch()` (via `@microsoft/fetch-event-source`), not native `EventSource`, since `EventSource` cannot send custom headers |
 | Event name | `sync_changed` |
 | Payload | `{ "type": "sync_changed", "server_timestamp": "<ISO-8601>" }` |
 | Keepalive | `: keepalive` comment every 15 s |
@@ -63,12 +63,12 @@ Worktime uses a **notify-then-pull** pattern over SSE. The backend signals that 
 
 - **Proxy buffering** — set `X-Accel-Buffering: no` (already sent by the endpoint) so Nginx/Caddy does not buffer the stream.
 - **Timeouts** — ensure the proxy does not close idle SSE connections before the 15 s keepalive fires. Caddy's default idle timeout is fine; Nginx needs `proxy_read_timeout` ≥ 60 s.
-- **CORS / cookies** — the frontend uses `withCredentials: true`; the backend must echo `Access-Control-Allow-Credentials: true` and a non-wildcard `Access-Control-Allow-Origin`.
+- **CORS** — cross-origin dev setups rely on the existing `CORSMiddleware` config (`Authorization` is already in `allow_headers`); same-origin production deployments (frontend and API behind the same Caddy host) need no CORS handling at all for this endpoint.
 - **Postgres LISTEN/NOTIFY** — the backend subscribes to the `worktime_sync_changed` channel for cross-process broadcast. If the asyncpg LISTEN connection is unavailable (e.g. during startup or a Postgres restart), the manager falls back to in-process delivery automatically; no operator action is required.
 
 ### Adding new live-update behaviour
 
-- **Reuse `SyncSignalTransport`** when the update follows the same notify-then-pull shape: the live signal is just a freshness hint and the data arrives via a normal fetch. Implement a new `SyncSignalTransport` adapter (or reuse `createSseTransport`) and pass it to `useSyncSignal`.
+- **Reuse `SyncSignalTransport`** when the update follows the same notify-then-pull shape: the live signal is just a freshness hint and the data arrives via a normal fetch. Implement a new `SyncSignalTransport` adapter (or reuse `createFetchSseTransport`) and pass it to `useSyncSignal`.
 - **Stay request/poll-based** for user-triggered actions, infrequent state changes, or anything that needs the full response payload inline (not a separate fetch). Adding SSE complexity for those cases is not worth it.
 - The transport abstraction also decouples the wire protocol: replacing SSE with WebSockets later only requires a new adapter — no changes to `useSyncSignal` or its callers.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Worktime uses a **notify-then-pull** pattern over SSE. The backend signals that 
 | Field | Value |
 |-------|-------|
 | Endpoint | `GET /api/sync/events` |
-| Auth | Bearer token via `Authorization` header, same as every other endpoint — the client opens the stream with `fetch()` (via `@microsoft/fetch-event-source`), not native `EventSource`, since `EventSource` cannot send custom headers |
+| Auth | Bearer token via `Authorization` header, same as every other endpoint — the client opens the stream with `fetch()` (parsed via `eventsource-parser`), not native `EventSource`, since `EventSource` cannot send custom headers |
 | Event name | `sync_changed` |
 | Payload | `{ "type": "sync_changed", "server_timestamp": "<ISO-8601>" }` |
 | Keepalive | `: keepalive` comment every 15 s |

--- a/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
+++ b/android/app/src/main/java/com/worktime/android/data/api/WorktimeApi.kt
@@ -70,14 +70,14 @@ interface WorktimeApi {
         @Query("user_id") userId: Int
     ): Response<TaskRecord>
 
-    @POST("api/work-locations/")
+    @POST("api/work-locations")
     suspend fun upsertWorkLocation(
         @Header("Authorization") authorization: String,
         @Query("user_id") userId: Int,
         @Body payload: WorkLocationMutationRequest
     ): WorkLocationRecord
 
-    @GET("api/work-locations/")
+    @GET("api/work-locations")
     suspend fun listWorkLocations(
         @Header("Authorization") authorization: String,
         @Query("user_id") userId: Int,
@@ -108,13 +108,13 @@ interface WorktimeApi {
     suspend fun deleteAccount(@Header("Authorization") authorization: String)
 
     // Time off is resolved from the bearer token only - no user_id query param.
-    @POST("api/time-off/")
+    @POST("api/time-off")
     suspend fun upsertTimeOffEntry(
         @Header("Authorization") authorization: String,
         @Body payload: TimeOffEntryMutationRequest
     ): Response<TimeOffEntryRecord>
 
-    @GET("api/time-off/")
+    @GET("api/time-off")
     suspend fun listTimeOffEntries(
         @Header("Authorization") authorization: String,
         @Query("start_date") startDate: String? = null,

--- a/android/app/src/test/java/com/worktime/android/data/api/WorktimeApiTest.kt
+++ b/android/app/src/test/java/com/worktime/android/data/api/WorktimeApiTest.kt
@@ -107,7 +107,7 @@ class WorktimeApiTest {
         val response = api.listTimeOffEntries(authorization = "Bearer token-123")
 
         val request = server.takeRequest()
-        assertEquals("/api/time-off/", request.requestLine.substringAfter(' ').substringBefore(' '))
+        assertEquals("/api/time-off", request.requestLine.substringAfter(' ').substringBefore(' '))
         assertEquals("Bearer token-123", request.headers["Authorization"])
         assertEquals(1, response.items.size)
         assertEquals("entry-1", response.items.first().entryId)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -187,3 +187,15 @@ OIDC_ALGORITHMS=RS256
 # Tokens expire after 60 seconds to prevent replay attacks.
 #
 METRICS_HMAC_SECRET=
+
+# -----------------------------------------------------------------------------
+# Rate Limiting
+# -----------------------------------------------------------------------------
+# Per-client-IP rate limit applied to every /api route (health probes are
+# exempt). Set RATE_LIMIT_ENABLED=false to disable entirely.
+#
+# RATE_LIMIT_DEFAULT uses the flask-limiter/slowapi rate string format, e.g.
+# "200/minute", "10/second", "5000/hour".
+#
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_DEFAULT=200/minute

--- a/backend/README.md
+++ b/backend/README.md
@@ -84,7 +84,7 @@ The shared directory is expected to look like this:
 - Auth endpoints:
   - internal SuperTokens base path: `/auth/*`
   - public shared-host path in this repo: `/auth/*`
-- Registration endpoint (public): `POST /api/users/register`
+- Registration endpoint (admin-only pre-provisioning): `POST /api/users/register`
 - Database endpoints: `/api/users/*`, `/api/time-tracking/*`, `/api/work-locations/*`, `/api/gantt-tasks/*`, `/api/sync/*`, `/api/preferences`, `/api/time-off/*`, `/api/me`
 - Debug endpoint in non-production only: `/api/debug/benchmark`
 

--- a/backend/app/audit/logger.py
+++ b/backend/app/audit/logger.py
@@ -1,12 +1,22 @@
 """Audit logging functionality for tracking API operations.
 
 This module provides audit logging that records all API operations
-to a persistent log file with structured JSON entries.
+to a persistent, size-rotated log file with structured JSON entries.
+
+Audit logging is diagnostic, not transactional: a logging failure (disk
+full, permission error, ...) must never fail the operation being recorded.
+``append()`` therefore never raises, and — when called from within a running
+event loop, as every caller in this codebase is — performs the file write on
+a background thread so a slow or contended disk never blocks request
+handling.
 """
 
+import asyncio
 import json
 import logging
+import threading
 from datetime import UTC, datetime
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -15,50 +25,115 @@ logger = logging.getLogger(__name__)
 AUDIT_LOG_DIR = Path(__file__).parent.parent.parent / "data"
 AUDIT_LOG_FILE = AUDIT_LOG_DIR / "audit.log"
 
+# Rotate at 10 MiB, keeping 5 backups (~50 MiB max on disk) so the log
+# doesn't grow without bound.
+_MAX_BYTES = 10 * 1024 * 1024
+_BACKUP_COUNT = 5
+
+_loggers_lock = threading.Lock()
+# Keyed by log file path rather than a single module-level logger so tests
+# can monkeypatch AUDIT_LOG_DIR/AUDIT_LOG_FILE per test (each temp path gets
+# its own logger+handler) without one test's state leaking into another's.
+_loggers: dict[Path, logging.Logger] = {}
+
+# Tracks in-flight background writes so flush() can wait for them. Entries
+# remove themselves via add_done_callback once complete.
+_pending_writes: set[asyncio.Future] = set()
+
+
+def _get_audit_logger(log_dir: Path, log_file: Path) -> logging.Logger | None:
+    """Return the rotating-file logger for *log_file*, creating it on first use.
+
+    Returns None (never raises) if the directory or file can't be created —
+    callers treat that as "logging unavailable this time" and move on.
+    """
+    with _loggers_lock:
+        existing = _loggers.get(log_file)
+        if existing is not None:
+            return existing
+
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+        except (PermissionError, OSError) as e:
+            logger.error(f"Failed to create audit log directory: {e}")
+            return None
+
+        try:
+            handler = RotatingFileHandler(
+                log_file, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT, encoding="utf-8"
+            )
+        except (PermissionError, OSError) as e:
+            logger.error(f"Failed to open audit log file: {e}")
+            return None
+
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        # A dedicated Logger instance (not the module's `logger`, and not
+        # registered via getLogger) keeps audit entries from ever leaking
+        # into the application's general log stream.
+        audit_logger = logging.Logger(f"worktime.audit[{log_file}]", level=logging.INFO)
+        audit_logger.propagate = False
+        audit_logger.addHandler(handler)
+        _loggers[log_file] = audit_logger
+        return audit_logger
+
+
+def _write_entry_sync(entry: dict) -> None:
+    """Write one JSON-lines entry to the audit log.
+
+    Never raises: RotatingFileHandler.emit() already routes write failures
+    (e.g. disk full) through logging.Handler.handleError() instead of
+    propagating them, and handler/directory creation failures are caught in
+    _get_audit_logger().
+    """
+    audit_logger = _get_audit_logger(AUDIT_LOG_DIR, AUDIT_LOG_FILE)
+    if audit_logger is None:
+        return
+    audit_logger.info(json.dumps(entry, ensure_ascii=False))
+
 
 def append(target: str, action: str, details: str | None = None) -> None:
-    """Append an audit log entry to the audit log file.
-    
+    """Record an audit log entry for *target* / *action* / *details*.
+
     Args:
         target: The target of the action (e.g., filename, user, resource)
         action: The action performed (e.g., "read", "write", "delete")
         details: Optional additional details about the action
-    
-    The audit log entry is a JSON object with the following fields:
-        - ts: ISO 8601 timestamp in UTC
-        - target: Target identifier
-        - action: Action performed
-        - details: Additional details (null if not provided)
-    
-    Example log entry:
-        {"ts": "2026-02-10T05:30:28.123456Z", "target": "user123.hday", 
-         "action": "read", "details": "via API"}
+
+    The entry is a JSON object: ``{"ts", "target", "action", "details"}``,
+    written as one line to the rotating audit log file.
+
+    When called from a running event loop (the normal case — every call site
+    in this codebase is inside an async request/tool handler), the file
+    write is dispatched to a background thread so it can't block the event
+    loop. Outside a running loop (e.g. a script or a plain sync test), the
+    write happens inline. Either way, this function itself never raises.
     """
-    # Generate UTC ISO 8601 timestamp
-    timestamp = datetime.now(UTC).isoformat()
-    
-    # Create audit entry
     entry = {
-        "ts": timestamp,
+        "ts": datetime.now(UTC).isoformat(),
         "target": target,
         "action": action,
-        "details": details
+        "details": details,
     }
-    
-    # Ensure log directory exists
+
     try:
-        AUDIT_LOG_DIR.mkdir(parents=True, exist_ok=True)
-    except (PermissionError, OSError) as e:
-        logger.error(f"Failed to create audit log directory: {e}")
-        raise
-    
-    # Append to audit log file
-    try:
-        with open(AUDIT_LOG_FILE, "a", encoding="utf-8") as f:
-            json.dump(entry, f, ensure_ascii=False)
-            f.write("\n")
-    except (PermissionError, OSError) as e:
-        logger.error(f"Failed to write to audit log: {e}")
-        raise
-    
-    logger.debug(f"Audit log entry: {entry}")
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _write_entry_sync(entry)
+        return
+
+    future = loop.run_in_executor(None, _write_entry_sync, entry)
+    _pending_writes.add(future)
+    future.add_done_callback(_pending_writes.discard)
+
+
+async def flush() -> None:
+    """Wait for all currently in-flight background audit writes to finish.
+
+    Production code never needs this — audit logging is intentionally
+    fire-and-forget. It exists for tests that assert on audit log file
+    contents immediately after triggering a write from within a running
+    event loop (where append() dispatches to a background thread).
+    """
+    pending = list(_pending_writes)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)

--- a/backend/app/config/oidc_config.py
+++ b/backend/app/config/oidc_config.py
@@ -102,6 +102,39 @@ async def _get_jwks(*, force_refresh: bool = False) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Periodic background refresh
+# ---------------------------------------------------------------------------
+
+_JWKS_REFRESH_INTERVAL_SECONDS = 3600
+
+
+async def _periodic_jwks_refresh_loop() -> None:
+    """Background loop that force-refreshes the JWKS cache periodically.
+
+    Without this, the cache only refreshes reactively when a token's ``kid``
+    isn't found in it (see ``decode_token``) — so a provider-side key
+    rotation that keeps the same ``kid``, or a JWKS URI change, would go
+    unnoticed until a process restart. Failures are logged and swallowed;
+    the existing cached JWKS keeps serving requests, and the reactive
+    refresh-on-miss path is unaffected by this loop failing.
+    """
+    while True:
+        try:
+            await asyncio.sleep(_JWKS_REFRESH_INTERVAL_SECONDS)
+            await _get_jwks(force_refresh=True)
+            logger.debug("Periodic JWKS refresh succeeded")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Periodic JWKS refresh failed (non-fatal)", exc_info=True)
+
+
+def start_periodic_jwks_refresh() -> asyncio.Task[None]:
+    """Start the background JWKS refresh loop and return its task for shutdown cancellation."""
+    return asyncio.create_task(_periodic_jwks_refresh_loop())
+
+
+# ---------------------------------------------------------------------------
 # Token validation
 # ---------------------------------------------------------------------------
 

--- a/backend/app/config/oidc_config.py
+++ b/backend/app/config/oidc_config.py
@@ -234,27 +234,43 @@ async def get_or_create_local_user(subject: str, claims: dict[str, Any], db_sess
     username, display_name = _derive_username_and_display_name(claims, subject)
     username = await _find_available_username(db_session, username, subject)
 
-    try:
-        local_user = await create_user(
-            db_session,
-            UserCreate(
-                username=username,
-                display_name=display_name,
-                settings={},
-            ),
-            oidc_subject=subject,
-        )
-        logger.info(
-            "Auto-provisioned local Worktime user %r for OIDC subject %s",
-            username,
-            subject,
-        )
-    except (IntegrityError, ConflictError):
-        # Race condition: concurrent first-login for the same subject.
-        await db_session.rollback()
-        result = await db_session.execute(select(User).where(User.oidc_subject == subject))
-        local_user = result.scalar_one_or_none()
-        if local_user is None:
+    for attempt in range(2):
+        try:
+            local_user = await create_user(
+                db_session,
+                UserCreate(
+                    username=username,
+                    display_name=display_name,
+                    settings={},
+                ),
+                oidc_subject=subject,
+            )
+            logger.info(
+                "Auto-provisioned local Worktime user %r for OIDC subject %s",
+                username,
+                subject,
+            )
+            return local_user
+        except (IntegrityError, ConflictError):
+            # Two possible races: a concurrent first-login for the *same*
+            # subject won the INSERT, or a *different* new user claimed the
+            # derived username between the availability check and the INSERT.
+            await db_session.rollback()
+            result = await db_session.execute(select(User).where(User.oidc_subject == subject))
+            local_user = result.scalar_one_or_none()
+            if local_user is not None:
+                return local_user
+            if attempt == 0:
+                # Username collision with a different subject — the conflicting
+                # row is now committed and visible, so re-deriving produces a
+                # fresh candidate. Retry once instead of failing the login.
+                logger.info(
+                    "Username %r was claimed concurrently — retrying provisioning for subject %s",
+                    username,
+                    subject,
+                )
+                username = await _find_available_username(db_session, username, subject)
+                continue
             raise
 
-    return local_user
+    raise RuntimeError(f"Could not provision local user for OIDC subject {subject!r}")

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -78,6 +78,11 @@ class Settings(BaseSettings):
     # OIDC_ALGORITHMS: Comma-separated list of accepted signing algorithms
     OIDC_ALGORITHMS: str = "RS256"
 
+    # Per-client-IP rate limiting (slowapi). RATE_LIMIT_DEFAULT applies to every
+    # /api route unless explicitly exempted (e.g. health probes).
+    RATE_LIMIT_ENABLED: bool = True
+    RATE_LIMIT_DEFAULT: str = "200/minute"
+
     @field_validator("DATABASE_URL")
     @classmethod
     def validate_database_url(cls, v: str) -> str:

--- a/backend/app/database/engine.py
+++ b/backend/app/database/engine.py
@@ -27,6 +27,12 @@ def _build_engine():
             # Override via DATABASE_POOL_SIZE / DATABASE_POOL_MAX_OVERFLOW env vars if needed.
             pool_size=settings.DATABASE_POOL_SIZE,
             max_overflow=settings.DATABASE_POOL_MAX_OVERFLOW,
+            # Test each pooled connection with a lightweight ping before handing
+            # it out. Without this, connections dropped by a Postgres restart
+            # (or an idle-connection reaper) sit in the pool until first use,
+            # so the first requests after such an event fail instead of
+            # transparently reconnecting.
+            pool_pre_ping=True,
         )
         _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -89,6 +89,7 @@ class TimeTrackingLabel(ClientTimestampMixin, Base):
             unique=True,
             postgresql_where=sql_text("deleted_at IS NULL"),
         ),
+        Index("ix_time_tracking_labels_user_id_updated_at", "user_id", "updated_at"),
     )
 
 
@@ -121,6 +122,11 @@ class TimeTrackingTask(ClientTimestampMixin, Base):
         DateTime(timezone=True), nullable=True, index=True
     )
 
+    __table_args__ = (
+        Index("ix_time_tracking_tasks_user_id_updated_at", "user_id", "updated_at"),
+        Index("ix_time_tracking_tasks_user_id_start_time", "user_id", "start_time"),
+    )
+
 
 class TimeTrackingTemplate(ClientTimestampMixin, Base):
     """Reusable time tracking template."""
@@ -143,6 +149,10 @@ class TimeTrackingTemplate(ClientTimestampMixin, Base):
     )
     deleted_at: Mapped[dt_datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
+    )
+
+    __table_args__ = (
+        Index("ix_time_tracking_templates_user_id_updated_at", "user_id", "updated_at"),
     )
 
 
@@ -174,6 +184,7 @@ class WorkLocation(ClientTimestampMixin, Base):
             unique=True,
             postgresql_where=sql_text("deleted_at IS NULL"),
         ),
+        Index("ix_work_locations_user_id_updated_at", "user_id", "updated_at"),
     )
 
 
@@ -201,6 +212,8 @@ class GanttTask(ClientTimestampMixin, Base):
     deleted_at: Mapped[dt_datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
     )
+
+    __table_args__ = (Index("ix_gantt_tasks_user_id_updated_at", "user_id", "updated_at"),)
 
 
 class UserPreferences(ClientTimestampMixin, Base):
@@ -280,6 +293,7 @@ class TimeOffEntry(ClientTimestampMixin, Base):
             " OR entry_kind = 'weekly' AND weekday IS NOT NULL AND date IS NULL AND start_date IS NULL AND end_date IS NULL",
             name="ck_time_off_shape",
         ),
+        Index("ix_time_off_entries_user_id_updated_at", "user_id", "updated_at"),
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -153,15 +153,28 @@ async def lifespan(app: FastAPI):
         # Start cache warming in background - don't block startup
         asyncio.create_task(_warm_cache_async())
         logger.info("✓ Cache warming started in background")
-    
+
+    # Periodically force-refresh the OIDC JWKS cache so a provider-side key
+    # rotation that reuses the same `kid`, or a JWKS URI change, is picked up
+    # without a backend restart (the reactive refresh-on-miss path alone
+    # can't detect either case).
+    jwks_refresh_task = None
+    if settings.OIDC_ISSUER_URL:
+        from .config.oidc_config import start_periodic_jwks_refresh
+
+        jwks_refresh_task = start_periodic_jwks_refresh()
+        logger.info("✓ Periodic OIDC JWKS refresh started in background")
+
     logger.info("=" * 60)
     logger.info("Startup complete - Server ready to accept connections")
     logger.info("=" * 60)
-    
+
     yield
-    
+
     # Shutdown
     logger.info("Worktime Backend API shutting down...")
+    if jwks_refresh_task is not None:
+        jwks_refresh_task.cancel()
     if settings.DATABASE_ENABLED:
         await sync_event_manager.stop_pg_listener()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,11 +15,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from fastmcp.utilities.lifespan import combine_lifespans
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 from .cache.warm_cache import warm_cache
 from .config import settings
 from .config.cors import get_cors_origins
 from .database import init_db
+from .middleware.rate_limit import handle_rate_limit_exceeded, limiter
 from .middleware.request_id import RequestIdMiddleware
 from .middleware.timing import TimingMiddleware
 from .routers.auth import router as auth_router
@@ -222,6 +225,17 @@ if _mcp_app is not None:
     app.add_middleware(_MCPAwareCORSMiddleware, **_cors_kwargs)
 else:
     app.add_middleware(CORSMiddleware, **_cors_kwargs)
+
+# Per-client-IP rate limiting. `limiter.enabled` (RATE_LIMIT_ENABLED) gates
+# actual enforcement; the middleware is always registered so a 429 still gets
+# a request ID, timing header, and access-log entry like any other response.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, handle_rate_limit_exceeded)
+app.add_middleware(SlowAPIMiddleware)
+if settings.RATE_LIMIT_ENABLED:
+    logger.info(f"✓ Rate limiting enabled ({settings.RATE_LIMIT_DEFAULT} per client IP)")
+else:
+    logger.info("Rate limiting disabled (RATE_LIMIT_ENABLED=false)")
 
 # TimingMiddleware records metrics and sets X-Total-Ms.
 app.add_middleware(TimingMiddleware)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import os
 from collections import Counter
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
-from typing import Any
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, Concatenate
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import AccessToken, MultiAuth
@@ -41,6 +42,7 @@ from app.schemas import (
 from app.services.db_service import (
     ConflictError,
     NotFoundError,
+    ValidationError,
     create_gantt_task,
     create_or_update_time_off_entry,
     create_or_update_work_location,
@@ -64,7 +66,11 @@ from app.services.db_service import (
     update_task,
     update_time_off_entry,
 )
-from app.services.read_models_service import build_dashboard_read_model, compute_next_shifts_for_team
+from app.services.read_models_service import (
+    build_dashboard_read_model,
+    compute_next_shifts_for_team,
+    get_schedule_type_for_user,
+)
 from app.services.sync_service import get_sync_status
 
 
@@ -121,6 +127,16 @@ def _parse_integration_key_mapping(value: str) -> dict[str, tuple[int, bool]]:
       token=user_id:admin
       token=user_id:user
     Multiple entries are comma-separated.
+
+    These are long-lived static bearer tokens with no built-in expiry — an
+    intentional trade-off for self-hosted, operator-controlled integrations
+    (they bypass the OIDC login flow entirely). To rotate a key: add a new
+    token=user_id entry alongside the old one, update the calling
+    integration to use it, then remove the old entry and restart the
+    process (the mapping is parsed once at startup, in _build_auth_provider).
+    There is no revocation mechanism short of removing the entry and
+    restarting, so treat these tokens like any other long-lived credential —
+    store them in a secret manager, not in version control.
     """
     mapping: dict[str, tuple[int, bool]] = {}
     for item in (part.strip() for part in value.split(",") if part.strip()):
@@ -170,6 +186,39 @@ def _to_iso_datetime(value: datetime) -> str:
         value = value.replace(tzinfo=UTC)
     return value.astimezone(UTC).isoformat()
 
+
+# Default lookback window for get_time_tracking_summary when the caller omits
+# both start_at and end_at — bounds the response to a reasonable size instead
+# of returning the user's entire tracked-task history into the model's
+# context on every unfiltered call.
+_DEFAULT_SUMMARY_WINDOW = timedelta(days=30)
+
+# Hard cap on items returned by get_gantt_tasks. Personal Gantt boards are
+# typically small (a handful of projects), so this is a defense-in-depth
+# bound rather than an expected everyday limit.
+_MAX_GANTT_TASKS_RETURNED = 200
+
+
+def _map_domain_errors[**P, R](
+    func: Callable[Concatenate[WorktimeMcpBackend, P], Awaitable[R]],
+) -> Callable[Concatenate[WorktimeMcpBackend, P], Awaitable[R]]:
+    """Translate db_service domain exceptions into ValueError for MCP callers.
+
+    Without this, only delete_label mapped ConflictError to ValueError —
+    every other write tool let ConflictError / NotFoundError / ValidationError
+    (e.g. "only one running task is allowed per user") propagate raw, so the
+    calling model saw an opaque failure instead of the actionable message the
+    exception already carries. Apply to every write tool method.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self: WorktimeMcpBackend, *args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return await func(self, *args, **kwargs)
+        except (ConflictError, NotFoundError, ValidationError) as exc:
+            raise ValueError(str(exc)) from exc
+
+    return wrapper
 
 
 class WorktimeMcpBackend:
@@ -333,12 +382,15 @@ class WorktimeMcpBackend:
             raise ValueError("limit must be at least 1")
         limit = min(limit, 50)
         async with self._tool_context() as (context, db):
-            principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
-            dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
-            schedule_type = dashboard.work_context.schedule_type
+            # Only the schedule type is needed here, so use the lightweight
+            # lookup instead of build_dashboard_read_model(), which would also
+            # fetch the user row, list time-off entries, and compute a
+            # team_status entry for every team in the schedule.
+            as_of = datetime.now(UTC)
+            schedule_type = await get_schedule_type_for_user(db, context.user_id)
             if schedule_type is None:
                 return {
-                    "as_of": _to_iso_datetime(dashboard.as_of),
+                    "as_of": _to_iso_datetime(as_of),
                     "schedule_type": None,
                     "team_number": team_number,
                     "items": [],
@@ -346,11 +398,11 @@ class WorktimeMcpBackend:
             items = compute_next_shifts_for_team(
                 schedule_type,
                 team_number,
-                as_of=dashboard.as_of,
+                as_of=as_of,
                 limit=limit,
             )
             return {
-                "as_of": _to_iso_datetime(dashboard.as_of),
+                "as_of": _to_iso_datetime(as_of),
                 "schedule_type": schedule_type,
                 "team_number": team_number,
                 "items": [
@@ -422,13 +474,22 @@ class WorktimeMcpBackend:
         start_at: datetime | None = None,
         end_at: datetime | None = None,
     ) -> dict[str, Any]:
+        """Summarize time-tracking tasks for the authenticated user.
+
+        When both start_at and end_at are omitted, defaults to the trailing
+        30 days rather than the user's entire history, so a plain call stays
+        bounded. Pass explicit dates for a wider or narrower range.
+        """
         now_utc = datetime.now(UTC)
+        default_range_applied = start_at is None and end_at is None
+        effective_end = end_at or now_utc
+        effective_start = start_at or (effective_end - _DEFAULT_SUMMARY_WINDOW)
         async with self._tool_context() as (context, db):
             tasks = await list_tasks(
                 db,
                 user_id=context.user_id,
-                start_date=start_at,
-                end_date=end_at,
+                start_date=effective_start,
+                end_date=effective_end,
             )
             payload_tasks = [TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json") for task in tasks]
             total_seconds = 0
@@ -450,8 +511,9 @@ class WorktimeMcpBackend:
 
             return {
                 "user_id": context.user_id,
-                "start_at": _to_iso_datetime(start_at) if start_at else None,
-                "end_at": _to_iso_datetime(end_at) if end_at else None,
+                "start_at": _to_iso_datetime(effective_start),
+                "end_at": _to_iso_datetime(effective_end),
+                "default_range_applied": default_range_applied,
                 "task_count": len(payload_tasks),
                 "tracked_seconds": total_seconds,
                 "running_task": running_payload,
@@ -473,6 +535,7 @@ class WorktimeMcpBackend:
                 ]
             }
 
+    @_map_domain_errors
     async def delete_label(self, label_id: str) -> dict[str, Any]:
         """Delete a time-tracking label owned by the authenticated user.
 
@@ -480,10 +543,7 @@ class WorktimeMcpBackend:
         templates.  Returns a confirmation payload on success.
         """
         async with self._tool_context() as (context, db):
-            try:
-                await delete_label(db, context.user_id, label_id)
-            except ConflictError as exc:
-                raise ValueError(str(exc)) from exc
+            await delete_label(db, context.user_id, label_id)
             audit.append(
                 target=f"user:{context.user_id}:label:{label_id}",
                 action="delete_label",
@@ -514,10 +574,15 @@ class WorktimeMcpBackend:
                     if task["start_date"] <= _to_iso_date(active_on) <= task["end_date"]
                 ]
 
+            total_tasks = len(payload_tasks)
+            truncated = total_tasks > _MAX_GANTT_TASKS_RETURNED
+            payload_tasks = payload_tasks[:_MAX_GANTT_TASKS_RETURNED]
+
             return {
                 "user_id": context.user_id,
                 "active_on": _to_iso_date(active_on) if active_on is not None else None,
-                "total_tasks": len(payload_tasks),
+                "total_tasks": total_tasks,
+                "truncated": truncated,
                 "tasks": payload_tasks,
             }
 
@@ -530,6 +595,7 @@ class WorktimeMcpBackend:
     # Personal write tools
     # ------------------------------------------------------------------
 
+    @_map_domain_errors
     async def start_time_entry(
         self,
         text: str,
@@ -559,6 +625,7 @@ class WorktimeMcpBackend:
             )
             return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def stop_time_entry(
         self,
         stop_time: datetime | None = None,
@@ -583,6 +650,7 @@ class WorktimeMcpBackend:
             )
             return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def create_time_tracking_task(
         self,
         text: str,
@@ -613,6 +681,7 @@ class WorktimeMcpBackend:
             )
             return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def update_time_tracking_task(
         self,
         task_id: str,
@@ -621,15 +690,20 @@ class WorktimeMcpBackend:
         stop_time: datetime | None = None,
         includes_break: bool | None = None,
         label_id: str | None = None,
+        clear_stop_time: bool = False,
+        clear_label_id: bool = False,
     ) -> dict[str, Any]:
         """Update a time-tracking task owned by the authenticated user.
 
-        Omit any parameter to leave it unchanged. Tasks always require a label;
-        label_id cannot be cleared.
+        Omit any parameter to leave it unchanged. Set clear_stop_time=True to
+        reopen the task (make it running again) instead of passing a
+        stop_time; set clear_label_id=True to unlink its label. Both take
+        precedence over the corresponding value parameter when true.
 
         Side effects: updates the specified TimeTrackingTask row.  Authorization
-        is enforced — the task must belong to the caller.  Returns the updated
-        task resource.
+        is enforced — the task must belong to the caller.  Reopening a task
+        (clear_stop_time=True) fails if another task is already running.
+        Returns the updated task resource.
         """
         async with self._tool_context() as (context, db):
             # Verify ownership before updating
@@ -637,11 +711,15 @@ class WorktimeMcpBackend:
             update_data: dict[str, Any] = {}
             if text is not None:
                 update_data["text"] = text
-            if label_id is not None:
+            if clear_label_id:
+                update_data["label_id"] = None
+            elif label_id is not None:
                 update_data["label_id"] = label_id
             if start_time is not None:
                 update_data["start_time"] = start_time
-            if stop_time is not None:
+            if clear_stop_time:
+                update_data["stop_time"] = None
+            elif stop_time is not None:
                 update_data["stop_time"] = stop_time
             if includes_break is not None:
                 update_data["includes_break"] = includes_break
@@ -655,14 +733,17 @@ class WorktimeMcpBackend:
             )
             return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def delete_time_tracking_task(
         self,
         task_id: str,
     ) -> dict[str, Any]:
         """Delete a time-tracking task owned by the authenticated user.
 
-        Side effects: removes the TimeTrackingTask row from the database.  The
-        task must belong to the caller.  Returns a confirmation payload.
+        Side effects: soft-deletes the TimeTrackingTask row (sets deleted_at
+        so the deletion propagates through the sync layer to other devices;
+        the row is not removed).  The task must belong to the caller.
+        Returns a confirmation payload.
         """
         async with self._tool_context() as (context, db):
             await delete_task(db, context.user_id, task_id)
@@ -673,6 +754,7 @@ class WorktimeMcpBackend:
             )
             return {"deleted": True, "task_id": task_id, "user_id": context.user_id}
 
+    @_map_domain_errors
     async def set_work_location(
         self,
         value_date: date,
@@ -694,14 +776,17 @@ class WorktimeMcpBackend:
             )
             return WorkLocationRead.model_validate(location, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def delete_work_location(
         self,
         value_date: date,
     ) -> dict[str, Any]:
         """Delete the work location entry for a given date.
 
-        Side effects: removes the WorkLocation row for (user_id, date).  Returns
-        a confirmation payload.
+        Side effects: soft-deletes the WorkLocation row for (user_id, date)
+        (sets deleted_at so the deletion propagates through the sync layer to
+        other devices; the row is not removed).  Returns a confirmation
+        payload.
         """
         async with self._tool_context() as (context, db):
             await delete_work_location(db, context.user_id, value_date)
@@ -712,6 +797,7 @@ class WorktimeMcpBackend:
             )
             return {"deleted": True, "date": value_date.isoformat(), "user_id": context.user_id}
 
+    @_map_domain_errors
     async def create_time_off_event(
         self,
         entry_kind: EntryKind,
@@ -751,6 +837,7 @@ class WorktimeMcpBackend:
             )
             return TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def update_time_off_event(
         self,
         entry_id: str,
@@ -798,6 +885,7 @@ class WorktimeMcpBackend:
             )
             return TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def delete_time_off_event(
         self,
         entry_id: str,
@@ -819,6 +907,7 @@ class WorktimeMcpBackend:
             )
             return {"deleted": True, "entry_id": entry_id, "user_id": context.user_id}
 
+    @_map_domain_errors
     async def create_gantt_task(
         self,
         name: str,
@@ -849,6 +938,7 @@ class WorktimeMcpBackend:
             )
             return GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def update_gantt_task(
         self,
         task_id: str,
@@ -890,14 +980,18 @@ class WorktimeMcpBackend:
             )
             return GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
+    @_map_domain_errors
     async def delete_gantt_task(
         self,
         task_id: str,
     ) -> dict[str, Any]:
         """Delete a personal Gantt task.
 
-        Side effects: removes the GanttTask row from the database.  The task
-        must belong to the authenticated user.  Returns a confirmation payload.
+        Side effects: soft-deletes the GanttTask row (sets deleted_at so the
+        deletion propagates through the sync layer to other devices; the row
+        is not removed) and unlinks any time-tracking tasks that referenced
+        it.  The task must belong to the authenticated user.  Returns a
+        confirmation payload.
         """
         async with self._tool_context() as (context, db):
             # Verify ownership before deleting

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -1,11 +1,33 @@
 """Per-client-IP rate limiting for the public API, via slowapi."""
 
+import ipaddress
+
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from starlette.requests import Request
 from starlette.responses import Response
 
 from ..config import settings
+
+
+def _peer_is_trusted_proxy(request: Request) -> bool:
+    """Whether the immediate TCP peer looks like an internal reverse proxy.
+
+    ``worktime-api`` is only ``expose``d (not published) on the infra Docker
+    network today, so Caddy should be the only thing that can ever connect
+    directly — but that's a network-topology assumption, not something this
+    process can verify on its own. Require the peer to be on a private
+    address before trusting a client-supplied ``X-Real-IP`` header, so a
+    request landing here some other way (a network misconfiguration, or a
+    peer sharing the same Docker network) can't set an arbitrary key and get
+    a fresh rate-limit bucket on every request.
+    """
+    if not request.client or not request.client.host:
+        return False
+    try:
+        return ipaddress.ip_address(request.client.host).is_private
+    except ValueError:
+        return False
 
 
 def get_client_ip(request: Request) -> str:
@@ -15,11 +37,12 @@ def get_client_ip(request: Request) -> str:
     reverse proxy's own address behind Caddy, which would bucket every real
     client together) or a malformed ``X-Forwarded-For`` lookup. Caddy already
     resolves the true client IP (trusting Cloudflare's edge) and forwards it
-    via ``X-Real-IP``, so prefer that and fall back to ``request.client.host``
-    for local development without a proxy in front.
+    via ``X-Real-IP``, so prefer that — but only when the request actually
+    came from a trusted internal peer; a header from anyone else is
+    caller-controlled and must not be trusted for rate-limit bucketing.
     """
     real_ip = request.headers.get("x-real-ip")
-    if real_ip:
+    if real_ip and _peer_is_trusted_proxy(request):
         return real_ip
     if request.client and request.client.host:
         return request.client.host

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -1,0 +1,47 @@
+"""Per-client-IP rate limiting for the public API, via slowapi."""
+
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from starlette.requests import Request
+from starlette.responses import Response
+
+from ..config import settings
+
+
+def get_client_ip(request: Request) -> str:
+    """Return the client IP, preferring the ``X-Real-IP`` header set by Caddy.
+
+    slowapi's built-in key functions read either ``request.client.host`` (the
+    reverse proxy's own address behind Caddy, which would bucket every real
+    client together) or a malformed ``X-Forwarded-For`` lookup. Caddy already
+    resolves the true client IP (trusting Cloudflare's edge) and forwards it
+    via ``X-Real-IP``, so prefer that and fall back to ``request.client.host``
+    for local development without a proxy in front.
+    """
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+limiter = Limiter(
+    key_func=get_client_ip,
+    default_limits=[settings.RATE_LIMIT_DEFAULT],
+    enabled=settings.RATE_LIMIT_ENABLED,
+    headers_enabled=True,
+)
+
+
+def handle_rate_limit_exceeded(request: Request, exc: Exception) -> Response:
+    """Adapt slowapi's handler to Starlette's ``ExceptionHandler`` signature.
+
+    ``app.add_exception_handler`` types the handler's second parameter as the
+    base ``Exception``, while slowapi's own handler narrows it to
+    ``RateLimitExceeded``. Starlette only invokes this for that registered
+    exception type, so the isinstance check just satisfies the type checker.
+    """
+    if not isinstance(exc, RateLimitExceeded):
+        raise exc
+    return _rate_limit_exceeded_handler(request, exc)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -155,6 +155,22 @@ def require_user_match(user_id: int, authenticated_user_id: int) -> None:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
 
+def resolve_scoped_user_id(user_id: int | None, authenticated_user_id: int) -> int:
+    """Resolve the effective user id for an endpoint with an optional ``user_id`` param.
+
+    A handful of older endpoints (time-tracking, work-locations, gantt-tasks)
+    require ``?user_id=`` and then 403 unless it equals the caller's own id —
+    there is no path where a different value is ever allowed, so the
+    parameter was pure ceremony. It's optional now: omit it (preferred) and
+    the authenticated user's own id is used directly, or pass it as before
+    for backward compatibility, in which case it's still validated to match.
+    """
+    if user_id is None:
+        return authenticated_user_id
+    require_user_match(user_id, authenticated_user_id)
+    return authenticated_user_id
+
+
 def require_user_or_admin_match(user_id: int, principal: AuthenticatedPrincipal) -> None:
     """Allow access to the same user or any user when the principal is admin."""
     if principal.is_admin:

--- a/backend/app/routers/db_gantt.py
+++ b/backend/app/routers/db_gantt.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import get_authenticated_user_id, require_user_match
+from app.routers.auth import get_authenticated_user_id, resolve_scoped_user_id
 from app.schemas import (
     GanttTaskCreate,
     GanttTaskListResponse,
@@ -24,6 +24,7 @@ from app.services.db_service import (
     list_gantt_tasks,
     update_gantt_task,
 )
+from app.utils.pagination import MAX_PAGE_LIMIT, paginate
 from app.utils.timing import time_operation
 
 router = APIRouter(prefix="/gantt-tasks", tags=["Gantt Tasks"])
@@ -42,11 +43,11 @@ def _handle_error(error: Exception) -> None:
 @router.post("", response_model=GanttTaskRead, status_code=status.HTTP_201_CREATED)
 async def create_gantt_task_endpoint(
     payload: GanttTaskCreate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> GanttTaskRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         task = await create_gantt_task(session, user_id, payload)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -58,18 +59,21 @@ async def create_gantt_task_endpoint(
 
 @router.get("", response_model=GanttTaskListResponse)
 async def list_gantt_tasks_endpoint(
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
+    limit: int | None = Query(default=None, ge=1, le=MAX_PAGE_LIMIT),
+    offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     timings: dict[str, float] = {}
     with time_operation("query", timings):
         tasks = await list_gantt_tasks(session, user_id=user_id)
 
+    page, total = paginate(tasks, limit=limit, offset=offset)
     response = GanttTaskListResponse(
-        items=[GanttTaskRead.model_validate(item, from_attributes=True) for item in tasks],
-        total=len(tasks),
+        items=[GanttTaskRead.model_validate(item, from_attributes=True) for item in page],
+        total=total,
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -81,11 +85,11 @@ async def list_gantt_tasks_endpoint(
 @router.get("/{task_id}", response_model=GanttTaskRead)
 async def get_gantt_task_endpoint(
     task_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> GanttTaskRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         task = await get_gantt_task(session, user_id, task_id)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -99,11 +103,11 @@ async def get_gantt_task_endpoint(
 async def update_gantt_task_endpoint(
     task_id: str,
     payload: GanttTaskUpdate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> GanttTaskRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         task = await update_gantt_task(session, user_id, task_id, payload)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -116,11 +120,11 @@ async def update_gantt_task_endpoint(
 @router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_gantt_task_endpoint(
     task_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         await delete_gantt_task(session, user_id, task_id)
     except (NotFoundError, ConflictError, ValidationError) as error:

--- a/backend/app/routers/db_preferences.py
+++ b/backend/app/routers/db_preferences.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
-
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,7 +10,6 @@ from app.database.engine import get_session
 from app.routers.auth import get_authenticated_user_id
 from app.schemas import UserPreferencesRead, UserPreferencesWrite
 from app.services.db_service import get_user_preferences, upsert_user_preferences
-from app.utils.sse_manager import sync_event_manager
 from app.utils.timing import time_operation
 
 router = APIRouter(prefix="/preferences", tags=["Preferences"])
@@ -54,10 +51,8 @@ async def put_preferences_endpoint(
     """
     timings: dict[str, float] = {}
     with time_operation("query", timings):
+        # upsert_user_preferences broadcasts the sync_changed hint itself.
         prefs = await upsert_user_preferences(session, authenticated_user_id, payload)
-
-    with contextlib.suppress(Exception):
-        await sync_event_manager.broadcast_sync_changed(authenticated_user_id)
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,

--- a/backend/app/routers/db_sync.py
+++ b/backend/app/routers/db_sync.py
@@ -20,7 +20,7 @@ from app.schemas import (
 )
 from app.services.db_service import ValidationError
 from app.services.sync_service import get_sync_status, pull_changes, push_changes
-from app.utils.sse_manager import sync_event_manager
+from app.utils.sse_manager import notify_sync_changed, sync_event_manager
 from app.utils.timing import time_operation
 
 logger = logging.getLogger(__name__)
@@ -55,12 +55,7 @@ async def push_endpoint(
     except ValidationError as error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
 
-    try:
-        await sync_event_manager.broadcast_sync_changed(authenticated_user_id)
-    except Exception:
-        logger.warning(
-            "SSE: broadcast_sync_changed failed for user %d (non-fatal)", authenticated_user_id, exc_info=True
-        )
+    await notify_sync_changed(authenticated_user_id)
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,

--- a/backend/app/routers/db_sync.py
+++ b/backend/app/routers/db_sync.py
@@ -18,7 +18,7 @@ from app.schemas import (
     SyncPushResponse,
     SyncStatusResponse,
 )
-from app.services.db_service import ValidationError
+from app.services.db_service import NotFoundError, ValidationError
 from app.services.sync_service import get_sync_status, pull_changes, push_changes
 from app.utils.sse_manager import notify_sync_changed, sync_event_manager
 from app.utils.timing import time_operation
@@ -52,7 +52,13 @@ async def push_endpoint(
     try:
         with time_operation("sync", timings):
             result = await push_changes(session, authenticated_user_id, payload)
-    except ValidationError as error:
+    except (ValidationError, NotFoundError) as error:
+        # NotFoundError surfaces from _validate_task_gantt_reference (a task
+        # or template linking to a gantt_task_id that doesn't exist, or was
+        # deleted on another device between pull and push) — a plausible
+        # everyday race in a multi-device offline-first client, not just a
+        # malformed-payload edge case, so it must map to 400 rather than
+        # bubbling up as an unhandled 500.
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
 
     await notify_sync_changed(authenticated_user_id)
@@ -124,9 +130,12 @@ async def events_endpoint(
     ``_SSE_KEEPALIVE_TIMEOUT`` seconds to prevent proxy/firewall
     idle-connection timeouts.
 
-    The browser reconnects automatically on drop; **no event replay** is
-    performed on reconnect.  Missed events are recovered by the incremental
-    pull that the client issues on reconnect anyway.
+    Each connection's event queue (maxsize=1) only exists while that
+    connection is open — a notification fired during a drop has no queue to
+    reach and is lost, not replayed on reconnect. The client is expected to
+    force an unconditional catch-up pull whenever its SSE connection
+    re-establishes (not just when an event arrives) to cover that gap; see
+    ``createFetchSseTransport`` in the frontend.
     """
     queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1)
     sync_event_manager.subscribe(authenticated_user_id, queue)

--- a/backend/app/routers/db_time_off.py
+++ b/backend/app/routers/db_time_off.py
@@ -31,7 +31,7 @@ from app.utils.timing import time_operation
 router = APIRouter(prefix="/time-off", tags=["Time Off"])
 
 
-@router.post("/", response_model=TimeOffEntryRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=TimeOffEntryRead, status_code=status.HTTP_201_CREATED)
 async def create_or_update_time_off_endpoint(
     payload: TimeOffEntryCreate,
     authenticated_user_id: int = Depends(get_authenticated_user_id),
@@ -45,7 +45,7 @@ async def create_or_update_time_off_endpoint(
     )
 
 
-@router.get("/", response_model=TimeOffEntryListResponse)
+@router.get("", response_model=TimeOffEntryListResponse)
 async def list_time_off_entries_endpoint(
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     start_date: date | None = None,

--- a/backend/app/routers/db_time_off.py
+++ b/backend/app/routers/db_time_off.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,6 +25,7 @@ from app.services.db_service import (
     list_time_off_entries,
     update_time_off_entry,
 )
+from app.utils.pagination import MAX_PAGE_LIMIT, paginate
 from app.utils.timing import time_operation
 
 router = APIRouter(prefix="/time-off", tags=["Time Off"])
@@ -49,6 +50,8 @@ async def list_time_off_entries_endpoint(
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     start_date: date | None = None,
     end_date: date | None = None,
+    limit: int | None = Query(default=None, ge=1, le=MAX_PAGE_LIMIT),
+    offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
     timings: dict[str, float] = {}
@@ -60,9 +63,10 @@ async def list_time_off_entries_endpoint(
             end_date=end_date,
         )
 
+    page, total = paginate(entries, limit=limit, offset=offset)
     response = TimeOffEntryListResponse(
-        items=[TimeOffEntryRead.model_validate(e, from_attributes=True) for e in entries],
-        total=len(entries),
+        items=[TimeOffEntryRead.model_validate(e, from_attributes=True) for e in page],
+        total=total,
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,

--- a/backend/app/routers/db_time_tracking.py
+++ b/backend/app/routers/db_time_tracking.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import get_authenticated_user_id, require_user_match
+from app.routers.auth import get_authenticated_user_id, resolve_scoped_user_id
 from app.schemas import (
     LabelCreate,
     LabelListResponse,
@@ -45,6 +45,7 @@ from app.services.db_service import (
     update_task,
     update_template,
 )
+from app.utils.pagination import MAX_PAGE_LIMIT, paginate
 from app.utils.timing import time_operation
 
 router = APIRouter(prefix="/time-tracking", tags=["Time Tracking"])
@@ -63,11 +64,11 @@ def _handle_error(error: Exception) -> None:
 @router.post("/labels", response_model=LabelRead, status_code=status.HTTP_201_CREATED)
 async def create_label_endpoint(
     payload: LabelCreate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> LabelRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         label = await create_label(session, user_id, payload)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -79,18 +80,21 @@ async def create_label_endpoint(
 
 @router.get("/labels", response_model=LabelListResponse)
 async def list_labels_endpoint(
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
+    limit: int | None = Query(default=None, ge=1, le=MAX_PAGE_LIMIT),
+    offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     timings: dict[str, float] = {}
     with time_operation("query", timings):
         labels = await list_labels_for_user(session, user_id)
 
+    page, total = paginate(labels, limit=limit, offset=offset)
     response = LabelListResponse(
-        items=[LabelRead.model_validate(item, from_attributes=True) for item in labels],
-        total=len(labels),
+        items=[LabelRead.model_validate(item, from_attributes=True) for item in page],
+        total=total,
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -102,11 +106,11 @@ async def list_labels_endpoint(
 @router.get("/labels/{label_id}", response_model=LabelRead)
 async def get_label_endpoint(
     label_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> LabelRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         label = await get_label(session, user_id, label_id)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -120,11 +124,11 @@ async def get_label_endpoint(
 async def update_label_endpoint(
     label_id: str,
     payload: LabelUpdate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> LabelRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         label = await update_label(session, user_id, label_id, payload)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -137,11 +141,11 @@ async def update_label_endpoint(
 @router.delete("/labels/{label_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_label_endpoint(
     label_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         await delete_label(session, user_id, label_id)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -153,11 +157,11 @@ async def delete_label_endpoint(
 @router.post("/tasks", response_model=TaskRead, status_code=status.HTTP_201_CREATED)
 async def create_task_endpoint(
     payload: TaskCreate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> TaskRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
 
     try:
         task = await create_task(session, user_id, payload)
@@ -170,15 +174,17 @@ async def create_task_endpoint(
 
 @router.get("/tasks", response_model=TaskListResponse)
 async def list_tasks_endpoint(
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     start_date: datetime | None = None,
     end_date: datetime | None = None,
     label_id: str | None = None,
     gantt_task_id: str | None = None,
+    limit: int | None = Query(default=None, ge=1, le=MAX_PAGE_LIMIT),
+    offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     timings: dict[str, float] = {}
     with time_operation("query", timings):
         tasks = await list_tasks(
@@ -190,9 +196,10 @@ async def list_tasks_endpoint(
             gantt_task_id=gantt_task_id,
         )
 
+    page, total = paginate(tasks, limit=limit, offset=offset)
     response = TaskListResponse(
-        items=[TaskRead.model_validate(item, from_attributes=True) for item in tasks],
-        total=len(tasks),
+        items=[TaskRead.model_validate(item, from_attributes=True) for item in page],
+        total=total,
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -203,11 +210,11 @@ async def list_tasks_endpoint(
 
 @router.get("/tasks/running", response_model=TaskRead | None)
 async def get_running_task_endpoint(
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     timings: dict[str, float] = {}
     with time_operation("query", timings):
         task = await get_running_task(session, user_id)
@@ -227,11 +234,11 @@ async def get_running_task_endpoint(
 @router.get("/tasks/{task_id}", response_model=TaskRead)
 async def get_task_endpoint(
     task_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> TaskRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         task = await get_task(session, user_id, task_id)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -245,11 +252,11 @@ async def get_task_endpoint(
 async def update_task_endpoint(
     task_id: str,
     payload: TaskUpdate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> TaskRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         task = await update_task(session, user_id, task_id, payload)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -262,11 +269,11 @@ async def update_task_endpoint(
 @router.delete("/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_task_endpoint(
     task_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         await delete_task(session, user_id, task_id)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -278,11 +285,11 @@ async def delete_task_endpoint(
 @router.post("/templates", response_model=TemplateRead, status_code=status.HTTP_201_CREATED)
 async def create_template_endpoint(
     payload: TemplateCreate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> TemplateRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
 
     try:
         template = await create_template(session, user_id, payload)
@@ -295,18 +302,21 @@ async def create_template_endpoint(
 
 @router.get("/templates", response_model=TemplateListResponse)
 async def list_templates_endpoint(
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
+    limit: int | None = Query(default=None, ge=1, le=MAX_PAGE_LIMIT),
+    offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     timings: dict[str, float] = {}
     with time_operation("query", timings):
         templates = await list_templates_for_user(session, user_id)
 
+    page, total = paginate(templates, limit=limit, offset=offset)
     response = TemplateListResponse(
-        items=[TemplateRead.model_validate(item, from_attributes=True) for item in templates],
-        total=len(templates),
+        items=[TemplateRead.model_validate(item, from_attributes=True) for item in page],
+        total=total,
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -318,11 +328,11 @@ async def list_templates_endpoint(
 @router.get("/templates/{template_id}", response_model=TemplateRead)
 async def get_template_endpoint(
     template_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> TemplateRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         template = await get_template(session, user_id, template_id)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -336,11 +346,11 @@ async def get_template_endpoint(
 async def update_template_endpoint(
     template_id: str,
     payload: TemplateUpdate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> TemplateRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         template = await update_template(session, user_id, template_id, payload)
     except (NotFoundError, ConflictError, ValidationError) as error:
@@ -353,11 +363,11 @@ async def update_template_endpoint(
 @router.delete("/templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_template_endpoint(
     template_id: str,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         await delete_template(session, user_id, template_id)
     except (NotFoundError, ConflictError, ValidationError) as error:

--- a/backend/app/routers/db_users.py
+++ b/backend/app/routers/db_users.py
@@ -158,10 +158,11 @@ async def get_user_by_username_endpoint(
     session: AsyncSession = Depends(get_session),
 ) -> UserRead:
     user = await get_user_by_username(session, username)
-    if user is None:
+    # Return 404 for both "does not exist" and "not yours": a 403 here would
+    # let any authenticated caller enumerate which usernames are taken.
+    if user is None or (not principal.is_admin and user.id != principal.user_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="user not found")
 
-    require_user_or_admin_match(user.id, principal)
     return UserRead.model_validate(user, from_attributes=True)
 
 

--- a/backend/app/routers/db_work_locations.py
+++ b/backend/app/routers/db_work_locations.py
@@ -29,7 +29,7 @@ from app.utils.timing import time_operation
 router = APIRouter(prefix="/work-locations", tags=["Work Locations"])
 
 
-@router.post("/", response_model=WorkLocationRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=WorkLocationRead, status_code=status.HTTP_201_CREATED)
 async def create_or_update_work_location_endpoint(
     payload: WorkLocationCreate,
     user_id: int | None = Query(default=None, ge=1),
@@ -48,7 +48,7 @@ async def create_or_update_work_location_endpoint(
     return WorkLocationRead.model_validate(location, from_attributes=True)
 
 
-@router.get("/", response_model=WorkLocationListResponse)
+@router.get("", response_model=WorkLocationListResponse)
 async def list_work_locations_endpoint(
     user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),

--- a/backend/app/routers/db_work_locations.py
+++ b/backend/app/routers/db_work_locations.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import get_authenticated_user_id, require_user_match
+from app.routers.auth import get_authenticated_user_id, resolve_scoped_user_id
 from app.schemas import (
     WorkLocationCreate,
     WorkLocationListResponse,
@@ -23,6 +23,7 @@ from app.services.db_service import (
     get_work_location,
     list_work_locations,
 )
+from app.utils.pagination import MAX_PAGE_LIMIT, paginate
 from app.utils.timing import time_operation
 
 router = APIRouter(prefix="/work-locations", tags=["Work Locations"])
@@ -31,11 +32,11 @@ router = APIRouter(prefix="/work-locations", tags=["Work Locations"])
 @router.post("/", response_model=WorkLocationRead, status_code=status.HTTP_201_CREATED)
 async def create_or_update_work_location_endpoint(
     payload: WorkLocationCreate,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> WorkLocationRead:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
 
     try:
         location = await create_or_update_work_location(session, user_id, payload)
@@ -49,13 +50,15 @@ async def create_or_update_work_location_endpoint(
 
 @router.get("/", response_model=WorkLocationListResponse)
 async def list_work_locations_endpoint(
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     start_date: date | None = None,
     end_date: date | None = None,
+    limit: int | None = Query(default=None, ge=1, le=MAX_PAGE_LIMIT),
+    offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     timings: dict[str, float] = {}
     with time_operation("query", timings):
         locations = await list_work_locations(
@@ -65,9 +68,10 @@ async def list_work_locations_endpoint(
             end_date=end_date,
         )
 
+    page, total = paginate(locations, limit=limit, offset=offset)
     response = WorkLocationListResponse(
-        items=[WorkLocationRead.model_validate(item, from_attributes=True) for item in locations],
-        total=len(locations),
+        items=[WorkLocationRead.model_validate(item, from_attributes=True) for item in page],
+        total=total,
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -79,11 +83,11 @@ async def list_work_locations_endpoint(
 @router.get("/{value_date}", response_model=WorkLocationRead)
 async def get_work_location_endpoint(
     value_date: date,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     timings: dict[str, float] = {}
     try:
         with time_operation("query", timings):
@@ -102,11 +106,11 @@ async def get_work_location_endpoint(
 @router.delete("/{value_date}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_work_location_endpoint(
     value_date: date,
-    user_id: int = Query(..., ge=1),
+    user_id: int | None = Query(default=None, ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    require_user_match(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
     try:
         await delete_work_location(session, user_id, value_date)
     except NotFoundError as error:

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..config import settings
 from ..config.oidc_config import OIDCTokenError, _resolve_jwks_uri
 from ..database.engine import get_session
+from ..middleware.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ async def _jwks_reachable() -> bool:
 
 
 @router.get("/health/liveness")
+@limiter.exempt
 async def liveness() -> JSONResponse:
     """Liveness probe — returns 200 immediately with no external I/O.
 
@@ -90,6 +92,7 @@ async def liveness() -> JSONResponse:
 
 
 @router.get("/health/readiness")
+@limiter.exempt
 async def readiness(
     db: Annotated[AsyncSession | None, Depends(_get_db_if_enabled)],
 ) -> JSONResponse:

--- a/backend/app/routers/registration.py
+++ b/backend/app/routers/registration.py
@@ -1,8 +1,8 @@
-"""Self-serve user registration endpoint.
+"""Admin-only user pre-registration endpoint.
 
-Provides a public ``POST /users/register`` route for pre-creating local user
-accounts.  User authentication and identity management are handled by the
-configured OIDC provider (e.g. authentik, Keycloak, ZITADEL).
+Provides ``POST /users/register`` for pre-creating local user accounts.
+User authentication and identity management are handled by the configured
+OIDC provider (e.g. authentik, Keycloak, ZITADEL).
 
 Pre-provisioned users created via this endpoint are NOT automatically linked to
 an OIDC login.  On first login the backend provisions a new local user record
@@ -10,6 +10,10 @@ from the token claims (see ``app.config.oidc_config``), regardless of any
 pre-existing rows with a matching username.  Use this endpoint only when a local
 record must exist before the user's first sign-in and the admin will manually
 associate the ``oidc_subject`` out-of-band.
+
+The endpoint requires an admin principal: because pre-registered rows are never
+auto-linked, public self-registration would only enable username squatting and
+unbounded creation of orphaned user rows.
 """
 
 from __future__ import annotations
@@ -20,6 +24,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
+from app.routers.auth import AuthenticatedPrincipal, get_authenticated_principal
 from app.schemas import UserCreate, UserRead, UserRegister
 from app.services.db_service import ConflictError, create_user
 
@@ -31,15 +36,22 @@ router = APIRouter(prefix="/users", tags=["Registration"])
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
 async def register_user(
     payload: UserRegister,
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> UserRead:
-    """Pre-register a local user account.
+    """Pre-register a local user account (admin only).
 
     Creates a local database user row.  No password is stored; authentication
     is handled by the OIDC provider.  The ``oidc_subject`` is left NULL and is
     NOT populated automatically — pre-provisioned users are not auto-linked to
     a matching OIDC login.
     """
+    if not principal.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="admin privileges required",
+        )
+
     user_create = UserCreate(
         username=payload.username,
         display_name=payload.display_name or payload.username,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -24,13 +24,22 @@ class ListResponse[T](BaseModel):
 
 
 class UserRegister(BaseModel):
-    """Payload for the self-serve registration endpoint.
+    """Payload for the admin-only pre-registration endpoint.
 
     ``display_name`` is optional; it defaults to the username when omitted.
     Authentication is handled by the OIDC provider; no password is stored locally.
+
+    The username pattern mirrors what OIDC auto-provisioning derives from
+    ``preferred_username``/email claims: it must start with a letter or digit
+    and may contain letters, digits, and ``. _ @ + -`` (no whitespace or
+    control characters).
     """
 
-    username: str = Field(min_length=1, max_length=150)
+    username: str = Field(
+        min_length=1,
+        max_length=150,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._@+-]*$",
+    )
     display_name: str | None = None
 
 
@@ -722,15 +731,29 @@ class UserDataExport(BaseModel):
     preferences: dict[str, Any]
 
 
+# Upper bound per entity list in a single push batch.  Generous for real
+# outbox flushes (which hold at most a few hundred queued changes) while
+# preventing a single request from processing an unbounded batch in one
+# transaction.  Clients with more pending changes must split into multiple
+# pushes.
+MAX_SYNC_PUSH_ITEMS = 1000
+
+
 class SyncPushRequest(BaseModel):
     """Batched push of local changes from client to server."""
 
-    labels: list[LabelSyncItem] = []
-    tasks: list[TaskSyncItem] = []
-    templates: list[TemplateSyncItem] = []
-    work_locations: list[WorkLocationSyncItem] = []
-    time_off_entries: list[TimeOffEntrySyncItem] = []
-    gantt_tasks: list[GanttTaskSyncItem] = []
+    labels: list[LabelSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
+    tasks: list[TaskSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
+    templates: list[TemplateSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
+    work_locations: list[WorkLocationSyncItem] = Field(
+        default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS
+    )
+    time_off_entries: list[TimeOffEntrySyncItem] = Field(
+        default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS
+    )
+    gantt_tasks: list[GanttTaskSyncItem] = Field(
+        default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS
+    )
 
 
 class SyncPushResponse(BaseModel):

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -41,6 +41,7 @@ from app.schemas import (
     WorkLocationUpdate,
 )
 from app.utils.datetime import as_utc
+from app.utils.sse_manager import notify_sync_changed
 
 
 class NotFoundError(Exception):
@@ -242,6 +243,7 @@ async def create_label(session: AsyncSession, user_id: int, payload: LabelCreate
     session.add(label)
     await session.commit()
     await session.refresh(label)
+    await notify_sync_changed(user_id)
     return label
 
 
@@ -282,9 +284,13 @@ async def update_label(
 
     for field, value in data.items():
         setattr(label, field, value)
+    # Bump the LWW timestamp so a later sync push carrying stale data cannot
+    # silently overwrite this edit (conflict detection compares client_updated_at).
+    label.client_updated_at = datetime.now(UTC)
     session.add(label)
     await session.commit()
     await session.refresh(label)
+    await notify_sync_changed(user_id)
     return label
 
 
@@ -309,6 +315,7 @@ async def delete_label(session: AsyncSession, user_id: int, label_id: str) -> No
     label.client_updated_at = now
     session.add(label)
     await session.commit()
+    await notify_sync_changed(user_id)
 
 
 # Task operations
@@ -345,6 +352,7 @@ async def create_task(session: AsyncSession, user_id: int, payload: TaskCreate) 
     session.add(task)
     await session.commit()
     await session.refresh(task)
+    await notify_sync_changed(user_id)
     return task
 
 
@@ -419,9 +427,13 @@ async def update_task(
 
     for field, value in data.items():
         setattr(task, field, value)
+    # Bump the LWW timestamp so a later sync push carrying stale data cannot
+    # silently overwrite this edit (conflict detection compares client_updated_at).
+    task.client_updated_at = datetime.now(UTC)
     session.add(task)
     await session.commit()
     await session.refresh(task)
+    await notify_sync_changed(user_id)
     return task
 
 
@@ -432,6 +444,7 @@ async def delete_task(session: AsyncSession, user_id: int, task_id: str) -> None
     task.client_updated_at = now
     session.add(task)
     await session.commit()
+    await notify_sync_changed(user_id)
 
 
 # Template operations
@@ -446,6 +459,7 @@ async def create_template(
     session.add(template)
     await session.commit()
     await session.refresh(template)
+    await notify_sync_changed(user_id)
     return template
 
 
@@ -484,9 +498,13 @@ async def update_template(
 
     for field, value in data.items():
         setattr(template, field, value)
+    # Bump the LWW timestamp so a later sync push carrying stale data cannot
+    # silently overwrite this edit (conflict detection compares client_updated_at).
+    template.client_updated_at = datetime.now(UTC)
     session.add(template)
     await session.commit()
     await session.refresh(template)
+    await notify_sync_changed(user_id)
     return template
 
 
@@ -497,6 +515,7 @@ async def delete_template(session: AsyncSession, user_id: int, template_id: str)
     template.client_updated_at = now
     session.add(template)
     await session.commit()
+    await notify_sync_changed(user_id)
 
 
 # Work location operations
@@ -507,12 +526,17 @@ async def create_or_update_work_location(
 ) -> WorkLocation:
     await _ensure_user_exists(session, user_id)
 
+    # The unique index on (user_id, date) is partial (active rows only), so
+    # multiple soft-deleted rows are legal at the schema level.  Pick the
+    # active row if one exists, otherwise the most recently updated tombstone,
+    # instead of scalar_one_or_none() which would raise on duplicates.
     result = await session.execute(
-        select(WorkLocation).where(
-            WorkLocation.user_id == user_id, WorkLocation.date == payload.date
-        )
+        select(WorkLocation)
+        .where(WorkLocation.user_id == user_id, WorkLocation.date == payload.date)
+        .order_by(WorkLocation.deleted_at.is_(None).desc(), WorkLocation.updated_at.desc())
+        .limit(1)
     )
-    location = result.scalar_one_or_none()
+    location = result.scalars().first()
 
     if location is None:
         location = WorkLocation(user_id=user_id, **payload.model_dump())
@@ -525,6 +549,7 @@ async def create_or_update_work_location(
     session.add(location)
     await session.commit()
     await session.refresh(location)
+    await notify_sync_changed(user_id)
     return location
 
 
@@ -574,9 +599,13 @@ async def update_work_location(
 
     for field, value in data.items():
         setattr(location, field, value)
+    # Bump the LWW timestamp so a later sync push carrying stale data cannot
+    # silently overwrite this edit (conflict detection compares client_updated_at).
+    location.client_updated_at = datetime.now(UTC)
     session.add(location)
     await session.commit()
     await session.refresh(location)
+    await notify_sync_changed(user_id)
     return location
 
 
@@ -587,6 +616,7 @@ async def delete_work_location(session: AsyncSession, user_id: int, value_date: 
     location.client_updated_at = now
     session.add(location)
     await session.commit()
+    await notify_sync_changed(user_id)
 
 
 # Gantt task operations
@@ -603,6 +633,7 @@ async def create_gantt_task(
     session.add(task)
     await session.commit()
     await session.refresh(task)
+    await notify_sync_changed(user_id)
     return task
 
 
@@ -635,9 +666,13 @@ async def update_gantt_task(
 
     for field, value in data.items():
         setattr(task, field, value)
+    # Bump the LWW timestamp so a later sync push carrying stale data cannot
+    # silently overwrite this edit (conflict detection compares client_updated_at).
+    task.client_updated_at = datetime.now(UTC)
     session.add(task)
     await session.commit()
     await session.refresh(task)
+    await notify_sync_changed(user_id)
     return task
 
 
@@ -653,6 +688,7 @@ async def delete_gantt_task(session: AsyncSession, user_id: int, task_id: str) -
         .values(gantt_task_id=None, client_updated_at=now, updated_at=now)
     )
     await session.commit()
+    await notify_sync_changed(user_id)
 
 
 # User preferences operations
@@ -699,6 +735,7 @@ async def upsert_user_preferences(
             raise RuntimeError("user preferences upsert failed to return or load a row")
 
     await session.commit()
+    await notify_sync_changed(user_id)
     return prefs
 
 
@@ -833,7 +870,9 @@ async def create_or_update_time_off_entry(
         entry.entry_flag = payload.entry_flag
         entry.note = payload.note
         entry.deleted_at = None
-        entry.updated_at = datetime.now(UTC)
+        now = datetime.now(UTC)
+        entry.updated_at = now
+        entry.client_updated_at = now
         created = False
 
     session.add(entry)
@@ -863,11 +902,14 @@ async def create_or_update_time_off_entry(
         entry.entry_flag = payload.entry_flag
         entry.note = payload.note
         entry.deleted_at = None
-        entry.updated_at = datetime.now(UTC)
+        now = datetime.now(UTC)
+        entry.updated_at = now
+        entry.client_updated_at = now
         session.add(entry)
         await session.commit()
         created = False
     await session.refresh(entry)
+    await notify_sync_changed(user_id)
     return entry, created
 
 
@@ -896,10 +938,15 @@ async def update_time_off_entry(
         }
     for field, value in data.items():
         setattr(entry, field, value)
-    entry.updated_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    entry.updated_at = now
+    # Bump the LWW timestamp so a later sync push carrying stale data cannot
+    # silently overwrite this edit (conflict detection compares client_updated_at).
+    entry.client_updated_at = now
     session.add(entry)
     await session.commit()
     await session.refresh(entry)
+    await notify_sync_changed(user_id)
     return entry
 
 
@@ -909,5 +956,7 @@ async def delete_time_off_entry(session: AsyncSession, user_id: int, entry_id: s
     now = datetime.now(UTC)
     entry.deleted_at = now
     entry.updated_at = now
+    entry.client_updated_at = now
     session.add(entry)
     await session.commit()
+    await notify_sync_changed(user_id)

--- a/backend/app/services/read_models_service.py
+++ b/backend/app/services/read_models_service.py
@@ -465,6 +465,19 @@ def _build_work_context(preferences_data: Mapping[str, Any]) -> ReadModelWorkCon
     )
 
 
+async def get_schedule_type_for_user(session: AsyncSession, user_id: int) -> ScheduleType | None:
+    """Return just the user's configured schedule type, or None if unset.
+
+    A lightweight alternative to build_dashboard_read_model() for callers
+    that only need the schedule type: it issues a single preferences query
+    instead of also fetching the user row, computing time-off entries, and
+    building a full team_status list for every team in the schedule.
+    """
+    preferences = await get_user_preferences(session, user_id)
+    preferences_data = preferences.data if preferences is not None else {}
+    return _build_work_context(preferences_data).schedule_type
+
+
 async def build_dashboard_read_model(
     session: AsyncSession,
     principal: AuthenticatedPrincipal,

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -31,7 +31,7 @@ from datetime import UTC, datetime, timedelta
 
 from pydantic import BaseModel
 from sqlalchemy import func as sql_func
-from sqlalchemy import select, update
+from sqlalchemy import literal, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.models import (
@@ -669,28 +669,48 @@ async def pull_changes(
     )
 
 
+type _StatusEntityModel = SyncEntityModel | UserPreferences
+
+_STATUS_ENTITY_MODELS: tuple[tuple[str, type[_StatusEntityModel]], ...] = (
+    ("labels", TimeTrackingLabel),
+    ("tasks", TimeTrackingTask),
+    ("templates", TimeTrackingTemplate),
+    ("work_locations", WorkLocation),
+    ("time_off_entries", TimeOffEntry),
+    ("gantt_tasks", GanttTask),
+    ("preferences", UserPreferences),
+)
+
+
 async def get_sync_status(session: AsyncSession, user_id: int) -> SyncStatusResponse:
-    """Return the most-recent ``updated_at`` per entity type for the user."""
+    """Return the most-recent ``updated_at`` per entity type for the user.
 
-    async def _max_ts(model, user_id: int) -> datetime | None:
-        result = await session.execute(
-            select(sql_func.max(model.updated_at)).where(model.user_id == user_id)
-        )
-        return result.scalar_one_or_none()
-
-    async def _prefs_updated_at(user_id: int) -> datetime | None:
-        result = await session.execute(
-            select(UserPreferences.updated_at).where(UserPreferences.user_id == user_id)
-        )
-        return result.scalar_one_or_none()
+    A single UNION ALL query replaces what used to be 7 sequential
+    round-trips (one MAX(updated_at) query per entity type plus one for
+    preferences) — AsyncSession only supports one in-flight statement at a
+    time anyway, so those awaits were purely serial latency, not parallel
+    work. Each subquery is an unconditional MAX() with no GROUP BY, so it
+    always returns exactly one row (NULL when the user has no rows for that
+    entity), keeping the UNION ALL at a fixed 7 rows.
+    """
+    subqueries = [
+        select(
+            literal(entity).label("entity"),
+            sql_func.max(model.updated_at).label("updated_at"),
+        ).where(model.user_id == user_id)
+        for entity, model in _STATUS_ENTITY_MODELS
+    ]
+    combined = subqueries[0].union_all(*subqueries[1:])
+    result = await session.execute(combined)
+    by_entity: dict[str, datetime | None] = {row.entity: row.updated_at for row in result}
 
     return SyncStatusResponse(
-        labels_updated_at=await _max_ts(TimeTrackingLabel, user_id),
-        tasks_updated_at=await _max_ts(TimeTrackingTask, user_id),
-        templates_updated_at=await _max_ts(TimeTrackingTemplate, user_id),
-        work_locations_updated_at=await _max_ts(WorkLocation, user_id),
-        time_off_entries_updated_at=await _max_ts(TimeOffEntry, user_id),
-        gantt_tasks_updated_at=await _max_ts(GanttTask, user_id),
-        preferences_updated_at=await _prefs_updated_at(user_id),
+        labels_updated_at=by_entity.get("labels"),
+        tasks_updated_at=by_entity.get("tasks"),
+        templates_updated_at=by_entity.get("templates"),
+        work_locations_updated_at=by_entity.get("work_locations"),
+        time_off_entries_updated_at=by_entity.get("time_off_entries"),
+        gantt_tasks_updated_at=by_entity.get("gantt_tasks"),
+        preferences_updated_at=by_entity.get("preferences"),
         server_timestamp=_now() - _PULL_CURSOR_OVERLAP,
     )

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -27,7 +27,7 @@ removing the row, so pull queries can propagate the deletion to other clients.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from pydantic import BaseModel
 from sqlalchemy import func as sql_func
@@ -69,6 +69,20 @@ from app.utils.datetime import as_utc
 
 def _now() -> datetime:
     return datetime.now(UTC)
+
+
+# Safety overlap subtracted from the server_timestamp reported by pull_changes
+# and get_sync_status (clients persist either value as their sync cursor).
+#
+# Push handlers stamp ``updated_at`` when they process a record, but the row
+# only becomes visible to other transactions at commit time.  A pull that runs
+# concurrently can therefore return a ``server_timestamp`` *later* than the
+# ``updated_at`` of a record it never saw — and a client storing that value as
+# its cursor would skip the record forever.  Reporting a slightly older
+# timestamp makes the next incremental pull re-read the recent window instead.
+# Re-delivered records are harmless: clients apply pulls idempotently via
+# last-write-wins.
+_PULL_CURSOR_OVERLAP = timedelta(seconds=30)
 
 
 
@@ -114,11 +128,17 @@ async def _push_label(
                 server_updated_at=label.updated_at,
                 conflict_reason="server version is newer",
             )
+        # Only *active* references block deletion — soft-deleted tasks/templates
+        # must not pin their label forever (mirrors db_service.delete_label).
         task_count = await session.scalar(
-            select(sql_func.count()).select_from(TimeTrackingTask).where(TimeTrackingTask.label_id == item.id)
+            select(sql_func.count())
+            .select_from(TimeTrackingTask)
+            .where(TimeTrackingTask.label_id == item.id, TimeTrackingTask.deleted_at.is_(None))
         )
         template_count = await session.scalar(
-            select(sql_func.count()).select_from(TimeTrackingTemplate).where(TimeTrackingTemplate.label_id == item.id)
+            select(sql_func.count())
+            .select_from(TimeTrackingTemplate)
+            .where(TimeTrackingTemplate.label_id == item.id, TimeTrackingTemplate.deleted_at.is_(None))
         )
         if task_count or template_count:
             return SyncRecordResult(
@@ -322,13 +342,21 @@ async def _push_work_location(
     now = _now()
     date_key = item.date.isoformat()
 
+    # The unique index on (user_id, date) is partial (active rows only), so
+    # multiple soft-deleted rows are legal at the schema level.  Pick the
+    # active row if one exists, otherwise the most recently updated tombstone,
+    # instead of scalar_one_or_none() which would raise on duplicates and
+    # abort the whole push batch.
     result = await session.execute(
-        select(WorkLocation).where(
+        select(WorkLocation)
+        .where(
             WorkLocation.user_id == user_id,
             WorkLocation.date == item.date,
         )
+        .order_by(WorkLocation.deleted_at.is_(None).desc(), WorkLocation.updated_at.desc())
+        .limit(1)
     )
-    location: WorkLocation | None = result.scalar_one_or_none()
+    location: WorkLocation | None = result.scalars().first()
 
     if item.action == "delete":
         if location is None or location.deleted_at is not None:
@@ -590,8 +618,16 @@ async def push_changes(
         "gantt_tasks": [],
     }
 
+    # Referenced entities are processed before the entities that link to them:
+    # labels and gantt tasks must exist before tasks/templates that reference
+    # them are validated.  A first-sync upload sends everything in one batch,
+    # so processing tasks before gantt tasks would reject any task carrying a
+    # gantt_task_id link with "gantt task not found".
     for item in changes.labels:
         results["labels"].append(await _push_label(session, user_id, item))
+
+    for item in changes.gantt_tasks:
+        results["gantt_tasks"].append(await _push_gantt_task(session, user_id, item))
 
     for item in changes.tasks:
         results["tasks"].append(await _push_task(session, user_id, item))
@@ -604,9 +640,6 @@ async def push_changes(
 
     for item in changes.time_off_entries:
         results["time_off_entries"].append(await _push_time_off_entry(session, user_id, item))
-
-    for item in changes.gantt_tasks:
-        results["gantt_tasks"].append(await _push_gantt_task(session, user_id, item))
 
     await session.commit()
     return SyncPushResponse(results=results)
@@ -632,7 +665,7 @@ async def pull_changes(
         work_locations=[WorkLocationSyncRead.model_validate(r, from_attributes=True) for r in work_locations],
         time_off_entries=[TimeOffEntrySyncRead.model_validate(r, from_attributes=True) for r in time_off_entries],
         gantt_tasks=[GanttTaskSyncRead.model_validate(r, from_attributes=True) for r in gantt_tasks],
-        server_timestamp=_now(),
+        server_timestamp=_now() - _PULL_CURSOR_OVERLAP,
     )
 
 
@@ -659,5 +692,5 @@ async def get_sync_status(session: AsyncSession, user_id: int) -> SyncStatusResp
         time_off_entries_updated_at=await _max_ts(TimeOffEntry, user_id),
         gantt_tasks_updated_at=await _max_ts(GanttTask, user_id),
         preferences_updated_at=await _prefs_updated_at(user_id),
-        server_timestamp=_now(),
+        server_timestamp=_now() - _PULL_CURSOR_OVERLAP,
     )

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -84,7 +84,23 @@ def _now() -> datetime:
 # last-write-wins.
 _PULL_CURSOR_OVERLAP = timedelta(seconds=30)
 
+# Upper bound on how far into the future a client-supplied client_updated_at
+# is trusted, relative to the server's own clock.
+#
+# LWW conflict detection is a pure ">" comparison on this field with no other
+# tiebreaker, so a device with a badly wrong clock (or a unit bug — e.g.
+# sending milliseconds where seconds were expected, landing sometime in the
+# year 48000) would otherwise win every future comparison unconditionally,
+# permanently freezing that record: no other device could ever generate a
+# "later" timestamp to overwrite it, including a subsequent correction from
+# the same device once its clock is fixed. Clamping bounds the damage to
+# _MAX_CLOCK_SKEW of un-overwritable time instead of forever.
+_MAX_CLOCK_SKEW = timedelta(minutes=5)
 
+
+def _clamp_client_timestamp(client_updated_at: datetime) -> datetime:
+    """Clamp a client-supplied timestamp to at most _MAX_CLOCK_SKEW into the future."""
+    return min(as_utc(client_updated_at), _now() + _MAX_CLOCK_SKEW)
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +128,28 @@ async def _validate_task_label_reference(
         raise ValidationError("label not found")
 
 
+async def _label_name_taken(
+    session: AsyncSession, user_id: int, name: str, *, exclude_id: str | None
+) -> bool:
+    """Whether another *active* label already owns (user_id, name).
+
+    Mirrors the ``uq_active_label_user_name`` partial unique index so callers
+    can return a per-record conflict instead of letting the INSERT/UPDATE hit
+    that constraint at commit time — which would raise ``IntegrityError`` for
+    the whole batch (one transaction covers every record in the push), not
+    just the offending label.
+    """
+    conditions = [
+        TimeTrackingLabel.user_id == user_id,
+        TimeTrackingLabel.name == name,
+        TimeTrackingLabel.deleted_at.is_(None),
+    ]
+    if exclude_id is not None:
+        conditions.append(TimeTrackingLabel.id != exclude_id)
+    result = await session.execute(select(TimeTrackingLabel.id).where(*conditions).limit(1))
+    return result.scalar_one_or_none() is not None
+
+
 async def _push_label(
     session: AsyncSession, user_id: int, item: LabelSyncItem
 ) -> SyncRecordResult:
@@ -121,7 +159,7 @@ async def _push_label(
     if item.action == "delete":
         if label is None or label.user_id != user_id or label.deleted_at is not None:
             return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
-        if as_utc(item.client_updated_at) <= as_utc(label.client_updated_at):
+        if _clamp_client_timestamp(item.client_updated_at) <= as_utc(label.client_updated_at):
             return SyncRecordResult(
                 id=item.id,
                 status="conflict",
@@ -147,7 +185,7 @@ async def _push_label(
                 server_updated_at=label.updated_at,
                 conflict_reason="label is in use by tasks or templates and cannot be deleted",
             )
-        label.client_updated_at = as_utc(item.client_updated_at)
+        label.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
         label.deleted_at = now
         label.updated_at = now
         session.add(label)
@@ -158,34 +196,63 @@ async def _push_label(
         if item.name is None or item.color is None:
             from app.services.db_service import ValidationError
             raise ValidationError("name and color are required for label create")
+        if await _label_name_taken(session, user_id, item.name, exclude_id=None):
+            return SyncRecordResult(
+                id=item.id,
+                status="conflict",
+                conflict_reason="a label with this name already exists",
+            )
         label = TimeTrackingLabel(
             id=item.id,
             user_id=user_id,
             name=item.name,
             color=item.color,
-            client_updated_at=as_utc(item.client_updated_at),
+            client_updated_at=_clamp_client_timestamp(item.client_updated_at),
         )
         session.add(label)
         return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
     if label.user_id != user_id:
-        from app.services.db_service import ValidationError
-        raise ValidationError("label not found")
+        # The id collides with another user's label. Returning a per-record
+        # conflict (rather than raising, which would 400 the whole batch) both
+        # keeps the rest of the batch processing and avoids leaking whether
+        # the id belongs to someone else vs. genuinely being stale — same
+        # response shape as an ordinary LWW conflict either way.
+        return SyncRecordResult(
+            id=item.id,
+            status="conflict",
+            conflict_reason="server version is newer",
+        )
 
-    if as_utc(item.client_updated_at) <= as_utc(label.client_updated_at):
+    if _clamp_client_timestamp(item.client_updated_at) <= as_utc(label.client_updated_at):
         return SyncRecordResult(
             id=item.id,
             status="conflict",
             server_updated_at=label.updated_at,
             conflict_reason="server version is newer",
         )
+    new_name = item.name if item.name is not None else label.name
+    is_reviving = label.deleted_at is not None
+    # A rename or a revival-from-soft-delete can each collide with another
+    # active label that already holds that name — a same-name, no-op update
+    # (name unchanged, already active) cannot, so skip the check there to
+    # avoid a spurious self-collision false positive.
+    if (new_name != label.name or is_reviving) and await _label_name_taken(
+        session, user_id, new_name, exclude_id=label.id
+    ):
+        return SyncRecordResult(
+            id=item.id,
+            status="conflict",
+            server_updated_at=label.updated_at,
+            conflict_reason="a label with this name already exists",
+        )
     if item.name is not None:
         label.name = item.name
     if item.color is not None:
         label.color = item.color
-    if label.deleted_at is not None:
+    if is_reviving:
         label.deleted_at = None
-    label.client_updated_at = as_utc(item.client_updated_at)
+    label.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
     label.updated_at = now
     session.add(label)
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
@@ -200,14 +267,14 @@ async def _push_task(
     if item.action == "delete":
         if task is None or task.user_id != user_id or task.deleted_at is not None:
             return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
-        if as_utc(item.client_updated_at) <= as_utc(task.client_updated_at):
+        if _clamp_client_timestamp(item.client_updated_at) <= as_utc(task.client_updated_at):
             return SyncRecordResult(
                 id=item.id,
                 status="conflict",
                 server_updated_at=task.updated_at,
                 conflict_reason="server version is newer",
             )
-        task.client_updated_at = as_utc(item.client_updated_at)
+        task.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
         task.deleted_at = now
         task.updated_at = now
         session.add(task)
@@ -217,6 +284,9 @@ async def _push_task(
         if item.text is None or item.start_time is None:
             from app.services.db_service import ValidationError
             raise ValidationError("text and start_time are required for task create")
+        if item.stop_time is not None and as_utc(item.stop_time) < as_utc(item.start_time):
+            from app.services.db_service import ValidationError
+            raise ValidationError("stop_time cannot be earlier than start_time")
         await _validate_task_label_reference(session, user_id, item.label_id)
         await _validate_task_gantt_reference(session, user_id, item.gantt_task_id)
         task = TimeTrackingTask(
@@ -228,16 +298,22 @@ async def _push_task(
             start_time=item.start_time,
             stop_time=item.stop_time,
             includes_break=item.includes_break or False,
-            client_updated_at=as_utc(item.client_updated_at),
+            client_updated_at=_clamp_client_timestamp(item.client_updated_at),
         )
         session.add(task)
         return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
     if task.user_id != user_id:
-        from app.services.db_service import ValidationError
-        raise ValidationError("task not found")
+        # See the equivalent check in _push_label: a per-record conflict
+        # keeps the rest of the batch processing and avoids an id-ownership
+        # oracle, rather than raising and 400ing the whole batch.
+        return SyncRecordResult(
+            id=item.id,
+            status="conflict",
+            conflict_reason="server version is newer",
+        )
 
-    if as_utc(item.client_updated_at) <= as_utc(task.client_updated_at):
+    if _clamp_client_timestamp(item.client_updated_at) <= as_utc(task.client_updated_at):
         return SyncRecordResult(
             id=item.id,
             status="conflict",
@@ -245,6 +321,15 @@ async def _push_task(
             conflict_reason="server version is newer",
         )
     provided_fields = _get_provided_fields(item) - {"action", "client_updated_at"}
+    candidate_start_time = (
+        item.start_time
+        if "start_time" in provided_fields and item.start_time is not None
+        else task.start_time
+    )
+    candidate_stop_time = item.stop_time if "stop_time" in provided_fields else task.stop_time
+    if candidate_stop_time is not None and as_utc(candidate_stop_time) < as_utc(candidate_start_time):
+        from app.services.db_service import ValidationError
+        raise ValidationError("stop_time cannot be earlier than start_time")
     if "text" in provided_fields and item.text is not None:
         task.text = item.text
     if "label_id" in provided_fields:
@@ -261,7 +346,7 @@ async def _push_task(
         task.includes_break = item.includes_break
     if task.deleted_at is not None:
         task.deleted_at = None
-    task.client_updated_at = as_utc(item.client_updated_at)
+    task.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
     task.updated_at = now
     session.add(task)
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
@@ -276,14 +361,14 @@ async def _push_template(
     if item.action == "delete":
         if template is None or template.user_id != user_id or template.deleted_at is not None:
             return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
-        if as_utc(item.client_updated_at) <= as_utc(template.client_updated_at):
+        if _clamp_client_timestamp(item.client_updated_at) <= as_utc(template.client_updated_at):
             return SyncRecordResult(
                 id=item.id,
                 status="conflict",
                 server_updated_at=template.updated_at,
                 conflict_reason="server version is newer",
             )
-        template.client_updated_at = as_utc(item.client_updated_at)
+        template.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
         template.deleted_at = now
         template.updated_at = now
         session.add(template)
@@ -301,16 +386,20 @@ async def _push_template(
             text=item.text,
             start_time=item.start_time,
             stop_time=item.stop_time,
-            client_updated_at=as_utc(item.client_updated_at),
+            client_updated_at=_clamp_client_timestamp(item.client_updated_at),
         )
         session.add(template)
         return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
     if template.user_id != user_id:
-        from app.services.db_service import ValidationError
-        raise ValidationError("template not found")
+        # See the equivalent check in _push_label.
+        return SyncRecordResult(
+            id=item.id,
+            status="conflict",
+            conflict_reason="server version is newer",
+        )
 
-    if as_utc(item.client_updated_at) <= as_utc(template.client_updated_at):
+    if _clamp_client_timestamp(item.client_updated_at) <= as_utc(template.client_updated_at):
         return SyncRecordResult(
             id=item.id,
             status="conflict",
@@ -329,7 +418,7 @@ async def _push_template(
         template.stop_time = item.stop_time
     if template.deleted_at is not None:
         template.deleted_at = None
-    template.client_updated_at = as_utc(item.client_updated_at)
+    template.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
     template.updated_at = now
     session.add(template)
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
@@ -361,14 +450,14 @@ async def _push_work_location(
     if item.action == "delete":
         if location is None or location.deleted_at is not None:
             return SyncRecordResult(id=date_key, status="ok", server_updated_at=now)
-        if as_utc(item.client_updated_at) <= as_utc(location.client_updated_at):
+        if _clamp_client_timestamp(item.client_updated_at) <= as_utc(location.client_updated_at):
             return SyncRecordResult(
                 id=date_key,
                 status="conflict",
                 server_updated_at=location.updated_at,
                 conflict_reason="server version is newer",
             )
-        location.client_updated_at = as_utc(item.client_updated_at)
+        location.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
         location.deleted_at = now
         location.updated_at = now
         session.add(location)
@@ -383,12 +472,12 @@ async def _push_work_location(
             date=item.date,
             country_code=item.country_code,
             label=item.label,
-            client_updated_at=as_utc(item.client_updated_at),
+            client_updated_at=_clamp_client_timestamp(item.client_updated_at),
         )
         session.add(location)
         return SyncRecordResult(id=date_key, status="ok", server_updated_at=now)
 
-    if as_utc(item.client_updated_at) <= as_utc(location.client_updated_at):
+    if _clamp_client_timestamp(item.client_updated_at) <= as_utc(location.client_updated_at):
         return SyncRecordResult(
             id=date_key,
             status="conflict",
@@ -402,7 +491,7 @@ async def _push_work_location(
         location.label = item.label
     if location.deleted_at is not None:
         location.deleted_at = None
-    location.client_updated_at = as_utc(item.client_updated_at)
+    location.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
     location.updated_at = now
     session.add(location)
     return SyncRecordResult(id=date_key, status="ok", server_updated_at=now)
@@ -426,14 +515,14 @@ async def _push_time_off_entry(
     if isinstance(item, TimeOffEntrySyncDeleteItem):
         if entry is None or entry.deleted_at is not None:
             return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
-        if as_utc(item.client_updated_at) <= as_utc(entry.client_updated_at):
+        if _clamp_client_timestamp(item.client_updated_at) <= as_utc(entry.client_updated_at):
             return SyncRecordResult(
                 id=item.id,
                 status="conflict",
                 server_updated_at=entry.updated_at,
                 conflict_reason="server version is newer",
             )
-        entry.client_updated_at = as_utc(item.client_updated_at)
+        entry.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
         entry.deleted_at = now
         entry.updated_at = now
         session.add(entry)
@@ -466,11 +555,11 @@ async def _push_time_off_entry(
             end_date=item.end_date,
             weekday=item.weekday,
         )
-        entry.client_updated_at = as_utc(item.client_updated_at)
+        entry.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
         session.add(entry)
         return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
-    if as_utc(item.client_updated_at) <= as_utc(entry.client_updated_at):
+    if _clamp_client_timestamp(item.client_updated_at) <= as_utc(entry.client_updated_at):
         return SyncRecordResult(
             id=item.id,
             status="conflict",
@@ -494,7 +583,7 @@ async def _push_time_off_entry(
         entry.note = item.note
     if entry.deleted_at is not None:
         entry.deleted_at = None
-    entry.client_updated_at = as_utc(item.client_updated_at)
+    entry.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
     entry.updated_at = now
     session.add(entry)
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
@@ -509,14 +598,14 @@ async def _push_gantt_task(
     if item.action == "delete":
         if task is None or task.user_id != user_id or task.deleted_at is not None:
             return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
-        if as_utc(item.client_updated_at) <= as_utc(task.client_updated_at):
+        if _clamp_client_timestamp(item.client_updated_at) <= as_utc(task.client_updated_at):
             return SyncRecordResult(
                 id=item.id,
                 status="conflict",
                 server_updated_at=task.updated_at,
                 conflict_reason="server version is newer",
             )
-        task.client_updated_at = as_utc(item.client_updated_at)
+        task.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
         task.deleted_at = now
         task.updated_at = now
         session.add(task)
@@ -540,16 +629,20 @@ async def _push_gantt_task(
             progress=item.progress or 0,
             dependencies=item.dependencies,
             notes=item.notes,
-            client_updated_at=as_utc(item.client_updated_at),
+            client_updated_at=_clamp_client_timestamp(item.client_updated_at),
         )
         session.add(task)
         return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
     if task.user_id != user_id:
-        from app.services.db_service import ValidationError
-        raise ValidationError("gantt task not found")
+        # See the equivalent check in _push_label.
+        return SyncRecordResult(
+            id=item.id,
+            status="conflict",
+            conflict_reason="server version is newer",
+        )
 
-    if as_utc(item.client_updated_at) <= as_utc(task.client_updated_at):
+    if _clamp_client_timestamp(item.client_updated_at) <= as_utc(task.client_updated_at):
         return SyncRecordResult(
             id=item.id,
             status="conflict",
@@ -571,7 +664,7 @@ async def _push_gantt_task(
         task.notes = item.notes
     if task.deleted_at is not None:
         task.deleted_at = None
-    task.client_updated_at = as_utc(item.client_updated_at)
+    task.client_updated_at = _clamp_client_timestamp(item.client_updated_at)
     task.updated_at = now
     session.add(task)
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)

--- a/backend/app/utils/pagination.py
+++ b/backend/app/utils/pagination.py
@@ -1,0 +1,29 @@
+"""In-process pagination for list endpoints.
+
+The list_* service functions still fetch every matching row for the user
+(cheap given the per-user composite indexes — see migration 003) rather than
+pushing LIMIT/OFFSET into the query. Slicing here instead of in the service
+layer keeps every existing service-function caller (MCP tools, read models,
+other routers) working unchanged, while still bounding the JSON response size
+sent to a paginating client.
+"""
+
+from __future__ import annotations
+
+# Upper bound on `limit` accepted by any paginated list endpoint.
+MAX_PAGE_LIMIT = 500
+
+
+def paginate[T](items: list[T], *, limit: int | None, offset: int) -> tuple[list[T], int]:
+    """Return ``(page, total)``; *total* is the full, unsliced item count.
+
+    ``offset`` is always applied (0 is a no-op slice). ``limit=None`` returns
+    every remaining item after ``offset`` — the default, preserving the
+    unpaginated behavior existing callers rely on when they don't pass these
+    params at all.
+    """
+    total = len(items)
+    page = items[offset:]
+    if limit is not None:
+        page = page[:limit]
+    return page, total

--- a/backend/app/utils/sse_manager.py
+++ b/backend/app/utils/sse_manager.py
@@ -240,3 +240,17 @@ class SyncEventManager:
 
 #: Module-level singleton; imported by routers and wired up in main.py lifespan.
 sync_event_manager = SyncEventManager()
+
+
+async def notify_sync_changed(user_id: int) -> None:
+    """Broadcast a ``sync_changed`` hint for *user_id*, swallowing all errors.
+
+    The hint is a freshness signal only — a failed broadcast must never fail
+    the write that triggered it, so every exception is logged and suppressed.
+    """
+    try:
+        await sync_event_manager.broadcast_sync_changed(user_id)
+    except Exception:
+        logger.warning(
+            "SSE: broadcast_sync_changed failed for user %d (non-fatal)", user_id, exc_info=True
+        )

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U worktime"]
       interval: 5s

--- a/backend/migrations/versions/003_composite_sync_indexes.py
+++ b/backend/migrations/versions/003_composite_sync_indexes.py
@@ -1,0 +1,51 @@
+"""Add composite indexes for the hot sync-pull and task-listing queries.
+
+pull_changes filters every synced table on (user_id, updated_at > since);
+list_tasks additionally sorts by start_time within a user_id filter. Only
+single-column indexes existed on user_id and updated_at separately, so
+Postgres had to intersect two index scans (or fall back to a user_id scan
+plus filter) instead of satisfying each query with a single composite index
+scan.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-07-21
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "003"
+down_revision: str | None = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SYNCED_TABLES = (
+    "time_tracking_labels",
+    "time_tracking_tasks",
+    "time_tracking_templates",
+    "work_locations",
+    "gantt_tasks",
+    "time_off_entries",
+)
+
+
+def upgrade() -> None:
+    for table in _SYNCED_TABLES:
+        op.create_index(
+            f"ix_{table}_user_id_updated_at",
+            table,
+            ["user_id", "updated_at"],
+        )
+    op.create_index(
+        "ix_time_tracking_tasks_user_id_start_time",
+        "time_tracking_tasks",
+        ["user_id", "start_time"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_time_tracking_tasks_user_id_start_time", table_name="time_tracking_tasks")
+    for table in reversed(_SYNCED_TABLES):
+        op.drop_index(f"ix_{table}_user_id_updated_at", table_name=table)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "python-dotenv==1.2.2",
   "sqlalchemy==2.0.51",
   "uvicorn[standard]==0.51.0",
+  "slowapi==0.1.10",
 ]
 
 [dependency-groups]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -69,6 +69,17 @@ def reset_cache() -> Generator[None, None, None]:
     yield
 
 
+@pytest.fixture(autouse=True)
+def reset_rate_limiter() -> Generator[None, None, None]:
+    """Clear the rate limiter's in-memory storage before each test.
+
+    TestClient requests all share the same client IP, so without this every
+    test in the suite would draw down the same RATE_LIMIT_DEFAULT bucket.
+    """
+    app.state.limiter.reset()
+    yield
+
+
 @pytest_asyncio.fixture(scope="session")
 async def _schema_engine() -> AsyncGenerator[AsyncEngine, None]:
     """Session-scoped engine: create schema once, drop it after all tests."""

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -174,23 +174,80 @@ def test_audit_timestamp_format(temp_audit_dir):
     assert timestamp.tzinfo is not None
 
 
-def test_audit_append_permission_error(temp_audit_dir, monkeypatch):
-    """Test that permission errors are raised."""
+def test_audit_append_permission_error_is_swallowed(temp_audit_dir, monkeypatch):
+    """Audit logging is diagnostic: a permission error must not raise.
+
+    A failure to create the audit log directory (or open the log file) is
+    logged and swallowed rather than propagated, so a disk/permissions issue
+    on the audit log can never fail the operation being recorded.
+    """
     audit_dir, audit_file = temp_audit_dir
-    
+
     # Create directory with no write permissions (Unix only)
     audit_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Mock mkdir to raise PermissionError
     original_mkdir = Path.mkdir
-    
+
     def mock_mkdir(self, *args, **kwargs):
         if str(self) == str(audit_dir):
             raise PermissionError("No write permission")
         return original_mkdir(self, *args, **kwargs)
-    
+
     monkeypatch.setattr(Path, "mkdir", mock_mkdir)
-    
-    # Should raise PermissionError
-    with pytest.raises(PermissionError):
-        audit_logger.append("test.hday", "read")
+
+    # Must not raise, and must not have written anything.
+    audit_logger.append("test.hday", "read")
+    assert not audit_file.exists()
+
+
+def test_audit_append_dispatches_to_thread_inside_event_loop(temp_audit_dir):
+    """Inside a running event loop, the write happens on a background thread.
+
+    append() itself is synchronous, so this drives it from an async test and
+    awaits the dispatched executor future to observe the completed write
+    without depending on real-world thread-scheduling timing.
+    """
+    import asyncio
+
+    audit_dir, audit_file = temp_audit_dir
+
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        original_run_in_executor = loop.run_in_executor
+        futures = []
+
+        def capturing_run_in_executor(executor, func, *args):
+            future = original_run_in_executor(executor, func, *args)
+            futures.append(future)
+            return future
+
+        loop.run_in_executor = capturing_run_in_executor
+        try:
+            audit_logger.append("async.hday", "read", "via loop")
+            assert futures, "append() did not dispatch to run_in_executor"
+            await futures[0]
+        finally:
+            loop.run_in_executor = original_run_in_executor
+
+    asyncio.run(_run())
+
+    with open(audit_file, encoding="utf-8") as f:
+        entry = json.loads(f.readline())
+    assert entry["target"] == "async.hday"
+    assert entry["details"] == "via loop"
+
+
+def test_audit_log_rotates_past_max_bytes(temp_audit_dir, monkeypatch):
+    """The audit log rotates to a backup file once it exceeds the size cap."""
+    from app.audit import logger as audit_module
+
+    audit_dir, audit_file = temp_audit_dir
+    monkeypatch.setattr(audit_module, "_MAX_BYTES", 200)
+    monkeypatch.setattr(audit_module, "_BACKUP_COUNT", 2)
+
+    for i in range(50):
+        audit_logger.append(f"file{i}.hday", "read", "x" * 20)
+
+    backup_file = audit_file.with_name(audit_file.name + ".1")
+    assert backup_file.exists(), "expected at least one rotation to have occurred"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -26,6 +26,8 @@ def test_default_settings():
     assert settings.OIDC_ISSUER_URL == "http://localhost:9000/application/o/worktime"
     assert settings.OIDC_AUDIENCE == ""
     assert settings.OIDC_ALGORITHMS == "RS256"
+    assert settings.RATE_LIMIT_ENABLED is True
+    assert settings.RATE_LIMIT_DEFAULT == "200/minute"
 
 
 def test_custom_settings():

--- a/backend/tests/test_db_api_endpoints.py
+++ b/backend/tests/test_db_api_endpoints.py
@@ -86,11 +86,13 @@ def test_db_user_crud_endpoints(
     assert by_username_response.status_code == 200
     assert by_username_response.json()["id"] == user_id
 
-    forbidden_by_username = client.get(
+    # 404 (not 403) for a foreign username — a 403 here would let any
+    # authenticated caller enumerate which usernames are taken.
+    not_found_by_username = client.get(
         "/api/users/by-username/api-user-other",
         headers=_auth_headers(user_id),
     )
-    assert forbidden_by_username.status_code == 403
+    assert not_found_by_username.status_code == 404
 
     update_response = client.put(
         f"/api/users/{user_id}",

--- a/backend/tests/test_db_api_endpoints.py
+++ b/backend/tests/test_db_api_endpoints.py
@@ -445,11 +445,11 @@ def test_work_location_endpoints_require_auth_and_user_match(db_client: TestClie
         headers=admin_headers,
     ).json()["id"]
 
-    unauthenticated = client.get(f"/api/work-locations/?user_id={owner_id}")
+    unauthenticated = client.get(f"/api/work-locations?user_id={owner_id}")
     assert unauthenticated.status_code == 401
 
     forbidden = client.get(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         headers=_auth_headers(other_id),
     )
     assert forbidden.status_code == 403
@@ -467,7 +467,7 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     headers = _auth_headers(user_id)
 
     create_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-01-02", "country_code": "nl", "label": "Home"},
         headers=headers,
     )
@@ -475,7 +475,7 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     assert create_response.json()["country_code"] == "NL"
 
     update_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-01-02", "country_code": "BE", "label": "Client"},
         headers=headers,
     )
@@ -483,7 +483,7 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     assert update_response.json()["label"] == "Client"
 
     list_response = client.get(
-        f"/api/work-locations/?user_id={user_id}&start_date=2026-01-01&end_date=2026-01-03",
+        f"/api/work-locations?user_id={user_id}&start_date=2026-01-01&end_date=2026-01-03",
         headers=headers,
     )
     assert list_response.status_code == 200
@@ -510,14 +510,14 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     assert missing_response.status_code == 404
 
     invalid_country_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-01-03", "country_code": "ZZ", "label": None},
         headers=headers,
     )
     assert invalid_country_response.status_code == 422
 
     missing_body_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         headers=headers,
     )
     assert missing_body_response.status_code == 422

--- a/backend/tests/test_db_time_off.py
+++ b/backend/tests/test_db_time_off.py
@@ -13,7 +13,7 @@ def _create_entry(
     payload: dict | None = None,
 ) -> dict:
     response = client.post(
-        "/api/time-off/",
+        "/api/time-off",
         json=payload or {"date": "2026-06-01", "entry_type": "vacation"},
         headers=headers,
     )
@@ -23,11 +23,11 @@ def _create_entry(
 
 class TestTimeOffAuth:
     def test_list_requires_auth(self, db_client: TestClient) -> None:
-        assert db_client.get("/api/time-off/").status_code == 401
+        assert db_client.get("/api/time-off").status_code == 401
 
     def test_create_requires_auth(self, db_client: TestClient) -> None:
         assert db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-06-01", "entry_type": "vacation"},
         ).status_code == 401
 
@@ -76,7 +76,7 @@ class TestCreateTimeOff:
         headers = auth_headers(user_id)
 
         resp = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-07-14", "entry_type": "vacation", "entry_flag": "half_am", "note": "summer"},
             headers=headers,
         )
@@ -104,14 +104,14 @@ class TestCreateTimeOff:
         entry_id = "timeoff-upsert-1"
 
         first = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"entry_id": entry_id, "date": "2026-08-01", "entry_type": "vacation"},
             headers=headers,
         )
         assert first.status_code == 201
 
         second = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={
                 "entry_id": entry_id,
                 "entry_kind": "range",
@@ -148,7 +148,7 @@ class TestTimeOffValidation:
         headers = auth_headers(user_id)
 
         resp = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-07-14", "entry_type": "sick"},
             headers=headers,
         )
@@ -165,7 +165,7 @@ class TestTimeOffValidation:
         headers = auth_headers(user_id)
 
         resp = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-07-14", "entry_type": "vacation", "entry_flag": "unknown_flag"},
             headers=headers,
         )
@@ -183,7 +183,7 @@ class TestListTimeOff:
         user_id = create_user_factory(db_client, admin_h, "to-list-empty")
         headers = auth_headers(user_id)
 
-        resp = db_client.get("/api/time-off/", headers=headers)
+        resp = db_client.get("/api/time-off", headers=headers)
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
         assert resp.json()["items"] == []
@@ -210,7 +210,7 @@ class TestListTimeOff:
             {"entry_kind": "weekly", "weekday": 1, "entry_type": "in", "note": "Mondays"},
         )
 
-        resp = db_client.get("/api/time-off/", headers=headers)
+        resp = db_client.get("/api/time-off", headers=headers)
         assert resp.status_code == 200
         assert resp.json()["total"] == 3
 
@@ -234,7 +234,7 @@ class TestListTimeOff:
         _create_entry(db_client, headers, {"date": "2026-06-20", "entry_type": "vacation"})
 
         resp = db_client.get(
-            "/api/time-off/?start_date=2026-06-10&end_date=2026-06-15",
+            "/api/time-off?start_date=2026-06-10&end_date=2026-06-15",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -255,7 +255,7 @@ class TestListTimeOff:
 
         _create_entry(db_client, headers_a, {"date": "2026-07-01", "entry_type": "vacation"})
 
-        resp = db_client.get("/api/time-off/", headers=headers_b)
+        resp = db_client.get("/api/time-off", headers=headers_b)
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
 
@@ -296,7 +296,7 @@ class TestGetPatchDeleteTimeOff:
         delete_resp = db_client.delete(f"/api/time-off/{entry_id}", headers=headers)
         assert delete_resp.status_code == 204
 
-        list_resp = db_client.get("/api/time-off/", headers=headers)
+        list_resp = db_client.get("/api/time-off", headers=headers)
         assert list_resp.json()["total"] == 0
 
     def test_returns_404_when_entry_is_missing(
@@ -336,7 +336,7 @@ class TestGetPatchDeleteTimeOff:
         assert db_client.delete(f"/api/time-off/{entry_id}", headers=headers).status_code == 204
 
         recreate = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"entry_id": entry_id, "date": "2026-11-11", "entry_type": "ill"},
             headers=headers,
         )

--- a/backend/tests/test_db_time_tracking.py
+++ b/backend/tests/test_db_time_tracking.py
@@ -488,3 +488,108 @@ def test_cross_user_cannot_read_modify_or_delete_time_tracking_resources(
         f"/api/time-tracking/templates/{template_id}?user_id={owner_id}",
         headers=other_headers,
     ).status_code == 403
+
+
+def test_user_id_query_param_is_optional_and_derived_from_auth(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    """Omitting ?user_id= now works — the authenticated user's own id is used.
+
+    The parameter is kept for backward compatibility (and is still validated
+    to match when provided — see the next test), but new callers no longer
+    need to pass it.
+    """
+    admin_headers = auth_headers(1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "no-param-owner")
+    headers = auth_headers(user_id)
+
+    label_response = db_client.post(
+        "/api/time-tracking/labels",
+        json={"name": "No param", "color": "#445566"},
+        headers=headers,
+    )
+    assert label_response.status_code == 201, label_response.text
+    label_id = label_response.json()["id"]
+
+    list_response = db_client.get("/api/time-tracking/labels", headers=headers)
+    assert list_response.status_code == 200
+    assert any(item["id"] == label_id for item in list_response.json()["items"])
+
+    get_response = db_client.get(f"/api/time-tracking/labels/{label_id}", headers=headers)
+    assert get_response.status_code == 200
+
+    delete_response = db_client.delete(f"/api/time-tracking/labels/{label_id}", headers=headers)
+    assert delete_response.status_code == 204
+
+
+def test_user_id_query_param_still_validated_when_provided(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    """Passing a foreign user_id (old calling convention) still 403s."""
+    admin_headers = auth_headers(1, is_admin=True)
+    owner_id = create_user_factory(db_client, admin_headers, "param-owner")
+    other_id = create_user_factory(db_client, admin_headers, "param-other")
+    other_headers = auth_headers(other_id)
+
+    response = db_client.post(
+        f"/api/time-tracking/labels?user_id={owner_id}",
+        json={"name": "Should fail", "color": "#665544"},
+        headers=other_headers,
+    )
+    assert response.status_code == 403
+
+
+def test_list_labels_pagination(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    """?limit=&offset= slice the response while `total` reflects the full count."""
+    admin_headers = auth_headers(1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "pagination-owner")
+    headers = auth_headers(user_id)
+
+    created_ids = []
+    for i in range(5):
+        response = db_client.post(
+            "/api/time-tracking/labels",
+            json={"name": f"Label {i}", "color": "#010101"},
+            headers=headers,
+        )
+        assert response.status_code == 201
+        created_ids.append(response.json()["id"])
+
+    # No pagination params — unpaginated behavior is unchanged.
+    full = db_client.get("/api/time-tracking/labels", headers=headers)
+    assert full.status_code == 200
+    assert full.json()["total"] == 5
+    assert len(full.json()["items"]) == 5
+
+    # limit alone.
+    first_page = db_client.get("/api/time-tracking/labels?limit=2", headers=headers)
+    assert first_page.status_code == 200
+    assert first_page.json()["total"] == 5
+    assert len(first_page.json()["items"]) == 2
+
+    # limit + offset covers the remainder without overlap or gaps.
+    second_page = db_client.get("/api/time-tracking/labels?limit=2&offset=2", headers=headers)
+    third_page = db_client.get("/api/time-tracking/labels?limit=2&offset=4", headers=headers)
+    assert len(second_page.json()["items"]) == 2
+    assert len(third_page.json()["items"]) == 1
+
+    seen_ids = {item["id"] for item in first_page.json()["items"]}
+    seen_ids |= {item["id"] for item in second_page.json()["items"]}
+    seen_ids |= {item["id"] for item in third_page.json()["items"]}
+    assert seen_ids == set(created_ids)
+
+    # Exceeding the server-side cap is rejected rather than silently clamped.
+    from app.utils.pagination import MAX_PAGE_LIMIT
+
+    too_large = db_client.get(
+        f"/api/time-tracking/labels?limit={MAX_PAGE_LIMIT + 1}", headers=headers
+    )
+    assert too_large.status_code == 422

--- a/backend/tests/test_db_work_locations.py
+++ b/backend/tests/test_db_work_locations.py
@@ -20,14 +20,14 @@ def test_work_location_upsert_and_filtering(
     other_headers = auth_headers(other_id)
 
     first_create = db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-01", "country_code": "nl", "label": "Home"},
         headers=owner_headers,
     )
     assert first_create.status_code == 201
 
     upsert_update = db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-01", "country_code": "BE", "label": "Client office"},
         headers=owner_headers,
     )
@@ -37,14 +37,14 @@ def test_work_location_upsert_and_filtering(
     assert upsert_update.json()["label"] == "Client office"
 
     other_user_location = db_client.post(
-        f"/api/work-locations/?user_id={other_id}",
+        f"/api/work-locations?user_id={other_id}",
         json={"date": "2026-02-01", "country_code": "DE", "label": "HQ"},
         headers=other_headers,
     )
     assert other_user_location.status_code == 201
 
     owner_filtered = db_client.get(
-        f"/api/work-locations/?user_id={owner_id}&start_date=2026-02-01&end_date=2026-02-01",
+        f"/api/work-locations?user_id={owner_id}&start_date=2026-02-01&end_date=2026-02-01",
         headers=owner_headers,
     )
     assert owner_filtered.status_code == 200
@@ -52,7 +52,7 @@ def test_work_location_upsert_and_filtering(
     assert owner_filtered.json()["items"][0]["date"] == "2026-02-01"
 
     owner_out_of_range = db_client.get(
-        f"/api/work-locations/?user_id={owner_id}&start_date=2026-02-02&end_date=2026-02-03",
+        f"/api/work-locations?user_id={owner_id}&start_date=2026-02-02&end_date=2026-02-03",
         headers=owner_headers,
     )
     assert owner_out_of_range.status_code == 200
@@ -69,7 +69,7 @@ def test_work_location_country_code_validation(
     headers = auth_headers(user_id)
 
     invalid_country_code = db_client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-02-02", "country_code": "ZZ", "label": "Unknown"},
         headers=headers,
     )
@@ -89,7 +89,7 @@ def test_cross_user_cannot_read_modify_or_delete_work_locations(
     other_headers = auth_headers(other_id)
 
     create_response = db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-05", "country_code": "NL", "label": "Home"},
         headers=owner_headers,
     )
@@ -100,7 +100,7 @@ def test_cross_user_cannot_read_modify_or_delete_work_locations(
         headers=other_headers,
     ).status_code == 403
     assert db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-05", "country_code": "BE", "label": "Office"},
         headers=other_headers,
     ).status_code == 403

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -241,7 +241,7 @@ async def test_start_time_entry_blocks_second_running_task(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """start_time_entry raises ConflictError when a running task already exists."""
+    """start_time_entry raises ValueError (mapped from ConflictError) when a running task already exists."""
     import app.audit.logger as audit_module
 
     monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
@@ -260,7 +260,7 @@ text="First task",
         start_time=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
     )
 
-    with pytest.raises(db_service.ConflictError):
+    with pytest.raises(ValueError, match="only one running task"):
         await backend.start_time_entry(
         text="Second task",
             start_time=datetime(2026, 5, 1, 9, 30, tzinfo=UTC),
@@ -272,7 +272,7 @@ async def test_stop_time_entry_no_running_task(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """stop_time_entry raises NotFoundError when no running task exists."""
+    """stop_time_entry raises ValueError (mapped from NotFoundError) when no running task exists."""
     import app.audit.logger as audit_module
 
     monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
@@ -286,7 +286,7 @@ async def test_stop_time_entry_no_running_task(
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
-    with pytest.raises(db_service.NotFoundError, match="no running task"):
+    with pytest.raises(ValueError, match="no running task"):
         await backend.stop_time_entry()
 
 
@@ -363,7 +363,7 @@ async def test_update_time_tracking_task_unauthorized(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """update_time_tracking_task raises NotFoundError for another user's task."""
+    """update_time_tracking_task raises ValueError (mapped from NotFoundError) for another user's task."""
     import app.audit.logger as audit_module
 
     monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
@@ -387,7 +387,7 @@ async def test_update_time_tracking_task_unauthorized(
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(attacker.id))
 
-    with pytest.raises(db_service.NotFoundError):
+    with pytest.raises(ValueError):
         await backend.update_time_tracking_task(
         task_id=task.id,
             text="Hacked",
@@ -442,7 +442,7 @@ async def test_delete_time_tracking_task_unauthorized(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """delete_time_tracking_task raises NotFoundError for another user's task."""
+    """delete_time_tracking_task raises ValueError (mapped from NotFoundError) for another user's task."""
     import app.audit.logger as audit_module
 
     monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
@@ -470,7 +470,7 @@ async def test_delete_time_tracking_task_unauthorized(
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(attacker.id))
 
-    with pytest.raises(db_service.NotFoundError):
+    with pytest.raises(ValueError):
         await backend.delete_time_tracking_task(task_id=task.id)
 
 
@@ -541,7 +541,7 @@ value_date=date(2026, 5, 1),
     assert deleted["date"] == "2026-05-01"
     assert deleted["user_id"] == user.id
 
-    with pytest.raises(db_service.NotFoundError):
+    with pytest.raises(ValueError):
         await backend.delete_work_location(
         value_date=date(2026, 5, 1),
         )
@@ -657,7 +657,7 @@ async def test_delete_time_off_event_unauthorized(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """delete_time_off_event raises NotFoundError for another user's entry."""
+    """delete_time_off_event raises ValueError (mapped from NotFoundError) for another user's entry."""
     import app.audit.logger as audit_module
 
     monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
@@ -681,7 +681,7 @@ async def test_delete_time_off_event_unauthorized(
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(attacker.id))
 
-    with pytest.raises(db_service.NotFoundError):
+    with pytest.raises(ValueError):
         await backend.delete_time_off_event(entry_id=entry.entry_id)
 
 
@@ -765,7 +765,7 @@ async def test_delete_gantt_task_unauthorized(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """delete_gantt_task raises NotFoundError for another user's task."""
+    """delete_gantt_task raises ValueError (mapped from NotFoundError) for another user's task."""
     import app.audit.logger as audit_module
 
     monkeypatch.setattr(audit_module, "AUDIT_LOG_DIR", tmp_path)
@@ -789,7 +789,7 @@ async def test_delete_gantt_task_unauthorized(
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(attacker.id))
 
-    with pytest.raises(db_service.NotFoundError):
+    with pytest.raises(ValueError):
         await backend.delete_gantt_task(task_id=gantt.id)
 
 
@@ -821,6 +821,10 @@ async def test_write_tools_produce_audit_log_entries(
 value_date=date(2026, 5, 1),
         country_code="DE",
     )
+    # append() dispatches the file write to a background thread when called
+    # from a running event loop (which this async test is) — wait for it
+    # before asserting on file contents.
+    await audit_module.flush()
 
     assert audit_file.exists()
     lines = [json.loads(line) for line in audit_file.read_text().splitlines() if line.strip()]

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -95,13 +95,67 @@ async def test_whoami_and_time_tracking_summary_happy_path(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     whoami_payload = await backend.whoami()
-    summary_payload = await backend.get_time_tracking_summary()
+    # Explicit range: the fixed 2026-05-01 task date would fall outside the
+    # no-args default 30-day lookback window once "now" (real wall-clock
+    # time in CI) moves past it — see test_get_time_tracking_summary_default_window
+    # for coverage of that default.
+    summary_payload = await backend.get_time_tracking_summary(
+        start_at=datetime(2026, 4, 1, tzinfo=UTC),
+        end_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
 
     assert whoami_payload["user_id"] == user.id
     assert whoami_payload["username"] == "mcp-user"
     assert summary_payload["task_count"] == 1
     assert summary_payload["tracked_seconds"] == 5400
     assert summary_payload["tasks"][0]["text"] == "Task from MCP"
+    assert summary_payload["default_range_applied"] is False
+
+
+async def test_get_time_tracking_summary_default_window(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting both start_at and end_at defaults to a trailing 30-day window.
+
+    A task inside the window is included; one 60 days back (well outside
+    the 30-day default) is not — bounding the response to a recent slice
+    instead of the user's entire history.
+    """
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+    now = datetime.now(UTC)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="default-window-user", display_name="Default Window")
+        )
+        await db_service.create_task(
+            session,
+            user.id,
+            TaskCreate(
+                text="Recent task",
+                start_time=now - timedelta(days=1),
+                stop_time=now - timedelta(days=1) + timedelta(hours=1),
+            ),
+        )
+        await db_service.create_task(
+            session,
+            user.id,
+            TaskCreate(
+                text="Old task",
+                start_time=now - timedelta(days=60),
+                stop_time=now - timedelta(days=60) + timedelta(hours=1),
+            ),
+        )
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
+
+    summary_payload = await backend.get_time_tracking_summary()
+
+    assert summary_payload["default_range_applied"] is True
+    assert summary_payload["task_count"] == 1
+    assert summary_payload["tasks"][0]["text"] == "Recent task"
 
 
 async def test_list_labels_returns_active_labels_for_authenticated_user(

--- a/backend/tests/test_oidc_config.py
+++ b/backend/tests/test_oidc_config.py
@@ -385,3 +385,66 @@ async def test_get_or_create_local_user_appends_suffix_on_username_conflict(monk
 
     assert local_user is created_local_user
     assert recorded["username"].startswith("alice-")
+
+
+async def test_get_or_create_local_user_retries_on_username_collision_race(monkeypatch) -> None:
+    """A concurrent signup claiming the derived username must not fail the login.
+
+    When create_user raises because a *different* subject won the username
+    between the availability check and the INSERT, provisioning re-derives a
+    fresh candidate and retries once instead of surfacing a 500.
+    """
+    from app.services.db_service import ConflictError
+
+    created_local_user = SimpleNamespace(id=44, username="alice-sub-abc1", display_name="Alice")
+
+    class FakeResult:
+        def __init__(self, value):
+            self._value = value
+
+        def scalar_one_or_none(self):
+            return self._value
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = 0
+            self.rollbacks = 0
+
+        async def execute(self, _query):
+            self.calls += 1
+            if self.calls == 1:
+                return FakeResult(None)  # oidc_subject lookup → not found
+            if self.calls == 2:
+                return FakeResult(None)  # username "alice" appears available
+            if self.calls == 3:
+                return FakeResult(None)  # subject re-lookup after collision → still missing
+            if self.calls == 4:
+                return FakeResult(object())  # "alice" now visibly taken by the other signup
+            return FakeResult(None)  # suffixed candidate is available
+
+        async def rollback(self):
+            self.rollbacks += 1
+
+    create_attempts: list[str] = []
+
+    async def fake_create_user(session, payload, *, oidc_subject=None):
+        create_attempts.append(payload.username)
+        if len(create_attempts) == 1:
+            raise ConflictError("username already exists")
+        return created_local_user
+
+    monkeypatch.setattr(oidc_config, "create_user", fake_create_user)
+
+    session = FakeSession()
+    local_user = await oidc_config.get_or_create_local_user(
+        "sub-abc12345",
+        {"preferred_username": "alice"},
+        session,
+    )
+
+    assert local_user is created_local_user
+    assert session.rollbacks == 1
+    assert len(create_attempts) == 2
+    assert create_attempts[0] == "alice"
+    assert create_attempts[1] != "alice"
+    assert create_attempts[1].startswith("alice-")

--- a/backend/tests/test_oidc_config.py
+++ b/backend/tests/test_oidc_config.py
@@ -448,3 +448,68 @@ async def test_get_or_create_local_user_retries_on_username_collision_race(monke
     assert create_attempts[0] == "alice"
     assert create_attempts[1] != "alice"
     assert create_attempts[1].startswith("alice-")
+
+
+# ---------------------------------------------------------------------------
+# Periodic JWKS refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_periodic_jwks_refresh_loop_calls_force_refresh(monkeypatch) -> None:
+    """The loop force-refreshes the JWKS cache once per sleep interval."""
+    sleep_calls: list[float] = []
+    refresh_calls = 0
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 3:
+            raise asyncio.CancelledError
+
+    async def fake_get_jwks(*, force_refresh: bool = False) -> dict:
+        nonlocal refresh_calls
+        assert force_refresh is True
+        refresh_calls += 1
+        return {"keys": []}
+
+    monkeypatch.setattr(oidc_config.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(oidc_config, "_get_jwks", fake_get_jwks)
+
+    with pytest.raises(asyncio.CancelledError):
+        await oidc_config._periodic_jwks_refresh_loop()
+
+    assert sleep_calls == [oidc_config._JWKS_REFRESH_INTERVAL_SECONDS] * 3
+    assert refresh_calls == 2
+
+
+async def test_periodic_jwks_refresh_loop_swallows_refresh_failures(monkeypatch) -> None:
+    """A failed refresh is logged and swallowed — the loop keeps running."""
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 3:
+            raise asyncio.CancelledError
+
+    async def failing_get_jwks(*, force_refresh: bool = False) -> dict:
+        raise httpx.HTTPError("upstream unavailable")
+
+    monkeypatch.setattr(oidc_config.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(oidc_config, "_get_jwks", failing_get_jwks)
+
+    with pytest.raises(asyncio.CancelledError):
+        await oidc_config._periodic_jwks_refresh_loop()
+
+    # The loop must have survived two failed refreshes to reach the third sleep.
+    assert len(sleep_calls) == 3
+
+
+async def test_start_periodic_jwks_refresh_returns_cancellable_task() -> None:
+    """start_periodic_jwks_refresh schedules the loop and returns its task."""
+    task = oidc_config.start_periodic_jwks_refresh()
+    try:
+        assert isinstance(task, asyncio.Task)
+        assert not task.done()
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -62,7 +62,11 @@ def test_disabled_limiter_never_rejects():
 
 
 def test_different_client_ips_get_independent_buckets():
-    client = TestClient(_build_app())
+    # TestClient's default simulated peer is the string "testclient", not an
+    # IP, so it would never pass the trusted-proxy check on its own. Pin it
+    # to a private address to simulate "arrived via Caddy" and vary
+    # X-Real-IP per request to simulate different real clients behind it.
+    client = TestClient(_build_app(), client=("172.20.0.2", 12345))
     assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 200
     assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 200
     assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 429
@@ -88,3 +92,20 @@ def test_get_client_ip_falls_back_to_request_client():
     request = Request(scope)
 
     assert get_client_ip(request) == "10.0.0.5"
+
+
+def test_get_client_ip_ignores_x_real_ip_from_untrusted_public_peer():
+    """A caller reaching the app directly (bypassing Caddy) can't spoof X-Real-IP.
+
+    If the request didn't come from a private-network peer, the header is
+    attacker-controlled — trusting it would let a single caller draw a fresh
+    rate-limit bucket on every request by varying the header value.
+    """
+    scope = {
+        "type": "http",
+        "headers": [(b"x-real-ip", b"9.9.9.9")],
+        "client": ("8.8.8.8", 12345),
+    }
+    request = Request(scope)
+
+    assert get_client_ip(request) == "8.8.8.8"

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,90 @@
+"""Tests for the per-client-IP rate limiting middleware (app.middleware.rate_limit)."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from starlette.requests import Request
+
+from app.middleware.rate_limit import get_client_ip, handle_rate_limit_exceeded
+
+
+def _build_app(*, limit: str = "2/minute", enabled: bool = True) -> FastAPI:
+    """Build a throwaway app wired the same way as the real one, but with a tiny limit."""
+    limiter = Limiter(key_func=get_client_ip, default_limits=[limit], enabled=enabled)
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, handle_rate_limit_exceeded)
+    app.add_middleware(SlowAPIMiddleware)
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    @app.get("/health")
+    @limiter.exempt
+    async def health():
+        return {"ok": True}
+
+    return app
+
+
+def test_requests_within_limit_succeed():
+    client = TestClient(_build_app())
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+
+
+def test_requests_over_limit_are_rejected_with_429():
+    client = TestClient(_build_app())
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+
+    response = client.get("/ping")
+
+    assert response.status_code == 429
+    assert "Rate limit exceeded" in response.json()["error"]
+
+
+def test_exempt_route_is_never_limited():
+    client = TestClient(_build_app())
+    for _ in range(5):
+        assert client.get("/health").status_code == 200
+
+
+def test_disabled_limiter_never_rejects():
+    client = TestClient(_build_app(enabled=False))
+    for _ in range(5):
+        assert client.get("/ping").status_code == 200
+
+
+def test_different_client_ips_get_independent_buckets():
+    client = TestClient(_build_app())
+    assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 200
+    assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 200
+    assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 429
+
+    # A different client IP draws from its own, untouched bucket.
+    assert client.get("/ping", headers={"X-Real-IP": "2.2.2.2"}).status_code == 200
+
+
+def test_get_client_ip_prefers_x_real_ip_header():
+    """Behind Caddy, request.client.host is Caddy's own address, not the real client's."""
+    scope = {
+        "type": "http",
+        "headers": [(b"x-real-ip", b"9.9.9.9")],
+        "client": ("127.0.0.1", 12345),
+    }
+    request = Request(scope)
+
+    assert get_client_ip(request) == "9.9.9.9"
+
+
+def test_get_client_ip_falls_back_to_request_client():
+    scope = {"type": "http", "headers": [], "client": ("10.0.0.5", 12345)}
+    request = Request(scope)
+
+    assert get_client_ip(request) == "10.0.0.5"

--- a/backend/tests/test_read_models.py
+++ b/backend/tests/test_read_models.py
@@ -52,7 +52,7 @@ def test_dashboard_returns_reusable_read_models(
     _seed_work_context(db_client, headers, schedule_type="5-shift", team_number=1)
 
     first_time_off = db_client.post(
-        "/api/time-off/",
+        "/api/time-off",
         json={
             "entry_id": "summer-trip",
             "entry_kind": "date",
@@ -66,7 +66,7 @@ def test_dashboard_returns_reusable_read_models(
     assert first_time_off.status_code == 201, first_time_off.text
 
     second_time_off = db_client.post(
-        "/api/time-off/",
+        "/api/time-off",
         json={
             "entry_id": "training-week",
             "entry_kind": "range",

--- a/backend/tests/test_registration.py
+++ b/backend/tests/test_registration.py
@@ -1,15 +1,16 @@
-"""Tests for the user registration endpoint."""
+"""Tests for the admin-only user pre-registration endpoint."""
 
 from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
 
-def test_register_success_defaults_display_name(db_client: TestClient) -> None:
+def test_register_success_defaults_display_name(db_client: TestClient, auth_headers) -> None:
     """Happy path: display_name defaults to username when not provided."""
     response = db_client.post(
         "/api/users/register",
         json={"username": "newuser"},
+        headers=auth_headers(1, is_admin=True),
     )
     assert response.status_code == 201
     body = response.json()
@@ -20,7 +21,7 @@ def test_register_success_defaults_display_name(db_client: TestClient) -> None:
     assert "settings" in body
 
 
-def test_register_success_with_display_name(db_client: TestClient) -> None:
+def test_register_success_with_display_name(db_client: TestClient, auth_headers) -> None:
     """Registration with an explicit display_name stores it correctly."""
     response = db_client.post(
         "/api/users/register",
@@ -28,6 +29,7 @@ def test_register_success_with_display_name(db_client: TestClient) -> None:
             "username": "nameduser",
             "display_name": "Named User",
         },
+        headers=auth_headers(1, is_admin=True),
     )
     assert response.status_code == 201
     body = response.json()
@@ -35,20 +37,32 @@ def test_register_success_with_display_name(db_client: TestClient) -> None:
     assert body["display_name"] == "Named User"
 
 
-def test_register_no_auth_required(db_client: TestClient) -> None:
-    """Registration endpoint must not require authentication."""
+def test_register_requires_auth(db_client: TestClient) -> None:
+    """Unauthenticated registration attempts are rejected."""
     response = db_client.post(
         "/api/users/register",
         json={"username": "publicuser"},
     )
-    assert response.status_code == 201
+    assert response.status_code == 401
 
 
-def test_register_duplicate_username_conflict(db_client: TestClient) -> None:
+def test_register_requires_admin(db_client: TestClient, auth_headers) -> None:
+    """Non-admin users cannot pre-register accounts (prevents username squatting)."""
+    response = db_client.post(
+        "/api/users/register",
+        json={"username": "squatter"},
+        headers=auth_headers(2, is_admin=False),
+    )
+    assert response.status_code == 403
+
+
+def test_register_duplicate_username_conflict(db_client: TestClient, auth_headers) -> None:
     """Second registration with the same username returns 409 Conflict."""
+    admin_h = auth_headers(1, is_admin=True)
     first_response = db_client.post(
         "/api/users/register",
         json={"username": "duplicate"},
+        headers=admin_h,
     )
     assert first_response.status_code == 201
     assert first_response.json()["username"] == "duplicate"
@@ -56,24 +70,49 @@ def test_register_duplicate_username_conflict(db_client: TestClient) -> None:
     response = db_client.post(
         "/api/users/register",
         json={"username": "duplicate"},
+        headers=admin_h,
     )
     assert response.status_code == 409
     assert "username already exists" in response.json()["detail"]
 
 
-def test_register_empty_username_rejected(db_client: TestClient) -> None:
+def test_register_empty_username_rejected(db_client: TestClient, auth_headers) -> None:
     """Empty username is rejected with 422."""
     response = db_client.post(
         "/api/users/register",
         json={"username": ""},
+        headers=auth_headers(1, is_admin=True),
     )
     assert response.status_code == 422
 
 
-def test_register_username_too_long_rejected(db_client: TestClient) -> None:
+def test_register_username_too_long_rejected(db_client: TestClient, auth_headers) -> None:
     """Usernames longer than 150 characters are rejected with 422."""
     response = db_client.post(
         "/api/users/register",
         json={"username": "x" * 151},
+        headers=auth_headers(1, is_admin=True),
     )
     assert response.status_code == 422
+
+
+def test_register_username_with_whitespace_rejected(db_client: TestClient, auth_headers) -> None:
+    """Usernames containing whitespace or control characters are rejected with 422."""
+    admin_h = auth_headers(1, is_admin=True)
+    for bad_username in ("has space", " leading", "tab\tchar", "new\nline"):
+        response = db_client.post(
+            "/api/users/register",
+            json={"username": bad_username},
+            headers=admin_h,
+        )
+        assert response.status_code == 422, bad_username
+
+
+def test_register_username_email_style_accepted(db_client: TestClient, auth_headers) -> None:
+    """Email-local-part style usernames (dots, plus, dashes) remain valid."""
+    response = db_client.post(
+        "/api/users/register",
+        json={"username": "first.last+tag-1"},
+        headers=auth_headers(1, is_admin=True),
+    )
+    assert response.status_code == 201

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -1873,6 +1873,156 @@ class TestSyncCorrectnessFixes:
         assert result["status"] == "conflict"
         assert "in use" in result["conflict_reason"]
 
+    def test_push_task_create_rejects_stop_time_before_start_time(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """Sync push must reject an inverted time range, matching the REST create_task check.
+
+        The REST path (db_service.create_task) already rejects
+        stop_time < start_time; the sync push path had no equivalent check,
+        so a client could silently write a negative-duration task that the
+        REST API would have refused.
+        """
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "task-time-order-create-user")
+        headers = auth_headers(user_id)
+
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": str(uuid4()),
+                        "action": "create",
+                        "client_updated_at": _ts(-5),
+                        "text": "Inverted range",
+                        "label_id": None,
+                        "start_time": "2026-02-01T10:00:00+00:00",
+                        "stop_time": "2026-02-01T09:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+    def test_push_task_update_rejects_stop_time_before_effective_start_time(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """The same check must apply to a partial update, using the merged start/stop times."""
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "task-time-order-update-user")
+        headers = auth_headers(user_id)
+
+        task_id = str(uuid4())
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-10),
+                        "text": "Valid range",
+                        "label_id": None,
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ]
+            },
+            headers=headers,
+        )
+
+        # Only start_time is updated (to after the existing stop_time) — the
+        # check must use the *effective* stop_time (unchanged), not skip
+        # validation just because stop_time wasn't part of this payload.
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-5),
+                        "start_time": "2026-02-01T11:00:00+00:00",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+    def test_push_client_updated_at_is_clamped_to_prevent_permanent_lww_lock(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """A wildly-future client_updated_at (bad clock / unit bug) must not permanently win LWW.
+
+        Conflict detection is a pure `>` comparison with no other tiebreaker,
+        so an unclamped record stamped far in the future would win every
+        future comparison forever — including a later correction from the
+        *same* device once its clock is fixed. The server clamps the stored
+        value to _MAX_CLOCK_SKEW ahead of its own clock, so a legitimate,
+        further-future edit from another device with a sane clock can still
+        win.
+        """
+        from app.services.sync_service import _MAX_CLOCK_SKEW
+
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "clock-skew-user")
+        headers = auth_headers(user_id)
+
+        task_id = str(uuid4())
+        bogus_future = (datetime.now(UTC) + timedelta(days=3650)).isoformat()
+
+        create_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "create",
+                        "client_updated_at": bogus_future,
+                        "text": "Created with a broken clock",
+                        "label_id": None,
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert create_resp.status_code == 200
+        assert create_resp.json()["results"]["tasks"][0]["status"] == "ok"
+
+        # A legitimate edit stamped further ahead than the clamp ceiling must
+        # still win — proving the bogus value did not get stored as-is.
+        legitimate_future_edit = (
+            datetime.now(UTC) + _MAX_CLOCK_SKEW + timedelta(minutes=1)
+        ).isoformat()
+        edit_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "update",
+                        "client_updated_at": legitimate_future_edit,
+                        "text": "Fixed-clock correction wins",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert edit_resp.status_code == 200, edit_resp.text
+        assert edit_resp.json()["results"]["tasks"][0]["status"] == "ok"
+
+        pull_resp = db_client.get("/api/sync/pull", headers=headers)
+        pulled = next(t for t in pull_resp.json()["tasks"] if t["id"] == task_id)
+        assert pulled["text"] == "Fixed-clock correction wins"
+
     def test_pull_server_timestamp_includes_safety_overlap(
         self, db_client: TestClient, auth_headers
     ) -> None:
@@ -1926,6 +2076,277 @@ class TestSyncCorrectnessFixes:
         }
         resp = db_client.post("/api/sync/push", json=oversized, headers=headers)
         assert resp.status_code == 422
+
+    def test_push_creating_two_labels_with_same_name_returns_conflict_not_500(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """Two devices independently creating a same-named label must not 500 the batch.
+
+        uq_active_label_user_name is a partial unique index on (user_id,
+        name); previously nothing checked for this before commit, so the
+        second label's INSERT raised IntegrityError, which /sync/push did not
+        catch — the whole batch (transaction) 500'd, and since the outbox
+        retries the identical batch forever, the offending label wedged every
+        other queued change behind it indefinitely.
+        """
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "label-collision-create-user")
+        headers = auth_headers(user_id)
+
+        first_id = str(uuid4())
+        second_id = str(uuid4())
+
+        first_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": first_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-10),
+                        "name": "Duplicate Name",
+                        "color": "#AABBCC",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert first_resp.status_code == 200
+        assert first_resp.json()["results"]["labels"][0]["status"] == "ok"
+
+        # A different label id, same name — as if two devices both created a
+        # "Duplicate Name" label offline before ever syncing.
+        second_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": second_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-5),
+                        "name": "Duplicate Name",
+                        "color": "#DDEEFF",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert second_resp.status_code == 200, second_resp.text
+        result = second_resp.json()["results"]["labels"][0]
+        assert result["status"] == "conflict"
+        assert "already exists" in result["conflict_reason"]
+
+        # The first label is untouched and the second was never created.
+        pull_resp = db_client.get("/api/sync/pull", headers=headers)
+        names = [label["name"] for label in pull_resp.json()["labels"] if label["deleted_at"] is None]
+        assert names == ["Duplicate Name"]
+
+    def test_push_creating_same_name_label_twice_in_one_batch_only_conflicts_the_second(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """The collision check must see earlier same-batch inserts (autoflush), not just committed rows."""
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "label-collision-batch-user")
+        headers = auth_headers(user_id)
+
+        first_id = str(uuid4())
+        second_id = str(uuid4())
+
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": first_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-10),
+                        "name": "Same Batch",
+                        "color": "#AABBCC",
+                    },
+                    {
+                        "id": second_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-9),
+                        "name": "Same Batch",
+                        "color": "#DDEEFF",
+                    },
+                ]
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        results = resp.json()["results"]["labels"]
+        assert results[0]["status"] == "ok"
+        assert results[1]["status"] == "conflict"
+
+    def test_push_rename_colliding_with_another_active_label_returns_conflict(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """Renaming a label to a name already used by another active label must conflict, not 500."""
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "label-rename-collision-user")
+        headers = auth_headers(user_id)
+
+        keep_id = str(uuid4())
+        rename_id = str(uuid4())
+
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": keep_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-20),
+                        "name": "Existing",
+                        "color": "#AABBCC",
+                    },
+                    {
+                        "id": rename_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-20),
+                        "name": "Original",
+                        "color": "#DDEEFF",
+                    },
+                ]
+            },
+            headers=headers,
+        )
+
+        rename_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": rename_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-5),
+                        "name": "Existing",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert rename_resp.status_code == 200, rename_resp.text
+        result = rename_resp.json()["results"]["labels"][0]
+        assert result["status"] == "conflict"
+        assert "already exists" in result["conflict_reason"]
+
+    def test_push_renaming_label_to_its_own_current_name_is_a_no_op_not_a_conflict(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """An update that doesn't actually change the name must not false-positive against itself."""
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "label-self-rename-user")
+        headers = auth_headers(user_id)
+
+        label_id = str(uuid4())
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": label_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-20),
+                        "name": "Unchanged",
+                        "color": "#AABBCC",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": label_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-5),
+                        "name": "Unchanged",
+                        "color": "#112233",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        result = resp.json()["results"]["labels"][0]
+        assert result["status"] == "ok"
+
+    def test_push_reviving_soft_deleted_label_colliding_with_active_label_returns_conflict(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """Reviving a soft-deleted label must also respect the active-name uniqueness."""
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "label-revive-collision-user")
+        headers = auth_headers(user_id)
+
+        tombstoned_id = str(uuid4())
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": tombstoned_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-30),
+                        "name": "Revivable",
+                        "color": "#AABBCC",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {"id": tombstoned_id, "action": "delete", "client_updated_at": _ts(-20)}
+                ]
+            },
+            headers=headers,
+        )
+
+        # A new, active label claims the freed-up name while the first is tombstoned.
+        new_active_id = str(uuid4())
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": new_active_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-10),
+                        "name": "Revivable",
+                        "color": "#DDEEFF",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+
+        # An old device, unaware of any of this, tries to revive its tombstoned label.
+        revive_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": tombstoned_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-5),
+                        "color": "#FFFFFF",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert revive_resp.status_code == 200, revive_resp.text
+        result = revive_resp.json()["results"]["labels"][0]
+        assert result["status"] == "conflict"
+        assert "already exists" in result["conflict_reason"]
 
     def test_rest_update_wins_over_stale_sync_push(
         self, db_client: TestClient, auth_headers
@@ -2046,6 +2467,182 @@ class TestSyncCorrectnessFixes:
         pull_resp = db_client.get("/api/sync/pull", headers=headers)
         pulled = [t for t in pull_resp.json()["tasks"] if t["id"] == task_id]
         assert pulled[0]["gantt_task_id"] == gantt_id
+
+    def test_push_task_with_nonexistent_gantt_reference_returns_400_not_500(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """A task linking to a gantt_task_id that doesn't exist must 400, not 500.
+
+        _validate_task_gantt_reference raises NotFoundError (not
+        ValidationError); the push endpoint previously only caught
+        ValidationError, so this bubbled up as an unhandled 500. This is a
+        plausible everyday race, not just a malformed-payload edge case: a
+        task's gantt_task_id can go stale if another device deletes that
+        gantt task between this device's last pull and its next push.
+        """
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "gantt-ref-404-user")
+        headers = auth_headers(user_id)
+
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": str(uuid4()),
+                        "action": "create",
+                        "client_updated_at": _ts(-5),
+                        "text": "Dangling gantt reference",
+                        "label_id": None,
+                        "gantt_task_id": str(uuid4()),  # does not exist
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_push_id_colliding_with_another_users_task_returns_conflict_not_400(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """A client-generated UUID colliding with another user's task id must not abort the batch.
+
+        Previously this raised ValidationError ("task not found"), 400ing the
+        *entire* batch — every other record in the same push failed too, and
+        the response also implicitly leaked that the id belongs to someone
+        else (distinguishable from an ordinary stale-record conflict).
+        """
+        admin_h = auth_headers(1, is_admin=True)
+        owner_id = _create_user(db_client, admin_h, "task-collision-owner")
+        prober_id = _create_user(db_client, admin_h, "task-collision-prober")
+        owner_headers = auth_headers(owner_id)
+        prober_headers = auth_headers(prober_id)
+
+        shared_id = str(uuid4())
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": shared_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-10),
+                        "text": "Owner's task",
+                        "label_id": None,
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ]
+            },
+            headers=owner_headers,
+        )
+
+        other_task_id = str(uuid4())
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": shared_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-5),
+                        "text": "Trying to update someone else's task",
+                    },
+                    {
+                        "id": other_task_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-5),
+                        "text": "Unrelated task in the same batch",
+                        "label_id": None,
+                        "start_time": "2026-02-01T11:00:00+00:00",
+                        "stop_time": "2026-02-01T12:00:00+00:00",
+                        "includes_break": False,
+                    },
+                ]
+            },
+            headers=prober_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        results = resp.json()["results"]["tasks"]
+        assert results[0]["status"] == "conflict"
+        assert results[1]["status"] == "ok"
+
+        # The owner's task is untouched.
+        owner_pull = db_client.get("/api/sync/pull", headers=owner_headers)
+        owner_task = next(t for t in owner_pull.json()["tasks"] if t["id"] == shared_id)
+        assert owner_task["text"] == "Owner's task"
+
+    def test_push_id_colliding_with_another_users_template_or_gantt_task_returns_conflict(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """Same fix as tasks/labels, for templates and gantt tasks."""
+        admin_h = auth_headers(1, is_admin=True)
+        owner_id = _create_user(db_client, admin_h, "other-entity-collision-owner")
+        prober_id = _create_user(db_client, admin_h, "other-entity-collision-prober")
+        owner_headers = auth_headers(owner_id)
+        prober_headers = auth_headers(prober_id)
+
+        template_id = str(uuid4())
+        gantt_id = str(uuid4())
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "templates": [
+                    {
+                        "id": template_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-10),
+                        "text": "Owner's template",
+                        "label_id": None,
+                        "start_time": "09:00:00",
+                        "stop_time": "10:00:00",
+                    }
+                ],
+                "gantt_tasks": [
+                    {
+                        "id": gantt_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-10),
+                        "name": "Owner's gantt task",
+                        "start_date": "2026-02-01",
+                        "end_date": "2026-02-28",
+                        "progress": 0,
+                    }
+                ],
+            },
+            headers=owner_headers,
+        )
+
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "templates": [
+                    {
+                        "id": template_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-5),
+                        "text": "Prober trying to rename",
+                    }
+                ],
+                "gantt_tasks": [
+                    {
+                        "id": gantt_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-5),
+                        "name": "Prober trying to rename",
+                    }
+                ],
+            },
+            headers=prober_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        results = resp.json()["results"]
+        assert results["templates"][0]["status"] == "conflict"
+        assert results["gantt_tasks"][0]["status"] == "conflict"
 
     def test_rest_write_triggers_sync_broadcast(self, db_client: TestClient, auth_headers) -> None:
         """CRUD writes must emit a sync_changed hint (previously only /sync/push did)."""

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -1751,3 +1751,317 @@ class TestSyncEventsEndpoint:
             )
             assert resp.status_code == 200
             mock_bc.assert_called_once_with(user_id)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for sync correctness fixes
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCorrectnessFixes:
+    """Regression tests for LWW/cursor correctness fixes."""
+
+    def test_sync_label_delete_ignores_soft_deleted_references(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """A label whose only referencing tasks are soft-deleted must be deletable.
+
+        Previously the sync push counted soft-deleted tasks as active references,
+        making the label permanently undeletable via sync (while the REST path
+        allowed it) — every outbox flush re-surfaced a bogus conflict.
+        """
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "label-tombstone-user")
+        headers = auth_headers(user_id)
+
+        label_id = str(uuid4())
+        task_id = str(uuid4())
+
+        create_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": label_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-20),
+                        "name": "Tombstoned",
+                        "color": "#AABBCC",
+                    }
+                ],
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-20),
+                        "text": "Uses label",
+                        "label_id": label_id,
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ],
+            },
+            headers=headers,
+        )
+        assert create_resp.status_code == 200
+
+        # Soft-delete the referencing task, then delete the label.
+        delete_task_resp = db_client.post(
+            "/api/sync/push",
+            json={"tasks": [{"id": task_id, "action": "delete", "client_updated_at": _ts(-10)}]},
+            headers=headers,
+        )
+        assert delete_task_resp.status_code == 200
+        assert delete_task_resp.json()["results"]["tasks"][0]["status"] == "ok"
+
+        delete_label_resp = db_client.post(
+            "/api/sync/push",
+            json={"labels": [{"id": label_id, "action": "delete", "client_updated_at": _ts(-5)}]},
+            headers=headers,
+        )
+        assert delete_label_resp.status_code == 200
+        result = delete_label_resp.json()["results"]["labels"][0]
+        assert result["status"] == "ok", result
+
+    def test_sync_label_delete_conflicts_on_active_reference(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """A label with an *active* referencing task must still refuse deletion."""
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "label-active-ref-user")
+        headers = auth_headers(user_id)
+
+        label_id = str(uuid4())
+        task_id = str(uuid4())
+
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "labels": [
+                    {
+                        "id": label_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-20),
+                        "name": "Still Used",
+                        "color": "#AABBCC",
+                    }
+                ],
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-20),
+                        "text": "Active task",
+                        "label_id": label_id,
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+        delete_label_resp = db_client.post(
+            "/api/sync/push",
+            json={"labels": [{"id": label_id, "action": "delete", "client_updated_at": _ts(-5)}]},
+            headers=headers,
+        )
+        assert delete_label_resp.status_code == 200
+        result = delete_label_resp.json()["results"]["labels"][0]
+        assert result["status"] == "conflict"
+        assert "in use" in result["conflict_reason"]
+
+    def test_pull_server_timestamp_includes_safety_overlap(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """The pull cursor must lag real time so concurrent pushes are not skipped.
+
+        pull_changes subtracts _PULL_CURSOR_OVERLAP from the reported
+        server_timestamp; without it, records committed concurrently with a
+        pull could fall permanently behind the client's cursor.
+        """
+        from app.services.sync_service import _PULL_CURSOR_OVERLAP
+
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "overlap-user")
+        headers = auth_headers(user_id)
+
+        before = datetime.now(UTC)
+        resp = db_client.get("/api/sync/pull", headers=headers)
+        after = datetime.now(UTC)
+        assert resp.status_code == 200
+
+        server_timestamp = datetime.fromisoformat(resp.json()["server_timestamp"])
+        assert server_timestamp <= after - _PULL_CURSOR_OVERLAP + timedelta(seconds=1)
+        assert server_timestamp >= before - _PULL_CURSOR_OVERLAP - timedelta(seconds=1)
+
+        # The status endpoint's server_timestamp is also persisted as a cursor
+        # by the frontend and must carry the same overlap.
+        status_resp = db_client.get("/api/sync/status", headers=headers)
+        assert status_resp.status_code == 200
+        status_timestamp = datetime.fromisoformat(status_resp.json()["server_timestamp"])
+        assert status_timestamp <= datetime.now(UTC) - _PULL_CURSOR_OVERLAP + timedelta(seconds=1)
+
+    def test_push_batch_size_limit_enforced(self, db_client: TestClient, auth_headers) -> None:
+        """A push batch exceeding MAX_SYNC_PUSH_ITEMS per entity list returns 422."""
+        from app.schemas import MAX_SYNC_PUSH_ITEMS
+
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "batch-limit-user")
+        headers = auth_headers(user_id)
+
+        oversized = {
+            "labels": [
+                {
+                    "id": str(uuid4()),
+                    "action": "create",
+                    "client_updated_at": _ts(-5),
+                    "name": f"Label {i}",
+                    "color": "#AABBCC",
+                }
+                for i in range(MAX_SYNC_PUSH_ITEMS + 1)
+            ]
+        }
+        resp = db_client.post("/api/sync/push", json=oversized, headers=headers)
+        assert resp.status_code == 422
+
+    def test_rest_update_wins_over_stale_sync_push(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """An edit made via the REST/MCP path must not be silently reverted.
+
+        REST updates now bump client_updated_at, so a sync push carrying a
+        client timestamp older than the REST edit (but newer than the record's
+        original creation) is reported as a conflict instead of clobbering it.
+        """
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "rest-lww-user")
+        headers = auth_headers(user_id)
+
+        task_id = str(uuid4())
+        db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-60),
+                        "text": "Original",
+                        "label_id": None,
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ]
+            },
+            headers=headers,
+        )
+
+        # Edit via the REST path (same code path the MCP server uses).
+        rest_resp = db_client.put(
+            f"/api/time-tracking/tasks/{task_id}?user_id={user_id}",
+            json={"text": "Edited via REST"},
+            headers=headers,
+        )
+        assert rest_resp.status_code == 200
+
+        # A stale device pushes an update stamped after creation but before
+        # the REST edit — it must lose, not silently overwrite.
+        stale_resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "update",
+                        "client_updated_at": _ts(-30),
+                        "text": "Stale offline edit",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert stale_resp.status_code == 200
+        result = stale_resp.json()["results"]["tasks"][0]
+        assert result["status"] == "conflict"
+
+        pull_resp = db_client.get("/api/sync/pull", headers=headers)
+        pulled = [t for t in pull_resp.json()["tasks"] if t["id"] == task_id]
+        assert pulled[0]["text"] == "Edited via REST"
+
+    def test_push_creates_gantt_linked_task_in_single_batch(
+        self, db_client: TestClient, auth_headers
+    ) -> None:
+        """A single batch may create a gantt task and a task linking to it.
+
+        First-sync uploads send everything in one push; gantt tasks must be
+        processed before time-tracking tasks or the gantt_task_id reference
+        validation rejects the whole batch with 400.
+        """
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "gantt-link-batch-user")
+        headers = auth_headers(user_id)
+
+        gantt_id = str(uuid4())
+        task_id = str(uuid4())
+
+        resp = db_client.post(
+            "/api/sync/push",
+            json={
+                "tasks": [
+                    {
+                        "id": task_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-5),
+                        "text": "Linked to gantt",
+                        "label_id": None,
+                        "gantt_task_id": gantt_id,
+                        "start_time": "2026-02-01T09:00:00+00:00",
+                        "stop_time": "2026-02-01T10:00:00+00:00",
+                        "includes_break": False,
+                    }
+                ],
+                "gantt_tasks": [
+                    {
+                        "id": gantt_id,
+                        "action": "create",
+                        "client_updated_at": _ts(-5),
+                        "name": "Project A",
+                        "start_date": "2026-02-01",
+                        "end_date": "2026-02-28",
+                        "progress": 0,
+                    }
+                ],
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        results = resp.json()["results"]
+        assert results["gantt_tasks"][0]["status"] == "ok"
+        assert results["tasks"][0]["status"] == "ok"
+
+        pull_resp = db_client.get("/api/sync/pull", headers=headers)
+        pulled = [t for t in pull_resp.json()["tasks"] if t["id"] == task_id]
+        assert pulled[0]["gantt_task_id"] == gantt_id
+
+    def test_rest_write_triggers_sync_broadcast(self, db_client: TestClient, auth_headers) -> None:
+        """CRUD writes must emit a sync_changed hint (previously only /sync/push did)."""
+        admin_h = auth_headers(1, is_admin=True)
+        user_id = _create_user(db_client, admin_h, "rest-broadcast-user")
+        headers = auth_headers(user_id)
+
+        with patch(
+            "app.utils.sse_manager.sync_event_manager.broadcast_sync_changed",
+            new_callable=AsyncMock,
+        ) as mock_bc:
+            mock_bc.return_value = 0
+            resp = db_client.post(
+                f"/api/time-tracking/labels?user_id={user_id}",
+                json={"name": "Broadcast Label", "color": "#AABBCC"},
+                headers=headers,
+            )
+            assert resp.status_code == 201
+            mock_bc.assert_called_once_with(user_id)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -322,6 +322,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -727,6 +739,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1457,6 +1483,18 @@ fastapi = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -1798,6 +1836,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
+    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1826,6 +1865,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "slowapi", specifier = "==0.1.10" },
     { name = "sqlalchemy", specifier = "==2.0.51" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
 ]
@@ -1839,4 +1879,68 @@ dev = [
     { name = "ruff", specifier = "==0.15.22" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.66.0" },
     { name = "ty", specifier = "==0.0.60" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "check-version-consistency": "tsx scripts/check-version-consistency.ts"
   },
   "dependencies": {
-    "@microsoft/fetch-event-source": "^2.0.1",
     "@schedule-x/calendar": "^4.6.1",
     "@schedule-x/drag-and-drop": "^3.7.3",
     "@schedule-x/event-modal": "^4.6.1",
@@ -56,6 +55,7 @@
     "bootstrap-icons": "^1.13.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.21",
+    "eventsource-parser": "^3.1.0",
     "frappe-gantt": "^1.2.2",
     "oidc-client-ts": "^3.5.0",
     "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "check-version-consistency": "tsx scripts/check-version-consistency.ts"
   },
   "dependencies": {
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@schedule-x/calendar": "^4.6.1",
     "@schedule-x/drag-and-drop": "^3.7.3",
     "@schedule-x/event-modal": "^4.6.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@microsoft/fetch-event-source':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@schedule-x/calendar':
         specifier: ^4.6.1
         version: 4.6.1(@preact/signals@2.9.1(preact@10.29.2))(preact@10.29.2)(temporal-polyfill@1.0.1)
@@ -56,6 +53,9 @@ importers:
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
+      eventsource-parser:
+        specifier: ^3.1.0
+        version: 3.1.0
       frappe-gantt:
         specifier: ^1.2.2
         version: 1.2.2
@@ -1020,9 +1020,6 @@ packages:
 
   '@lix-js/server-protocol-schema@0.1.1':
     resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
-
-  '@microsoft/fetch-event-source@2.0.1':
-    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -2469,6 +2466,10 @@ packages:
   eta@4.6.0:
     resolution: {integrity: sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==}
     engines: {node: '>=20'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -4897,8 +4898,6 @@ snapshots:
 
   '@lix-js/server-protocol-schema@0.1.1': {}
 
-  '@microsoft/fetch-event-source@2.0.1': {}
-
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -6086,6 +6085,8 @@ snapshots:
   esutils@2.0.3: {}
 
   eta@4.6.0: {}
+
+  eventsource-parser@3.1.0: {}
 
   expand-template@2.0.3: {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@microsoft/fetch-event-source':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@schedule-x/calendar':
         specifier: ^4.6.1
         version: 4.6.1(@preact/signals@2.9.1(preact@10.29.2))(preact@10.29.2)(temporal-polyfill@1.0.1)
@@ -1017,6 +1020,9 @@ packages:
 
   '@lix-js/server-protocol-schema@0.1.1':
     resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
+
+  '@microsoft/fetch-event-source@2.0.1':
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -4890,6 +4896,8 @@ snapshots:
       - babel-plugin-macros
 
   '@lix-js/server-protocol-schema@0.1.1': {}
+
+  '@microsoft/fetch-event-source@2.0.1': {}
 
   '@mswjs/interceptors@0.41.9':
     dependencies:

--- a/frontend/src/contexts/OngoingSyncContext.tsx
+++ b/frontend/src/contexts/OngoingSyncContext.tsx
@@ -26,7 +26,7 @@ import {
   type TriggerPullFn,
   type ResolveOngoingConflictsFn,
 } from "@/hooks/useOngoingSync";
-import { useSyncSignal, createSseTransport, type SyncSignalTransport } from "@/hooks/useSyncSignal";
+import { useSyncSignal, createFetchSseTransport, type SyncSignalTransport } from "@/hooks/useSyncSignal";
 import { setSyncCollectionAuth, applyIncrementalPullToCollections } from "@/db/collections";
 import { type SyncPullResponse, type SyncPushPayload } from "@/utils/syncClient";
 
@@ -138,13 +138,17 @@ export function OngoingSyncProvider({ children, isSyncEstablished }: OngoingSync
     onIncrementalPull,
   );
 
-  // Build the SSE transport. The transport is
-  // null when the user is not authenticated so that no connection is opened
-  // before sync is established.
+  // Build the SSE transport. The transport is null when the user is not
+  // authenticated, or has no access token yet, so that no connection is
+  // opened before sync is established. Re-created whenever the access token
+  // value changes (e.g. after a silent OIDC renewal) so the new connection
+  // always carries a fresh Bearer token — `createFetchSseTransport` bakes the
+  // token into the request at subscribe() time rather than reading it live.
+  const accessToken = isAuthenticated ? getAccessToken() : null;
   const sseTransport = useMemo<SyncSignalTransport | null>(() => {
-    if (!isAuthenticated) return null;
-    return createSseTransport("/api/sync/events");
-  }, [isAuthenticated]);
+    if (!accessToken) return null;
+    return createFetchSseTransport("/api/sync/events", accessToken);
+  }, [accessToken]);
 
   // Subscribe to sync-changed signals and trigger incremental pulls.
   useSyncSignal(isSyncEstablished && isAuthenticated, userId, triggerPull, sseTransport);

--- a/frontend/src/hooks/useOngoingSync.ts
+++ b/frontend/src/hooks/useOngoingSync.ts
@@ -35,7 +35,6 @@ import {
   dequeueAndMergeSyncOutbox,
   extractConflictedItems,
   fetchPreferences,
-  fetchSyncStatus,
   getSyncOutboxSize,
   maxConflictServerTimestamp,
   pullSyncData,
@@ -196,9 +195,34 @@ export function useOngoingSync(
   const retryDelayMsRef = useRef(0);
   const retryAfterRef = useRef<number | null>(null);
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
+  // Timer that actually fires the next retry once the back-off window
+  // elapses. Without this, back-off only *gates* passive triggers
+  // (visibility/online) — a tab left open and idle past the window would
+  // never retry until the user did something. `flushAndPullRef` breaks the
+  // circular reference (flushAndPull itself depends on scheduleBackOff).
+  const backOffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flushAndPullRef = useRef<
+    ((force?: boolean, suppressUnauthorizedRedirect?: boolean) => Promise<void>) | null
+  >(null);
+
+  const clearBackOffTimer = useCallback(() => {
+    if (backOffTimerRef.current !== null) {
+      clearTimeout(backOffTimerRef.current);
+      backOffTimerRef.current = null;
+    }
+  }, []);
+
+  /** Reset back-off state (refs, state, and any pending scheduled retry). */
+  const clearBackOff = useCallback(() => {
+    retryDelayMsRef.current = 0;
+    retryAfterRef.current = null;
+    setRetryAfter(null);
+    clearBackOffTimer();
+  }, [clearBackOffTimer]);
 
   /**
-   * Advance the back-off delay and set the next retry window.
+   * Advance the back-off delay, set the next retry window, and schedule a
+   * timer to actually attempt the retry when that window elapses.
    * Called on every failed flush-and-pull cycle.  Refs and the state setter are all
    * stable, so this callback never needs to be recreated.
    */
@@ -210,7 +234,18 @@ export function useOngoingSync(
     retryDelayMsRef.current = nextDelay;
     retryAfterRef.current = Date.now() + nextDelay;
     setRetryAfter(retryAfterRef.current);
-  }, []); // Refs and state setters are stable — empty dependency array is correct.
+
+    clearBackOffTimer();
+    backOffTimerRef.current = setTimeout(() => {
+      backOffTimerRef.current = null;
+      // `force` because the window has already elapsed by definition once
+      // this timer fires — no need to re-check it, and forcing sidesteps any
+      // Date.now() drift right at the boundary.
+      flushAndPullRef.current?.(true, true).catch((err: unknown) => {
+        logger.error("useOngoingSync: scheduled back-off retry failed:", err);
+      });
+    }, nextDelay);
+  }, [clearBackOffTimer]);
 
   // Keep a stable ref to the latest pull callback so the flush closure does
   // not become stale when `onIncrementalPull` identity changes.
@@ -320,9 +355,7 @@ export function useOngoingSync(
           setLastSyncedAt(pullResult.server_timestamp);
           setHasSyncError(false);
           // Reset back-off on success.
-          retryDelayMsRef.current = 0;
-          retryAfterRef.current = null;
-          setRetryAfter(null);
+          clearBackOff();
           if (flushConflicts === 0 && conflictedPayloadRef.current === null) {
             setConflictCount(0);
             setConflictedPayload(null);
@@ -338,8 +371,22 @@ export function useOngoingSync(
         isFlushingRef.current = false;
       }
     },
-    [isActive, userId, fetchFn, conflictCount, scheduleBackOff],
+    [isActive, userId, fetchFn, conflictCount, scheduleBackOff, clearBackOff],
   );
+
+  // Keep a stable ref to the latest flushAndPull so the back-off timer
+  // (scheduled outside React's render cycle) never calls a stale closure.
+  useEffect(() => {
+    flushAndPullRef.current = flushAndPull;
+  }, [flushAndPull]);
+
+  // Cancel any pending back-off retry on unmount so it doesn't fire (and
+  // touch state) after the component is gone.
+  useEffect(() => {
+    return () => {
+      clearBackOffTimer();
+    };
+  }, [clearBackOffTimer]);
 
   // Listen for reconnect and visibility-change events.
   useEffect(() => {
@@ -391,12 +438,11 @@ export function useOngoingSync(
     setConflictCount(0);
     conflictedPayloadRef.current = null;
     setConflictedPayload(null);
-    // Reset back-off when the signed-in user changes.
-    retryDelayMsRef.current = 0;
-    retryAfterRef.current = null;
-    setRetryAfter(null);
+    // Reset back-off (and cancel any pending scheduled retry for the
+    // previous user) when the signed-in user changes.
+    clearBackOff();
     hasRunInitialFlushRef.current = false;
-  }, [userId]);
+  }, [userId, clearBackOff]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -431,6 +477,11 @@ export function useOngoingSync(
       if (!isActive || !userId || !fetchFn) return;
 
       const doEnqueue = async () => {
+        // Recorded before the push so the post-push pull (below) can request
+        // everything from this point forward — including any concurrent
+        // change from another device that lands on the server while this
+        // push is in flight.
+        const cursorBeforePush = localStorage.getItem(getSyncCursorKey(userId)) ?? undefined;
         // Attempt an immediate push.
         const result = await pushSyncPayload(fetchFn, change);
         if (!mountedRef.current) return;
@@ -489,18 +540,40 @@ export function useOngoingSync(
               setConflictCount(0);
               setConflictedPayload(null);
             }
-            // Refresh the cursor so incremental pulls stay accurate.  A second
-            // network request is required here because the push response only
-            // contains per-record results (no server_timestamp).  The alternative
-            // would be to extend the backend push response with a timestamp, which
-            // would eliminate this extra round trip.
-            const newStatus = await fetchSyncStatus(fetchFn);
-            if (!mountedRef.current) return;
-            if (newStatus) {
-              storeSyncCursor(userId, newStatus.server_timestamp);
-              setLastSyncedAt(newStatus.server_timestamp);
+            // The cursor must only ever advance as the result of a pull that
+            // has actually ingested every record up to that point. Fetching
+            // just the status timestamp and storing it directly (as this used
+            // to do) would silently and permanently skip any concurrent
+            // change from another device landing between the old cursor and
+            // that new timestamp — a pull is required here, not a status
+            // check, even though this device's own push already applied
+            // locally.
+            let pullResult: SyncPullResponse | null = null;
+            try {
+              pullResult = await pullSyncData(fetchFn, cursorBeforePush);
+            } catch (err) {
+              logger.error("useOngoingSync: post-push pull threw:", err);
+              if (mountedRef.current) {
+                setHasSyncError(true);
+              }
+              return;
             }
-            setHasSyncError(false);
+            if (!mountedRef.current) return;
+            if (pullResult) {
+              try {
+                onIncrementalPullRef.current?.(pullResult);
+                storeSyncCursor(userId, pullResult.server_timestamp);
+                setLastSyncedAt(pullResult.server_timestamp);
+                setHasSyncError(false);
+              } catch (err) {
+                logger.error("useOngoingSync: post-push incremental-pull callback threw:", err);
+                if (mountedRef.current) {
+                  setHasSyncError(true);
+                }
+              }
+            } else {
+              setHasSyncError(true);
+            }
           }
         } else {
           // Push failed — queue for later flush.

--- a/frontend/src/hooks/useOngoingSync.ts
+++ b/frontend/src/hooks/useOngoingSync.ts
@@ -576,9 +576,18 @@ export function useOngoingSync(
             }
           }
         } else {
-          // Push failed — queue for later flush.
+          // Push failed — queue for later flush. Without setHasSyncError and
+          // scheduleBackOff here, this failure was invisible to the rest of
+          // the hook: hasSyncError stayed false (no UI indication anything
+          // was wrong) and nothing scheduled a retry — the change would sit
+          // in the outbox until some *unrelated* trigger (the next
+          // enqueueChange, a visibility/online event) happened to run
+          // flushAndPull. Now it drives the same back-off retry timer every
+          // other failure path in this file already uses.
           appendToSyncOutbox(userId, change);
           setOutboxCount(getSyncOutboxSize(userId));
+          setHasSyncError(true);
+          scheduleBackOff();
         }
       };
 
@@ -601,7 +610,7 @@ export function useOngoingSync(
         }
       });
     },
-    [isActive, userId, fetchFn],
+    [isActive, userId, fetchFn, scheduleBackOff],
   );
 
   /**

--- a/frontend/src/hooks/useSyncSignal.ts
+++ b/frontend/src/hooks/useSyncSignal.ts
@@ -22,8 +22,14 @@
  * - **Lifecycle**: the hook subscribes when both `isActive` is true and a
  *   transport is provided.  The transport's cleanup function is called on
  *   unmount or when inputs change.
+ *
+ * - **Reconnect recovery**: the server's per-connection event queue does not
+ *   survive a dropped connection, so `createFetchSseTransport` forces a
+ *   catch-up pull on every *re*connect (not the first connection), skipping
+ *   the dedup check — see its implementation for details.
  */
 
+import { fetchEventSource, EventStreamContentType } from "@microsoft/fetch-event-source";
 import { useEffect, useRef } from "react";
 import { getSyncCursorKey } from "@/constants/storageKeys";
 import type { TriggerPullFn } from "@/hooks/useOngoingSync";
@@ -59,47 +65,95 @@ export interface SyncSignalTransport {
 // SSE transport adapter
 // ---------------------------------------------------------------------------
 
+/** Thrown from `onopen`/`onerror` to stop `fetchEventSource` from retrying. */
+class FatalSseError extends Error {}
+
+const INITIAL_RETRY_MS = 1_000;
+const MAX_RETRY_MS = 30_000;
+
 /**
- * Create an SSE-based `SyncSignalTransport` that connects to the given URL.
+ * Create a fetch-based `SyncSignalTransport` that connects to the given URL
+ * with a Bearer token.
  *
- * The returned transport opens an `EventSource` connection on `subscribe()`
- * and listens for `sync_changed` events.  It uses `withCredentials: true` so
- * that the browser's session cookie is included, satisfying the authentication
- * requirement for the `/api/sync/events` endpoint.
+ * `GET /api/sync/events` authenticates the same way as every other endpoint —
+ * an `Authorization: Bearer <token>` header — which native `EventSource`
+ * cannot send (it has no API for custom request headers; `withCredentials`
+ * only forwards cookies, and the backend has no cookie-based auth). This
+ * transport uses `@microsoft/fetch-event-source` to open the stream via
+ * `fetch()` instead, so the token can be attached like any other request.
  *
- * `EventSource` reconnects automatically on network interruptions; no manual
- * reconnect logic is needed.
+ * Reconnects with exponential backoff on network/stream errors. A 401/403
+ * response is treated as fatal (stops retrying) rather than hammering the
+ * endpoint with a token the server has already rejected — `OngoingSyncContext`
+ * recreates this transport whenever the access token changes (e.g. after a
+ * silent renewal), which re-subscribes with a fresh token.
  *
  * @param url - The full URL of the SSE endpoint (e.g. `https://api/sync/events`).
+ * @param accessToken - The current OIDC access token to send as a Bearer header.
  */
-export function createSseTransport(url: string): SyncSignalTransport {
+export function createFetchSseTransport(url: string, accessToken: string): SyncSignalTransport {
   return {
     subscribe(onSignal) {
-      const es = new EventSource(url, { withCredentials: true });
+      const controller = new AbortController();
+      let retryMs = INITIAL_RETRY_MS;
+      // The server's per-connection event queue (maxsize=1) only exists while
+      // a connection is open — any sync_changed notification fired during a
+      // drop is lost, not queued. On every *re*connect (not the first
+      // connection, which already gets its own initial pull on mount), force
+      // a catch-up pull with a synthetic "now" timestamp so it always beats
+      // the dedup check in useSyncSignal, regardless of whether anything was
+      // actually missed.
+      let hasConnectedOnce = false;
 
-      const handleMessage = (event: MessageEvent) => {
-        try {
-          const data = JSON.parse(event.data) as { type?: string; server_timestamp?: string };
-          if (typeof data.server_timestamp === "string") {
-            onSignal(data.server_timestamp);
+      fetchEventSource(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: controller.signal,
+        async onopen(response) {
+          if (response.ok && response.headers.get("content-type")?.startsWith(EventStreamContentType)) {
+            retryMs = INITIAL_RETRY_MS;
+            if (hasConnectedOnce) {
+              onSignal(new Date().toISOString());
+            }
+            hasConnectedOnce = true;
+            return;
           }
-        } catch {
-          // Ignore malformed event data.
-          logger.warn("useSyncSignal: failed to parse SSE event data:", event.data);
-        }
-      };
-
-      es.addEventListener("sync_changed", handleMessage);
-
-      es.onerror = () => {
-        // EventSource reconnects automatically after every error; using debug
-        // level avoids console spam on flaky networks or proxy interruptions.
-        logger.debug("useSyncSignal: SSE connection error — will retry automatically.");
-      };
+          if (response.status === 401 || response.status === 403) {
+            throw new FatalSseError(`SSE authentication failed: ${response.status}`);
+          }
+          throw new Error(`SSE connection failed: ${response.status}`);
+        },
+        onmessage(event) {
+          if (event.event !== "sync_changed") return;
+          try {
+            const data = JSON.parse(event.data) as { type?: string; server_timestamp?: string };
+            if (typeof data.server_timestamp === "string") {
+              onSignal(data.server_timestamp);
+            }
+          } catch {
+            // Ignore malformed event data.
+            logger.warn("useSyncSignal: failed to parse SSE event data:", event.data);
+          }
+        },
+        onerror(err) {
+          if (err instanceof FatalSseError) {
+            logger.warn("useSyncSignal: SSE authentication failed — giving up until reconnect:", err);
+            throw err; // Rethrowing tells fetchEventSource to stop retrying.
+          }
+          // Any other error (network blip, proxy interruption, non-2xx status)
+          // gets an exponential-backoff retry; using debug level avoids console
+          // spam on flaky networks.
+          logger.debug("useSyncSignal: SSE connection error — retrying:", err);
+          const interval = retryMs;
+          retryMs = Math.min(retryMs * 2, MAX_RETRY_MS);
+          return interval;
+        },
+      }).catch(() => {
+        // Fatal errors and aborts both settle this promise; already logged
+        // above (or expected, for a clean unsubscribe) — nothing more to do.
+      });
 
       return () => {
-        es.removeEventListener("sync_changed", handleMessage);
-        es.close();
+        controller.abort();
       };
     },
   };

--- a/frontend/src/hooks/useSyncSignal.ts
+++ b/frontend/src/hooks/useSyncSignal.ts
@@ -29,7 +29,7 @@
  *   the dedup check — see its implementation for details.
  */
 
-import { fetchEventSource, EventStreamContentType } from "@microsoft/fetch-event-source";
+import { EventSourceParserStream } from "eventsource-parser/stream";
 import { useEffect, useRef } from "react";
 import { getSyncCursorKey } from "@/constants/storageKeys";
 import type { TriggerPullFn } from "@/hooks/useOngoingSync";
@@ -65,11 +65,14 @@ export interface SyncSignalTransport {
 // SSE transport adapter
 // ---------------------------------------------------------------------------
 
-/** Thrown from `onopen`/`onerror` to stop `fetchEventSource` from retrying. */
-class FatalSseError extends Error {}
-
+const EVENT_STREAM_CONTENT_TYPE = "text/event-stream";
 const INITIAL_RETRY_MS = 1_000;
 const MAX_RETRY_MS = 30_000;
+
+/** Whether the response status means "your token is bad" — not worth retrying blindly. */
+function isFatalAuthStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}
 
 /**
  * Create a fetch-based `SyncSignalTransport` that connects to the given URL
@@ -79,8 +82,13 @@ const MAX_RETRY_MS = 30_000;
  * an `Authorization: Bearer <token>` header — which native `EventSource`
  * cannot send (it has no API for custom request headers; `withCredentials`
  * only forwards cookies, and the backend has no cookie-based auth). This
- * transport uses `@microsoft/fetch-event-source` to open the stream via
- * `fetch()` instead, so the token can be attached like any other request.
+ * transport opens the stream via a plain `fetch()` instead, so the token can
+ * be attached like any other request, and pipes the response body through
+ * `eventsource-parser`'s `EventSourceParserStream` to turn it into SSE
+ * messages. (Not `@microsoft/fetch-event-source`, which bundled this same
+ * fetch+parse+retry shape — its last real release was 2021; `eventsource-parser`
+ * is actively maintained and the parsing is the one part worth not
+ * hand-rolling. The reconnect/backoff loop below is ours either way.)
  *
  * Reconnects with exponential backoff on network/stream errors. A 401/403
  * response is treated as fatal (stops retrying) rather than hammering the
@@ -94,7 +102,9 @@ const MAX_RETRY_MS = 30_000;
 export function createFetchSseTransport(url: string, accessToken: string): SyncSignalTransport {
   return {
     subscribe(onSignal) {
-      const controller = new AbortController();
+      let stopped = false;
+      let controller: AbortController | null = null;
+      let retryTimer: ReturnType<typeof setTimeout> | null = null;
       let retryMs = INITIAL_RETRY_MS;
       // The server's per-connection event queue (maxsize=1) only exists while
       // a connection is open — any sync_changed notification fired during a
@@ -105,55 +115,83 @@ export function createFetchSseTransport(url: string, accessToken: string): SyncS
       // actually missed.
       let hasConnectedOnce = false;
 
-      fetchEventSource(url, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        signal: controller.signal,
-        async onopen(response) {
-          if (response.ok && response.headers.get("content-type")?.startsWith(EventStreamContentType)) {
-            retryMs = INITIAL_RETRY_MS;
-            if (hasConnectedOnce) {
-              onSignal(new Date().toISOString());
-            }
-            hasConnectedOnce = true;
-            return;
+      function scheduleReconnect() {
+        if (stopped) return;
+        const interval = retryMs;
+        retryMs = Math.min(retryMs * 2, MAX_RETRY_MS);
+        retryTimer = setTimeout(() => {
+          retryTimer = null;
+          connect();
+        }, interval);
+      }
+
+      function handleMessage(event: { event?: string; data: string }) {
+        if (event.event !== "sync_changed") return;
+        try {
+          const data = JSON.parse(event.data) as { type?: string; server_timestamp?: string };
+          if (typeof data.server_timestamp === "string") {
+            onSignal(data.server_timestamp);
           }
-          if (response.status === 401 || response.status === 403) {
-            throw new FatalSseError(`SSE authentication failed: ${response.status}`);
+        } catch {
+          // Ignore malformed event data.
+          logger.warn("useSyncSignal: failed to parse SSE event data:", event.data);
+        }
+      }
+
+      async function connect() {
+        controller = new AbortController();
+        try {
+          const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${accessToken}`, Accept: EVENT_STREAM_CONTENT_TYPE },
+            signal: controller.signal,
+          });
+
+          if (isFatalAuthStatus(response.status)) {
+            logger.warn(
+              "useSyncSignal: SSE authentication failed — giving up until reconnect:",
+              response.status,
+            );
+            return; // No scheduleReconnect(): a bad token won't fix itself on retry.
           }
-          throw new Error(`SSE connection failed: ${response.status}`);
-        },
-        onmessage(event) {
-          if (event.event !== "sync_changed") return;
-          try {
-            const data = JSON.parse(event.data) as { type?: string; server_timestamp?: string };
-            if (typeof data.server_timestamp === "string") {
-              onSignal(data.server_timestamp);
-            }
-          } catch {
-            // Ignore malformed event data.
-            logger.warn("useSyncSignal: failed to parse SSE event data:", event.data);
+          if (!response.ok || !response.body || !response.headers.get("content-type")?.startsWith(EVENT_STREAM_CONTENT_TYPE)) {
+            throw new Error(`SSE connection failed: ${response.status}`);
           }
-        },
-        onerror(err) {
-          if (err instanceof FatalSseError) {
-            logger.warn("useSyncSignal: SSE authentication failed — giving up until reconnect:", err);
-            throw err; // Rethrowing tells fetchEventSource to stop retrying.
+
+          retryMs = INITIAL_RETRY_MS;
+          if (hasConnectedOnce) {
+            onSignal(new Date().toISOString());
           }
-          // Any other error (network blip, proxy interruption, non-2xx status)
-          // gets an exponential-backoff retry; using debug level avoids console
-          // spam on flaky networks.
+          hasConnectedOnce = true;
+
+          const reader = response.body
+            .pipeThrough(new TextDecoderStream())
+            .pipeThrough(new EventSourceParserStream())
+            .getReader();
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            handleMessage(value);
+          }
+          // The stream ended (server closed the connection, e.g. a deploy) —
+          // treat exactly like a dropped connection and reconnect.
+          if (!stopped) {
+            scheduleReconnect();
+          }
+        } catch (err) {
+          if (stopped) return; // Expected: abort() from the cleanup function below.
           logger.debug("useSyncSignal: SSE connection error — retrying:", err);
-          const interval = retryMs;
-          retryMs = Math.min(retryMs * 2, MAX_RETRY_MS);
-          return interval;
-        },
-      }).catch(() => {
-        // Fatal errors and aborts both settle this promise; already logged
-        // above (or expected, for a clean unsubscribe) — nothing more to do.
-      });
+          scheduleReconnect();
+        }
+      }
+
+      connect();
 
       return () => {
-        controller.abort();
+        stopped = true;
+        if (retryTimer !== null) {
+          clearTimeout(retryTimer);
+        }
+        controller?.abort();
       };
     },
   };

--- a/frontend/src/mocks/handlers/workLocations.ts
+++ b/frontend/src/mocks/handlers/workLocations.ts
@@ -16,7 +16,7 @@ export const workLocationHandlers = [
     });
   }),
 
-  http.post("*/api/work-locations/", async ({ request }) => {
+  http.post("*/api/work-locations", async ({ request }) => {
     const authFailure = buildAuthFailureResponse();
     if (authFailure) return authFailure;
     const scenario = getMockScenario();

--- a/frontend/src/utils/syncClient.ts
+++ b/frontend/src/utils/syncClient.ts
@@ -262,6 +262,21 @@ export function syncStatusHasData(status: SyncStatusResponse): boolean {
 }
 
 /**
+ * Deduplicate by natural key, keeping the last (most-recent local) entry per
+ * key.  The outbox merge concatenates multiple offline mutations, so the same
+ * record may appear more than once.  Keeping only the newest entry is safe
+ * because every queued mutation carries the full record (see collections.ts)
+ * and the server upserts creates/updates by natural key.
+ */
+function dedupeByKey<T>(items: T[], keyFn: (item: T) => string): T[] {
+  const map = new Map<string, T>();
+  for (const item of items) {
+    map.set(keyFn(item), item);
+  }
+  return Array.from(map.values());
+}
+
+/**
  * Count the total number of conflict records across all entity types in a
  * push response.  Returns 0 when there are no conflicts.
  */
@@ -292,17 +307,6 @@ export function extractConflictedItems(
     );
   }
   const ids = (key: string): Set<string> => conflicted[key] ?? new Set();
-
-  // Deduplicate by natural key, keeping the last (most-recent local) entry per key.
-  // The outbox merge concatenates multiple offline mutations, so the same record
-  // may appear more than once.
-  function dedupeByKey<T>(items: T[], keyFn: (item: T) => string): T[] {
-    const map = new Map<string, T>();
-    for (const item of items) {
-      map.set(keyFn(item), item);
-    }
-    return Array.from(map.values());
-  }
 
   return {
     labels: dedupeByKey(
@@ -383,10 +387,67 @@ export function bumpClientTimestamps(
 }
 
 /**
- * Call POST /db/sync/push with a pre-built payload.
- * Returns the server response, or null on network/parse failure.
+ * Maximum items per entity list accepted by POST /api/sync/push in a single
+ * request (mirrors MAX_SYNC_PUSH_ITEMS in backend/app/schemas.py).  Larger
+ * payloads are split transparently by pushSyncPayload.
  */
-export async function pushSyncPayload(
+export const MAX_SYNC_PUSH_ITEMS = 1000;
+
+/**
+ * Entity processing order for chunked pushes.  Referenced entities (labels,
+ * gantt tasks) are pushed before the tasks/templates that link to them so
+ * that server-side reference validation succeeds across chunk boundaries.
+ * Mirrors the processing order of push_changes in the backend sync service.
+ */
+const PUSH_ENTITY_ORDER: readonly (keyof SyncPushPayload)[] = [
+  "labels",
+  "gantt_tasks",
+  "tasks",
+  "templates",
+  "work_locations",
+  "time_off_entries",
+];
+
+function emptyPushPayload(): SyncPushPayload {
+  return {
+    labels: [],
+    tasks: [],
+    templates: [],
+    work_locations: [],
+    time_off_entries: [],
+    gantt_tasks: [],
+  };
+}
+
+/**
+ * Split an oversized payload into single-entity chunks of at most
+ * MAX_SYNC_PUSH_ITEMS items each, in dependency order.
+ */
+function chunkPushPayload(payload: SyncPushPayload): SyncPushPayload[] {
+  const chunks: SyncPushPayload[] = [];
+  for (const key of PUSH_ENTITY_ORDER) {
+    const items = payload[key] ?? [];
+    for (let i = 0; i < items.length; i += MAX_SYNC_PUSH_ITEMS) {
+      const chunk = emptyPushPayload();
+      (chunk[key] as unknown[]) = items.slice(i, i + MAX_SYNC_PUSH_ITEMS);
+      chunks.push(chunk);
+    }
+  }
+  return chunks;
+}
+
+/** Concatenate the per-entity results of several push responses into one. */
+function mergePushResponses(responses: SyncPushResponse[]): SyncPushResponse {
+  const results: Record<string, SyncRecordResult[]> = {};
+  for (const response of responses) {
+    for (const [entityType, records] of Object.entries(response.results ?? {})) {
+      (results[entityType] ??= []).push(...(records ?? []));
+    }
+  }
+  return { results };
+}
+
+async function pushSinglePayload(
   fetch: FetchFn,
   payload: SyncPushPayload,
 ): Promise<SyncPushResponse | null> {
@@ -401,6 +462,36 @@ export async function pushSyncPayload(
   } catch {
     return null;
   }
+}
+
+/**
+ * Call POST /db/sync/push with a pre-built payload.
+ * Returns the server response, or null on network/parse failure.
+ *
+ * Payloads whose entity lists exceed MAX_SYNC_PUSH_ITEMS (e.g. a first-sync
+ * upload of a long local history) are split into sequential requests and the
+ * per-record results merged back into a single response.  If any chunk fails,
+ * null is returned; chunks already applied are harmless because pushes are
+ * idempotent (last-write-wins per record), so a retry re-sends everything.
+ */
+export async function pushSyncPayload(
+  fetch: FetchFn,
+  payload: SyncPushPayload,
+): Promise<SyncPushResponse | null> {
+  const oversized = PUSH_ENTITY_ORDER.some(
+    (key) => (payload[key] ?? []).length > MAX_SYNC_PUSH_ITEMS,
+  );
+  if (!oversized) {
+    return pushSinglePayload(fetch, payload);
+  }
+
+  const responses: SyncPushResponse[] = [];
+  for (const chunk of chunkPushPayload(payload)) {
+    const response = await pushSinglePayload(fetch, chunk);
+    if (response === null) return null;
+    responses.push(response);
+  }
+  return mergePushResponses(responses);
 }
 
 /**
@@ -805,12 +896,10 @@ function readSyncOutbox(userId: string): SyncPushPayload[] {
  * Append a single change payload to the outbox queue stored in localStorage.
  * Called when an immediate push fails (e.g. offline).
  *
- * Note: entries are not coalesced — each failed write is stored as a separate
- * item.  Rapid offline mutations to the same record produce multiple entries,
- * all of which are merged and sent together in the next flush.  The backend
- * uses last-write-wins per record ID, so only the latest entry for a given ID
- * takes effect.  If outbox size ever becomes a concern, coalescing by ID could
- * be added here.
+ * Note: entries are not coalesced at append time — each failed write is
+ * stored as a separate item.  Rapid offline mutations to the same record
+ * produce multiple entries; dequeueAndMergeSyncOutbox coalesces them by
+ * natural key (keeping the newest) before the flush is sent.
  */
 export function appendToSyncOutbox(userId: string, change: SyncPushPayload): void {
   try {
@@ -844,6 +933,12 @@ export function getSyncOutboxSize(userId: string): number {
  * caller must invoke the returned `commit` function to clear the outbox.  If
  * the push fails the outbox is left intact and will be retried on the next
  * flush cycle.
+ *
+ * Entries are coalesced by natural key (id, or date for work locations),
+ * keeping only the newest entry per record.  This is safe because every
+ * queued mutation carries the full record and the server upserts by natural
+ * key, and it keeps long-offline flushes bounded by the number of *distinct*
+ * records rather than the number of mutations.
  */
 export function dequeueAndMergeSyncOutbox(
   userId: string,
@@ -872,5 +967,15 @@ export function dequeueAndMergeSyncOutbox(
     );
     merged.gantt_tasks.push(...(Array.isArray(payload.gantt_tasks) ? payload.gantt_tasks : []));
   }
-  return { merged, commit: () => clearSyncOutbox(userId) };
+  return {
+    merged: {
+      labels: dedupeByKey(merged.labels, (l) => l.id),
+      tasks: dedupeByKey(merged.tasks, (t) => t.id),
+      templates: dedupeByKey(merged.templates, (t) => t.id),
+      work_locations: dedupeByKey(merged.work_locations, (w) => w.date),
+      time_off_entries: dedupeByKey(merged.time_off_entries, (e) => e.id),
+      gantt_tasks: dedupeByKey(merged.gantt_tasks, (g) => g.id),
+    },
+    commit: () => clearSyncOutbox(userId),
+  };
 }

--- a/frontend/tests/hooks/useOngoingSync.test.ts
+++ b/frontend/tests/hooks/useOngoingSync.test.ts
@@ -248,6 +248,53 @@ describe("useOngoingSync", () => {
       const outbox = JSON.parse(outboxRaw!);
       expect(outbox[0].tasks[0].id).toBe("task-offline");
     });
+
+    it("sets hasSyncError and schedules a back-off retry when an immediate push fails", async () => {
+      // Regression test: a failed enqueueChange push previously queued the
+      // change to the outbox but left hasSyncError false and scheduled no
+      // retry — the change would sit unsynced until some *unrelated*
+      // trigger (the next enqueueChange, a visibility/online event)
+      // happened to run flushAndPull. Isolated from the initial mount flush
+      // (which succeeds here with an empty outbox) so this failure is the
+      // only thing that could have set hasSyncError/retryAfter.
+      storeSyncCursor("user-1", "2026-01-01T00:00:00.000Z");
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => incrementalPullResponse }) // initial pull
+        .mockResolvedValueOnce(failedResponse) // initial preferences fetch
+        .mockResolvedValueOnce({ ok: false }); // enqueueChange push fails
+
+      const { result } = renderHook(() => useOngoingSync(true, "user-1", mockFetch));
+
+      await waitFor(() => {
+        expect(result.current.lastSyncedAt).toBe("2026-02-01T00:00:00.000Z");
+      });
+      expect(result.current.hasSyncError).toBe(false);
+      expect(result.current.retryAfter).toBeNull();
+
+      const change = emptySyncPayload();
+      change.tasks.push({
+        id: "task-offline-2",
+        action: "create",
+        client_updated_at: "2026-01-02T00:00:00.000Z",
+        text: "Offline task 2",
+        label_id: null,
+        start_time: "2026-01-02T08:00:00.000Z",
+        stop_time: null,
+        includes_break: false,
+      });
+
+      await act(async () => {
+        result.current.enqueueChange(change);
+      });
+
+      await waitFor(() => {
+        expect(result.current.outboxCount).toBe(1);
+      });
+      expect(result.current.hasSyncError).toBe(true);
+      expect(result.current.retryAfter).not.toBeNull();
+      expect(result.current.retryAfter).toBeGreaterThan(Date.now());
+    });
   });
 
   describe("flush and pull on visibility change", () => {

--- a/frontend/tests/hooks/useOngoingSync.test.ts
+++ b/frontend/tests/hooks/useOngoingSync.test.ts
@@ -86,25 +86,26 @@ describe("useOngoingSync", () => {
   describe("enqueueChange", () => {
     it("pushes the change immediately when online and updates lastSyncedAt", async () => {
       storeSyncCursor("user-1", "2026-01-01T00:00:00.000Z");
-      const refreshedStatus = {
-        labels_updated_at: null,
-        tasks_updated_at: "2026-01-02T00:00:00.000Z",
-        templates_updated_at: null,
-        work_locations_updated_at: null,
-        time_off_entries_updated_at: null,
-        preferences_updated_at: null,
+      const postPushPullResponse = {
+        labels: [],
+        tasks: [],
+        templates: [],
+        work_locations: [],
+        time_off_entries: [],
+        gantt_tasks: [],
         server_timestamp: "2026-01-02T00:00:00.000Z",
       };
       // Mocks are consumed in order:
       // 1. Initial flush on mount: outbox empty → no push, only a pull
       // 2. enqueueChange: immediate push succeeds (no conflicts)
-      // 3. enqueueChange: fetchSyncStatus refreshes the cursor (extra round-trip
-      //    because the push response does not include a server_timestamp)
+      // 3. enqueueChange: pull from the pre-push cursor to advance the cursor
+      //    (a status-only refresh would silently skip concurrent changes from
+      //    other devices — see useOngoingSync.enqueueChange)
       mockFetch
         .mockResolvedValueOnce({ ok: true, json: async () => incrementalPullResponse }) // initial pull
         .mockResolvedValueOnce(failedResponse) // initial preferences fetch
         .mockResolvedValueOnce({ ok: true, json: async () => emptyPushResponse }) // enqueueChange push
-        .mockResolvedValueOnce({ ok: true, json: async () => refreshedStatus }); // status refresh
+        .mockResolvedValueOnce({ ok: true, json: async () => postPushPullResponse }); // post-push pull
 
       const { result } = renderHook(() => useOngoingSync(true, "user-1", mockFetch));
 
@@ -135,9 +136,84 @@ describe("useOngoingSync", () => {
 
       const pushCall = mockFetch.mock.calls.find(([url]: [string]) => url === "/api/sync/push");
       expect(pushCall).toBeDefined();
+      // The post-push pull must use the cursor from *before* this push, not a
+      // bare status refresh — otherwise a concurrent change from another
+      // device landing in that window would be silently skipped forever.
+      const postPushPullCall = mockFetch.mock.calls.find(([url]: [string]) =>
+        url.startsWith("/api/sync/pull?since="),
+      );
+      expect(postPushPullCall?.[0]).toBe(
+        `/api/sync/pull?since=${encodeURIComponent("2026-01-01T00:00:00.000Z")}`,
+      );
       // Outbox should remain empty after successful push
       expect(result.current.outboxCount).toBe(0);
       expect(getSyncOutboxSize("user-1")).toBe(0);
+    });
+
+    it("does not silently skip a concurrent change from another device landing during the push", async () => {
+      // Regression test for the cursor-advance race: previously, a successful
+      // push refreshed the cursor from GET /sync/status (a timestamp only,
+      // no data) instead of pulling — any record from another device with
+      // updated_at between the old and new cursor was never fetched again.
+      storeSyncCursor("user-1", "2026-01-01T00:00:00.000Z");
+
+      const concurrentChangeFromOtherDevice = {
+        labels: [],
+        tasks: [
+          {
+            id: "task-from-other-device",
+            user_id: 1,
+            label_id: null,
+            gantt_task_id: null,
+            text: "Created on another device",
+            start_time: "2026-01-01T12:00:00.000Z",
+            stop_time: null,
+            includes_break: false,
+            client_updated_at: "2026-01-01T12:00:00.000Z",
+            updated_at: "2026-01-01T12:00:00.000Z",
+            deleted_at: null,
+          },
+        ],
+        templates: [],
+        work_locations: [],
+        time_off_entries: [],
+        gantt_tasks: [],
+        server_timestamp: "2026-01-02T00:00:00.000Z",
+      };
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => incrementalPullResponse }) // initial pull
+        .mockResolvedValueOnce(failedResponse) // initial preferences fetch
+        .mockResolvedValueOnce({ ok: true, json: async () => emptyPushResponse }) // enqueueChange push
+        .mockResolvedValueOnce({ ok: true, json: async () => concurrentChangeFromOtherDevice }); // post-push pull
+
+      const onIncrementalPull = vi.fn();
+      const { result } = renderHook(() =>
+        useOngoingSync(true, "user-1", mockFetch, onIncrementalPull),
+      );
+
+      await waitFor(() => {
+        expect(result.current.lastSyncedAt).toBe("2026-02-01T00:00:00.000Z");
+      });
+      onIncrementalPull.mockClear();
+
+      await act(async () => {
+        result.current.enqueueChange(emptySyncPayload());
+      });
+
+      await waitFor(() => {
+        expect(result.current.lastSyncedAt).toBe("2026-01-02T00:00:00.000Z");
+      });
+
+      // The concurrent record from the other device must have been applied,
+      // not silently skipped by a bare cursor advance.
+      expect(onIncrementalPull).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tasks: expect.arrayContaining([
+            expect.objectContaining({ id: "task-from-other-device" }),
+          ]),
+        }),
+      );
     });
 
     it("queues the change in the outbox when push fails", async () => {
@@ -1043,6 +1119,95 @@ describe("useOngoingSync", () => {
       });
 
       dateSpy.mockRestore();
+    });
+
+    it("automatically retries once the back-off window elapses, with no user interaction", async () => {
+      // Regression test: back-off previously only *gated* passive triggers
+      // (visibility/online) — nothing scheduled a retry attempt on its own,
+      // so a tab left open and idle past the window would never retry until
+      // the user did something (switched tabs, went offline/online). Uses
+      // real timing (no fake timers) since this file relies on real promise
+      // resolution throughout; the back-off window is the real 1 s minimum.
+      storeSyncCursor("user-1", "2026-01-01T00:00:00.000Z");
+      appendToSyncOutbox("user-1", emptySyncPayload());
+
+      let callCount = 0;
+      mockFetch.mockImplementation(async (url: string) => {
+        callCount++;
+        if (url === "/api/sync/push") {
+          if (callCount <= 1) return { ok: false }; // Initial flush fails.
+          return { ok: true, json: async () => emptyPushResponse };
+        }
+        if (url.startsWith("/api/sync/pull")) {
+          return { ok: true, json: async () => incrementalPullResponse };
+        }
+        return { ok: false };
+      });
+
+      const { result } = renderHook(() => useOngoingSync(true, "user-1", mockFetch));
+
+      await waitFor(() => {
+        expect(result.current.hasSyncError).toBe(true);
+        expect(result.current.retryAfter).not.toBeNull();
+      });
+      const callsAfterInitialFailure = mockFetch.mock.calls.length;
+
+      // No visibility/online event fires — wait past the back-off window and
+      // let the scheduled timer retry on its own.
+      await waitFor(
+        () => {
+          expect(result.current.hasSyncError).toBe(false);
+        },
+        { timeout: INITIAL_BACK_OFF_MS + 2_000 },
+      );
+
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(callsAfterInitialFailure);
+      expect(result.current.retryAfter).toBeNull();
+    });
+
+    it("cancels the pending scheduled retry once a flush succeeds via another trigger", async () => {
+      // If the online event's forced flush succeeds first, the timer from
+      // the earlier failure must not fire a second, redundant retry later.
+      storeSyncCursor("user-1", "2026-01-01T00:00:00.000Z");
+      appendToSyncOutbox("user-1", emptySyncPayload());
+
+      let callCount = 0;
+      mockFetch.mockImplementation(async (url: string) => {
+        callCount++;
+        if (url === "/api/sync/push") {
+          if (callCount <= 1) return { ok: false }; // Initial flush fails.
+          return { ok: true, json: async () => emptyPushResponse };
+        }
+        if (url.startsWith("/api/sync/pull")) {
+          return { ok: true, json: async () => incrementalPullResponse };
+        }
+        return { ok: false };
+      });
+
+      const { result } = renderHook(() => useOngoingSync(true, "user-1", mockFetch));
+
+      await waitFor(() => {
+        expect(result.current.hasSyncError).toBe(true);
+        expect(result.current.retryAfter).not.toBeNull();
+      });
+
+      await act(async () => {
+        window.dispatchEvent(new Event("online"));
+      });
+
+      await waitFor(() => {
+        expect(result.current.hasSyncError).toBe(false);
+        expect(result.current.retryAfter).toBeNull();
+      });
+
+      const callsAfterOnlineSuccess = mockFetch.mock.calls.length;
+
+      // Wait past what would have been the original scheduled retry time.
+      // Real timing: no assertion inside waitFor can observe "nothing
+      // happened", so just wait out the window directly.
+      await new Promise((resolve) => setTimeout(resolve, INITIAL_BACK_OFF_MS + 200));
+
+      expect(mockFetch.mock.calls.length).toBe(callsAfterOnlineSuccess);
     });
   });
 });

--- a/frontend/tests/hooks/useSyncSignal.test.ts
+++ b/frontend/tests/hooks/useSyncSignal.test.ts
@@ -1,8 +1,15 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createSseTransport, useSyncSignal, type SyncSignalTransport } from "@/hooks/useSyncSignal";
+import { createFetchSseTransport, useSyncSignal, type SyncSignalTransport } from "@/hooks/useSyncSignal";
 import { storeSyncCursor } from "@/utils/syncClient";
 import { getSyncCursorKey } from "@/constants/storageKeys";
+
+const fetchEventSourceMock = vi.fn();
+
+vi.mock("@microsoft/fetch-event-source", () => ({
+  fetchEventSource: (...args: unknown[]) => fetchEventSourceMock(...args),
+  EventStreamContentType: "text/event-stream",
+}));
 
 /**
  * Create a mock transport that captures the onSignal callback so tests can
@@ -406,110 +413,97 @@ describe("useSyncSignal", () => {
 });
 
 // ---------------------------------------------------------------------------
-// createSseTransport — SSE adapter unit tests
+// createFetchSseTransport — fetch-based SSE adapter unit tests
 //
-// EventSource is not available in happy-dom, so we stub it globally and verify
-// the adapter's construction, message parsing, and cleanup behaviour.
+// @microsoft/fetch-event-source is mocked: its own frame-parsing is already
+// covered upstream, so these tests exercise our glue code by capturing the
+// options object passed to it and invoking the callbacks (onopen, onmessage,
+// onerror) directly, the same way the library would.
 // ---------------------------------------------------------------------------
 
-function makeEventSourceStub() {
-  const listeners: Map<string, EventListener> = new Map();
-  let activeInstance: { onerror: ((event: Event) => void) | null } | null = null;
-
-  const addEventListenerSpy = vi.fn((type: string, listener: EventListener) => {
-    listeners.set(type, listener);
-  });
-  const removeEventListenerSpy = vi.fn((type: string, listener: EventListener) => {
-    if (listeners.get(type) === listener) {
-      listeners.delete(type);
-    }
-  });
-  const closeSpy = vi.fn();
-
-  // Vitest requires mockImplementation with class syntax for constructor mocks.
-  const MockConstructor = vi.fn().mockImplementation(
-    class {
-      constructor() {
-        activeInstance = this as unknown as { onerror: ((event: Event) => void) | null };
-      }
-      onerror: ((event: Event) => void) | null = null;
-      addEventListener = addEventListenerSpy;
-      removeEventListener = removeEventListenerSpy;
-      close = closeSpy;
-    },
-  );
-
-  const dispatch = (type: string, data: string) => {
-    const listener = listeners.get(type);
-    if (listener) listener(new MessageEvent(type, { data }));
-  };
-
-  return {
-    MockConstructor,
-    dispatch,
-    addEventListenerSpy,
-    removeEventListenerSpy,
-    closeSpy,
-    /** Simulate an SSE connection error on the most-recently created instance. */
-    fireError() {
-      activeInstance?.onerror?.(new Event("error"));
-    },
-  };
+interface CapturedFetchEventSourceOptions {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+  onopen: (response: Response) => Promise<void>;
+  onmessage: (event: { id: string; event: string; data: string; retry?: number }) => void;
+  onerror: (err: unknown) => number | undefined;
 }
 
-describe("createSseTransport", () => {
+function captureOptions(): CapturedFetchEventSourceOptions {
+  expect(fetchEventSourceMock).toHaveBeenCalledTimes(1);
+  return fetchEventSourceMock.mock.calls[0]![1] as CapturedFetchEventSourceOptions;
+}
+
+function okResponse(): Response {
+  return new Response(null, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+describe("createFetchSseTransport", () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
+    fetchEventSourceMock.mockReset();
     vi.restoreAllMocks();
   });
 
-  it("opens an EventSource with the given URL and withCredentials: true", () => {
-    const { MockConstructor } = makeEventSourceStub();
-    vi.stubGlobal("EventSource", MockConstructor);
+  it("opens the stream with the given URL and Authorization header", () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
-    createSseTransport("https://api.example.com/sync/events").subscribe(vi.fn());
+    createFetchSseTransport("https://api.example.com/sync/events", "token-abc").subscribe(vi.fn());
 
-    expect(MockConstructor).toHaveBeenCalledWith("https://api.example.com/sync/events", {
-      withCredentials: true,
-    });
+    expect(fetchEventSourceMock).toHaveBeenCalledWith(
+      "https://api.example.com/sync/events",
+      expect.objectContaining({ headers: { Authorization: "Bearer token-abc" } }),
+    );
   });
 
-  it("calls onSignal with server_timestamp when a sync_changed event arrives", () => {
-    const { MockConstructor, dispatch } = makeEventSourceStub();
-    vi.stubGlobal("EventSource", MockConstructor);
+  it("calls onSignal with server_timestamp when a sync_changed event arrives", async () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
     const onSignal = vi.fn();
-    createSseTransport("/api/sync/events").subscribe(onSignal);
+    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
+    const options = captureOptions();
 
-    dispatch(
-      "sync_changed",
-      JSON.stringify({ type: "sync_changed", server_timestamp: "2026-03-01T12:00:00.000Z" }),
-    );
+    options.onmessage({
+      id: "",
+      event: "sync_changed",
+      data: JSON.stringify({ type: "sync_changed", server_timestamp: "2026-03-01T12:00:00.000Z" }),
+    });
 
     expect(onSignal).toHaveBeenCalledWith("2026-03-01T12:00:00.000Z");
   });
 
-  it("does not call onSignal when event data is missing server_timestamp", () => {
-    const { MockConstructor, dispatch } = makeEventSourceStub();
-    vi.stubGlobal("EventSource", MockConstructor);
+  it("ignores events whose event name is not sync_changed", () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
     const onSignal = vi.fn();
-    createSseTransport("/api/sync/events").subscribe(onSignal);
+    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
+    const options = captureOptions();
 
-    dispatch("sync_changed", JSON.stringify({ type: "sync_changed" }));
+    options.onmessage({ id: "", event: "keepalive", data: "{}" });
+
+    expect(onSignal).not.toHaveBeenCalled();
+  });
+
+  it("does not call onSignal when event data is missing server_timestamp", () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+
+    const onSignal = vi.fn();
+    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
+    const options = captureOptions();
+
+    options.onmessage({ id: "", event: "sync_changed", data: JSON.stringify({ type: "sync_changed" }) });
 
     expect(onSignal).not.toHaveBeenCalled();
   });
 
   it("does not throw and does not call onSignal when event data is malformed JSON", () => {
-    const { MockConstructor, dispatch } = makeEventSourceStub();
-    vi.stubGlobal("EventSource", MockConstructor);
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
     const onSignal = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
+    const options = captureOptions();
 
-    createSseTransport("/api/sync/events").subscribe(onSignal);
-    dispatch("sync_changed", "not-json{{{");
+    options.onmessage({ id: "", event: "sync_changed", data: "not-json{{{" });
 
     expect(onSignal).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
@@ -518,44 +512,103 @@ describe("createSseTransport", () => {
     );
   });
 
-  it("logs a debug message when the connection errors (EventSource auto-reconnects)", () => {
-    const { MockConstructor, fireError } = makeEventSourceStub();
-    vi.stubGlobal("EventSource", MockConstructor);
+  it("resolves onopen without throwing for a 200 text/event-stream response", async () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
-    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
+    const options = captureOptions();
 
-    createSseTransport("/api/sync/events").subscribe(vi.fn());
-    fireError();
-
-    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("SSE connection error"));
+    await expect(options.onopen(okResponse())).resolves.toBeUndefined();
   });
 
-  it("cleanup removes the sync_changed listener and closes the EventSource", () => {
-    const { MockConstructor, removeEventListenerSpy, closeSpy } = makeEventSourceStub();
-    vi.stubGlobal("EventSource", MockConstructor);
+  it("throws a fatal error from onopen on 401, and onerror rethrows it (stops retrying)", async () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
-    const cleanup = createSseTransport("/api/sync/events").subscribe(vi.fn());
+    createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
+    const options = captureOptions();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    cleanup();
+    const unauthorized = new Response(null, { status: 401 });
+    await expect(options.onopen(unauthorized)).rejects.toThrow("SSE authentication failed: 401");
 
-    expect(removeEventListenerSpy).toHaveBeenCalledWith("sync_changed", expect.any(Function));
-    expect(closeSpy).toHaveBeenCalledTimes(1);
+    let caught: unknown;
+    try {
+      await options.onopen(unauthorized);
+    } catch (err) {
+      caught = err;
+    }
+    expect(() => options.onerror(caught)).toThrow();
   });
 
-  it("does not call onSignal after cleanup", () => {
-    const { MockConstructor, dispatch } = makeEventSourceStub();
-    vi.stubGlobal("EventSource", MockConstructor);
+  it("throws a non-fatal error from onopen on other non-ok statuses", async () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+
+    createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
+    const options = captureOptions();
+
+    await expect(options.onopen(new Response(null, { status: 503 }))).rejects.toThrow(
+      "SSE connection failed: 503",
+    );
+  });
+
+  it("onerror returns an increasing back-off interval for non-fatal errors, capped at the max", () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
+    const options = captureOptions();
+
+    const first = options.onerror(new Error("network blip"));
+    const second = options.onerror(new Error("network blip"));
+    const third = options.onerror(new Error("network blip"));
+
+    expect(first).toBe(1_000);
+    expect(second).toBe(2_000);
+    expect(third).toBe(4_000);
+  });
+
+  it("resets the back-off interval after a successful reconnect", async () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
+    const options = captureOptions();
+
+    options.onerror(new Error("blip"));
+    expect(options.onerror(new Error("blip"))).toBe(2_000);
+
+    await options.onopen(okResponse());
+
+    expect(options.onerror(new Error("blip"))).toBe(1_000);
+  });
+
+  it("forces a catch-up pull (via onSignal) on a *re*connect, but not on the first connection", async () => {
+    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
     const onSignal = vi.fn();
-    const cleanup = createSseTransport("/api/sync/events").subscribe(onSignal);
+    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
+    const options = captureOptions();
 
-    cleanup();
-
-    dispatch(
-      "sync_changed",
-      JSON.stringify({ type: "sync_changed", server_timestamp: "2026-05-01T00:00:00.000Z" }),
-    );
-
+    await options.onopen(okResponse());
     expect(onSignal).not.toHaveBeenCalled();
+
+    await options.onopen(okResponse());
+    expect(onSignal).toHaveBeenCalledTimes(1);
+    expect(onSignal).toHaveBeenCalledWith(expect.any(String));
+    expect(Number.isNaN(Date.parse(onSignal.mock.calls[0]![0] as string))).toBe(false);
+  });
+
+  it("aborts the underlying request when the cleanup function is called", () => {
+    let capturedSignal: AbortSignal | undefined;
+    fetchEventSourceMock.mockImplementation((_url: string, options: CapturedFetchEventSourceOptions) => {
+      capturedSignal = options.signal;
+      return new Promise(() => {});
+    });
+
+    const cleanup = createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
+
+    expect(capturedSignal?.aborted).toBe(false);
+    cleanup();
+    expect(capturedSignal?.aborted).toBe(true);
   });
 });

--- a/frontend/tests/hooks/useSyncSignal.test.ts
+++ b/frontend/tests/hooks/useSyncSignal.test.ts
@@ -4,13 +4,6 @@ import { createFetchSseTransport, useSyncSignal, type SyncSignalTransport } from
 import { storeSyncCursor } from "@/utils/syncClient";
 import { getSyncCursorKey } from "@/constants/storageKeys";
 
-const fetchEventSourceMock = vi.fn();
-
-vi.mock("@microsoft/fetch-event-source", () => ({
-  fetchEventSource: (...args: unknown[]) => fetchEventSourceMock(...args),
-  EventStreamContentType: "text/event-stream",
-}));
-
 /**
  * Create a mock transport that captures the onSignal callback so tests can
  * simulate server-push events.  Returns both the transport and a helper to
@@ -415,200 +408,262 @@ describe("useSyncSignal", () => {
 // ---------------------------------------------------------------------------
 // createFetchSseTransport — fetch-based SSE adapter unit tests
 //
-// @microsoft/fetch-event-source is mocked: its own frame-parsing is already
-// covered upstream, so these tests exercise our glue code by capturing the
-// options object passed to it and invoking the callbacks (onopen, onmessage,
-// onerror) directly, the same way the library would.
+// eventsource-parser's own frame-parsing is well-tested upstream, so these
+// tests exercise it for real (through a genuine ReadableStream) rather than
+// mocking it away — what's actually ours to verify is the fetch/auth/retry
+// orchestration around it. Fake timers drive the exponential-backoff retry
+// loop deterministically instead of waiting on real wall-clock time.
 // ---------------------------------------------------------------------------
 
-interface CapturedFetchEventSourceOptions {
-  headers?: Record<string, string>;
-  signal?: AbortSignal;
-  onopen: (response: Response) => Promise<void>;
-  onmessage: (event: { id: string; event: string; data: string; retry?: number }) => void;
-  onerror: (err: unknown) => number | undefined;
+/** Build one raw SSE wire-format frame. */
+function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
-function captureOptions(): CapturedFetchEventSourceOptions {
-  expect(fetchEventSourceMock).toHaveBeenCalledTimes(1);
-  return fetchEventSourceMock.mock.calls[0]![1] as CapturedFetchEventSourceOptions;
+/** A live SSE response body the test can push frames into (or close/error) on demand. */
+function sseController() {
+  let controllerRef: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef = controller;
+    },
+  });
+  const encoder = new TextEncoder();
+  return {
+    stream,
+    send(event: string, data: unknown) {
+      controllerRef.enqueue(encoder.encode(sseFrame(event, data)));
+    },
+    /** Push a raw, hand-written frame (e.g. deliberately malformed JSON). */
+    sendRaw(rawFrame: string) {
+      controllerRef.enqueue(encoder.encode(rawFrame));
+    },
+    close() {
+      controllerRef.close();
+    },
+  };
 }
 
-function okResponse(): Response {
-  return new Response(null, { status: 200, headers: { "content-type": "text/event-stream" } });
+function sseResponse(stream: ReadableStream<Uint8Array>, status = 200): Response {
+  return new Response(stream, { status, headers: { "content-type": "text/event-stream" } });
 }
 
 describe("createFetchSseTransport", () => {
   afterEach(() => {
-    fetchEventSourceMock.mockReset();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("opens the stream with the given URL and Authorization header", () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+  it("opens fetch with the given URL, Authorization, and Accept headers", async () => {
+    const fetchMock = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
+    vi.stubGlobal("fetch", fetchMock);
 
     createFetchSseTransport("https://api.example.com/sync/events", "token-abc").subscribe(vi.fn());
 
-    expect(fetchEventSourceMock).toHaveBeenCalledWith(
+    expect(fetchMock).toHaveBeenCalledWith(
       "https://api.example.com/sync/events",
-      expect.objectContaining({ headers: { Authorization: "Bearer token-abc" } }),
+      expect.objectContaining({
+        headers: { Authorization: "Bearer token-abc", Accept: "text/event-stream" },
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 
   it("calls onSignal with server_timestamp when a sync_changed event arrives", async () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+    const controller = sseController();
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse(controller.stream));
+    vi.stubGlobal("fetch", fetchMock);
 
     const onSignal = vi.fn();
     createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
-    const options = captureOptions();
 
-    options.onmessage({
-      id: "",
-      event: "sync_changed",
-      data: JSON.stringify({ type: "sync_changed", server_timestamp: "2026-03-01T12:00:00.000Z" }),
-    });
+    controller.send("sync_changed", { type: "sync_changed", server_timestamp: "2026-03-01T12:00:00.000Z" });
+    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledWith("2026-03-01T12:00:00.000Z"));
+  });
 
+  it("ignores events whose event name is not sync_changed", async () => {
+    const controller = sseController();
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse(controller.stream));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onSignal = vi.fn();
+    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
+
+    controller.send("keepalive", { irrelevant: true });
+    controller.send("sync_changed", { type: "sync_changed", server_timestamp: "2026-03-01T12:00:00.000Z" });
+    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledTimes(1));
     expect(onSignal).toHaveBeenCalledWith("2026-03-01T12:00:00.000Z");
   });
 
-  it("ignores events whose event name is not sync_changed", () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+  it("does not call onSignal when event data is missing server_timestamp", async () => {
+    const controller = sseController();
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse(controller.stream));
+    vi.stubGlobal("fetch", fetchMock);
 
     const onSignal = vi.fn();
     createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
-    const options = captureOptions();
 
-    options.onmessage({ id: "", event: "keepalive", data: "{}" });
+    controller.send("sync_changed", { type: "sync_changed" });
+    // Follow up with a well-formed event so there's something to waitFor —
+    // proves the first (bad) event was processed and skipped, not just
+    // "not processed yet".
+    controller.send("sync_changed", { type: "sync_changed", server_timestamp: "2026-03-01T12:00:00.000Z" });
 
-    expect(onSignal).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledTimes(1));
+    expect(onSignal).toHaveBeenCalledWith("2026-03-01T12:00:00.000Z");
   });
 
-  it("does not call onSignal when event data is missing server_timestamp", () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
-
-    const onSignal = vi.fn();
-    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
-    const options = captureOptions();
-
-    options.onmessage({ id: "", event: "sync_changed", data: JSON.stringify({ type: "sync_changed" }) });
-
-    expect(onSignal).not.toHaveBeenCalled();
-  });
-
-  it("does not throw and does not call onSignal when event data is malformed JSON", () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+  it("does not throw and does not call onSignal when event data is malformed JSON", async () => {
+    const controller = sseController();
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse(controller.stream));
+    vi.stubGlobal("fetch", fetchMock);
 
     const onSignal = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
-    const options = captureOptions();
 
-    options.onmessage({ id: "", event: "sync_changed", data: "not-json{{{" });
+    controller.sendRaw("event: sync_changed\ndata: not-json{{{\n\n");
+    // Follow up with a well-formed event so there's something to waitFor —
+    // proves the malformed one was processed (and skipped), not just "not
+    // processed yet".
+    controller.send("sync_changed", { type: "sync_changed", server_timestamp: "2026-05-01T00:00:00.000Z" });
 
-    expect(onSignal).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledTimes(1));
+    expect(onSignal).toHaveBeenCalledWith("2026-05-01T00:00:00.000Z");
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("failed to parse SSE event data"),
       "not-json{{{",
     );
   });
 
-  it("resolves onopen without throwing for a 200 text/event-stream response", async () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+  it("resolves onopen without scheduling a retry for a 200 text/event-stream response", async () => {
+    vi.useFakeTimers();
+    const controller = sseController();
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse(controller.stream));
+    vi.stubGlobal("fetch", fetchMock);
 
     createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
-    const options = captureOptions();
+    await vi.advanceTimersByTimeAsync(0);
 
-    await expect(options.onopen(okResponse())).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // still just the one open connection
   });
 
-  it("throws a fatal error from onopen on 401, and onerror rethrows it (stops retrying)", async () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
-
-    createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
-    const options = captureOptions();
+  it("gives up (no retry) on a 401, and does not hammer the endpoint", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    const unauthorized = new Response(null, { status: 401 });
-    await expect(options.onopen(unauthorized)).rejects.toThrow("SSE authentication failed: 401");
-
-    let caught: unknown;
-    try {
-      await options.onopen(unauthorized);
-    } catch (err) {
-      caught = err;
-    }
-    expect(() => options.onerror(caught)).toThrow();
-  });
-
-  it("throws a non-fatal error from onopen on other non-ok statuses", async () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
-
     createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
-    const options = captureOptions();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    await expect(options.onopen(new Response(null, { status: 503 }))).rejects.toThrow(
-      "SSE connection failed: 503",
-    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no retry scheduled
   });
 
-  it("onerror returns an increasing back-off interval for non-fatal errors, capped at the max", () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+  it("retries a non-auth failure with an increasing back-off interval", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "debug").mockImplementation(() => {});
 
     createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
-    const options = captureOptions();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    const first = options.onerror(new Error("network blip"));
-    const second = options.onerror(new Error("network blip"));
-    const third = options.onerror(new Error("network blip"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 1s -> 2nd attempt
 
-    expect(first).toBe(1_000);
-    expect(second).toBe(2_000);
-    expect(third).toBe(4_000);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 2s -> 3rd attempt
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(fetchMock).toHaveBeenCalledTimes(4); // 4s -> 4th attempt
   });
 
   it("resets the back-off interval after a successful reconnect", async () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
+    vi.useFakeTimers();
+    const controller = sseController();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 })) // 1st: fails
+      .mockResolvedValueOnce(sseResponse(controller.stream)) // 2nd: succeeds, stays open
+      .mockResolvedValue(new Response(null, { status: 503 })); // 3rd+: fails again
+    vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "debug").mockImplementation(() => {});
-
-    createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
-    const options = captureOptions();
-
-    options.onerror(new Error("blip"));
-    expect(options.onerror(new Error("blip"))).toBe(2_000);
-
-    await options.onopen(okResponse());
-
-    expect(options.onerror(new Error("blip"))).toBe(1_000);
-  });
-
-  it("forces a catch-up pull (via onSignal) on a *re*connect, but not on the first connection", async () => {
-    fetchEventSourceMock.mockReturnValue(new Promise(() => {}));
 
     const onSignal = vi.fn();
     createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
-    const options = captureOptions();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    await options.onopen(okResponse());
+    await vi.advanceTimersByTimeAsync(1_000); // 2nd attempt (succeeds)
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Close the now-open stream to trigger a reconnect — if back-off hadn't
+    // reset, the next attempt would be scheduled 2s out instead of 1s.
+    controller.close();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // not yet — under 1s
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // exactly 1s after the drop
+  });
+
+  it("forces a catch-up pull (via onSignal) on a *re*connect, but not on the first connection", async () => {
+    vi.useFakeTimers();
+    const first = sseController();
+    const second = sseController();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(sseResponse(first.stream))
+      .mockResolvedValueOnce(sseResponse(second.stream));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    const onSignal = vi.fn();
+    createFetchSseTransport("/api/sync/events", "token").subscribe(onSignal);
+    await vi.advanceTimersByTimeAsync(0);
     expect(onSignal).not.toHaveBeenCalled();
 
-    await options.onopen(okResponse());
+    first.close(); // drop -> reconnect
+    await vi.advanceTimersByTimeAsync(1_000);
+
     expect(onSignal).toHaveBeenCalledTimes(1);
-    expect(onSignal).toHaveBeenCalledWith(expect.any(String));
     expect(Number.isNaN(Date.parse(onSignal.mock.calls[0]![0] as string))).toBe(false);
   });
 
-  it("aborts the underlying request when the cleanup function is called", () => {
-    let capturedSignal: AbortSignal | undefined;
-    fetchEventSourceMock.mockImplementation((_url: string, options: CapturedFetchEventSourceOptions) => {
-      capturedSignal = options.signal;
-      return new Promise(() => {});
-    });
+  it("aborts the in-flight fetch when the cleanup function is called", async () => {
+    const fetchMock = vi.fn().mockReturnValue(new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
 
     const cleanup = createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
 
-    expect(capturedSignal?.aborted).toBe(false);
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
     cleanup();
-    expect(capturedSignal?.aborted).toBe(true);
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("does not schedule a retry after cleanup, even if the in-flight request then fails", async () => {
+    vi.useFakeTimers();
+    let rejectFetch: (err: unknown) => void;
+    const fetchMock = vi.fn().mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectFetch = reject;
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const cleanup = createFetchSseTransport("/api/sync/events", "token").subscribe(vi.fn());
+    cleanup();
+    rejectFetch!(new DOMException("aborted", "AbortError"));
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no reconnect attempt after cleanup
   });
 });

--- a/frontend/tests/utils/syncClient.test.ts
+++ b/frontend/tests/utils/syncClient.test.ts
@@ -14,6 +14,7 @@ import {
   fetchSyncStatus,
   getSyncOutboxSize,
   hasSyncCursor,
+  MAX_SYNC_PUSH_ITEMS,
   maxConflictServerTimestamp,
   pullSyncData,
   pushPreferences,
@@ -21,6 +22,7 @@ import {
   storeSyncCursor,
   syncStatusHasData,
   timeOffEntriesToSyncItems,
+  type SyncPushPayload,
 } from "@/utils/syncClient";
 import {
   getSyncCursorKey,
@@ -549,6 +551,85 @@ describe("syncClient", () => {
         templates: [],
         work_locations: [],
       });
+      expect(result).toBeNull();
+    });
+
+    it("splits oversized payloads into chunks and merges the results", async () => {
+      const taskCount = MAX_SYNC_PUSH_ITEMS + 5;
+      const tasks = Array.from({ length: taskCount }, (_, i) => ({
+        id: `task-${i}`,
+        action: "create",
+        client_updated_at: "2026-01-01T00:00:00Z",
+        text: `Task ${i}`,
+        start_time: "2026-01-01T09:00:00Z",
+      }));
+      const labels = [
+        {
+          id: "label-1",
+          action: "create",
+          client_updated_at: "2026-01-01T00:00:00Z",
+          name: "L",
+          color: "#000",
+        },
+      ];
+
+      mockFetch.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as SyncPushPayload;
+        const results: Record<string, { id: string; status: string }[]> = {};
+        for (const [key, items] of Object.entries(body)) {
+          if (Array.isArray(items) && items.length > 0) {
+            results[key] = items.map((item) => ({
+              id: "id" in item ? (item.id as string) : (item as { date: string }).date,
+              status: "ok",
+            }));
+          }
+        }
+        return { ok: true, json: async () => ({ results }) };
+      });
+
+      const result = await pushSyncPayload(mockFetch, {
+        ...emptyPayload(),
+        labels,
+        tasks,
+      } as SyncPushPayload);
+
+      // 1 label chunk + 2 task chunks (1000 + 5)
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      // Referenced entities (labels) are pushed before tasks.
+      const firstBody = JSON.parse(
+        String((mockFetch.mock.calls[0] as [string, RequestInit])[1]?.body),
+      ) as SyncPushPayload;
+      expect(firstBody.labels).toHaveLength(1);
+      expect(firstBody.tasks).toHaveLength(0);
+      // Each request stays within the server's per-list cap.
+      for (const call of mockFetch.mock.calls as [string, RequestInit][]) {
+        const body = JSON.parse(String(call[1]?.body)) as SyncPushPayload;
+        for (const items of Object.values(body)) {
+          expect((items as unknown[]).length).toBeLessThanOrEqual(MAX_SYNC_PUSH_ITEMS);
+        }
+      }
+      // Merged response contains every record's result.
+      expect(result!.results["tasks"]).toHaveLength(taskCount);
+      expect(result!.results["labels"]).toHaveLength(1);
+    });
+
+    it("returns null when any chunk of an oversized payload fails", async () => {
+      const tasks = Array.from({ length: MAX_SYNC_PUSH_ITEMS + 1 }, (_, i) => ({
+        id: `task-${i}`,
+        action: "create",
+        client_updated_at: "2026-01-01T00:00:00Z",
+        text: `Task ${i}`,
+        start_time: "2026-01-01T09:00:00Z",
+      }));
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ results: {} }) })
+        .mockResolvedValueOnce({ ok: false });
+
+      const result = await pushSyncPayload(mockFetch, {
+        ...emptyPayload(),
+        tasks,
+      } as SyncPushPayload);
       expect(result).toBeNull();
     });
   });
@@ -1373,6 +1454,31 @@ describe("syncClient", () => {
       expect(result!.merged.labels).toHaveLength(1);
       expect(result!.merged.work_locations).toHaveLength(1);
       expect(result!.merged.templates).toHaveLength(1);
+    });
+
+    it("coalesces duplicate record ids keeping the newest entry", () => {
+      appendToSyncOutbox("user-1", {
+        ...emptyPayload(),
+        tasks: [{ id: "task-A", text: "first edit" }],
+        work_locations: [{ date: "2026-01-01", country_code: "BE" }],
+      } as never);
+      appendToSyncOutbox("user-1", {
+        ...emptyPayload(),
+        tasks: [{ id: "task-A", text: "second edit" }, { id: "task-B" }],
+        work_locations: [{ date: "2026-01-01", country_code: "NL" }],
+      } as never);
+
+      const result = dequeueAndMergeSyncOutbox("user-1");
+      expect(result).not.toBeNull();
+      // task-A appears once, with the newest payload winning.
+      expect(result!.merged.tasks).toHaveLength(2);
+      const taskA = result!.merged.tasks.find((t) => t.id === "task-A");
+      expect((taskA as { text?: string }).text).toBe("second edit");
+      // Work locations coalesce by date.
+      expect(result!.merged.work_locations).toHaveLength(1);
+      expect((result!.merged.work_locations[0] as { country_code?: string }).country_code).toBe(
+        "NL",
+      );
     });
 
     it("skips corrupted/non-object outbox entries without throwing", () => {


### PR DESCRIPTION
## Summary

Fixes from a backend audit of user accounts, data integrity, syncing, MCP tool contracts, API scoping, and DB performance (originally tracked in #984/#985/#986, now closed with fixes landed here). Also closes #988, the two items from that audit deliberately deferred to a follow-up — trailing-slash standardization and confirming rate limiting/compression.

**Sync correctness**
- Pull cursor race that could permanently drop concurrent pushes — `server_timestamp` now reports with a small safety overlap
- Label-delete conflict loop caused by counting soft-deleted task/template references as active
- Silent revert of REST/MCP edits — every update path now bumps `client_updated_at`, which LWW conflict detection relies on
- `push_changes` now processes labels/gantt tasks before the tasks/templates that reference them, so a single first-sync batch with a gantt-linked task no longer 400s
- Work-location lookups hardened against legal duplicate soft-deleted rows (partial unique index) that could 500 an entire push batch
- Sync push batch size is capped server-side; the client transparently chunks oversized payloads instead of failing
- Offline outbox is coalesced by natural key before flushing
- `sync_changed` SSE broadcasting centralized into the service layer so MCP and REST writes notify connected clients, not just `/sync/push`

**Account safety**
- `POST /users/register` now requires admin auth (was public, enabling username squatting) and validates the username pattern
- OIDC auto-provisioning retries once on a concurrent username collision instead of failing the login with a 500
- `GET /users/by-username/{username}` returns 404 (not 403) for a foreign user, closing a username-enumeration oracle

**MCP server (closes #984)**
- Audit logging rewritten: never raises, rotates via `RotatingFileHandler`, dispatches writes to a background thread instead of blocking the event loop
- Corrected docstrings that misstated soft-deletes as hard deletes (`delete_time_tracking_task`, `delete_work_location`, `delete_gantt_task`)
- All 14 write tools now consistently map `ConflictError`/`NotFoundError`/`ValidationError` to `ValueError` via a shared decorator (previously only `delete_label` did this)
- `get_time_tracking_summary` defaults to a trailing 30-day window and `get_gantt_tasks` caps at 200 items, instead of returning a user's entire history into the model's context
- `update_time_tracking_task` gained `clear_stop_time`/`clear_label_id`; `get_next_shifts_for_team` uses a lightweight schedule-type lookup instead of building the full dashboard; integration key rotation documented

**API (closes #985)**
- `user_id` query param made optional on time-tracking/work-locations/gantt-tasks endpoints (falls back to the authenticated user, still validated when provided)
- `limit`/`offset` pagination (capped at 500) added to all six list endpoints

**Performance (closes #986)**
- `pool_pre_ping=True` so dead pooled connections after a Postgres restart are replaced transparently
- Composite `(user_id, updated_at)` indexes on all six synced tables, `(user_id, start_time)` on tasks — migration `003_composite_sync_indexes.py`
- `get_sync_status` collapsed from 7 sequential queries into one `UNION ALL`
- OIDC JWKS cache now also refreshes hourly in the background, in addition to the existing reactive refresh-on-miss

**API hygiene (closes #988)**
- `work-locations` and `time-off` collection routes standardized on no trailing slash, matching `gantt-tasks`/`time-tracking` (was masked by FastAPI's `redirect_slashes`, but each mismatch cost a 307 round-trip). Updated the MSW mock and hardcoded test URLs that assumed the old form.
- Compression: confirmed neither Caddy nor FastAPI was doing it — `encode gzip zstd` added to the `worktime.tjor.im` block in the infra repo's Caddyfile (applied separately, outside this repo).
- Rate limiting: confirmed missing at both layers. `caddy-ratelimit` is a third-party module and the infra repo pins the stock `caddy:2` image (no xcaddy build), so enabling it there would mean introducing a custom image build — out of scope for this fix. Added `slowapi` as ASGI middleware instead (`backend/app/middleware/rate_limit.py`), default `200/minute` per client IP, configurable via `RATE_LIMIT_ENABLED`/`RATE_LIMIT_DEFAULT`:
  - In-memory backend is safe here because `backend/Dockerfile` runs uvicorn with no `--workers` flag (single process, so there's no cross-worker counter split to worry about).
  - Keys by the `X-Real-IP` header Caddy sets, not `request.client.host` — behind the reverse proxy that would otherwise be Caddy's own container address for every request, collapsing all real clients into one bucket.
  - `/api/health/liveness` and `/api/health/readiness` are exempted so infra probes are never affected.

**Review follow-ups & platform parity**
- Rate limiter's `X-Real-IP` trust hardened after automated review (greptile-apps): only honored when the immediate TCP peer is a private-network address, so a caller that ever reaches the process some other way than through Caddy can't spoof a fresh rate-limit bucket per request.
- `backend/docker-compose.yml`'s dev Postgres volume mount fixed for Postgres 18's new layout (`/var/lib/postgresql`, not `.../data` — the image now hard-refuses the old path even on an empty volume).
- Android's `WorktimeApi.kt` updated to match the trailing-slash change (`api/work-locations`/`api/time-off`, no trailing slash) — the old paths kept working via FastAPI's 307 redirect either way, this just drops the extra round-trip.

**Production sync audit (found directly on the VPS — prod logs, live schema, live endpoint behavior)**

Two were live production bugs, not just theoretical:
- **SSE live sync was completely non-functional in production.** `GET /api/sync/events` requires `Authorization: Bearer`, but the frontend connected via native `EventSource` with `withCredentials: true` (cookies only — `EventSource` still cannot send custom headers at all; [whatwg/html#2177](https://github.com/whatwg/html/issues/2177) has been open since 2016 — and the backend has no cookie auth). Confirmed against `worktime.tjor.im` directly: 401 with or without cookies. Per spec a non-200 SSE response never auto-retries, so every session got exactly one silent failure and no live channel afterward — cross-device updates only ever arrived on tab-focus/online/reconnect. Replaced with a `fetch()`-based transport that can carry the Bearer token: `eventsource-parser` handles just the wire-format parsing (~54M weekly downloads via being a dependency of Vercel's AI SDK, actively maintained, zero deps of its own — the initial fix used `@microsoft/fetch-event-source`, whose last real release was April 2021; swapped out in a follow-up commit after review), with the fetch call, headers, and retry/backoff loop hand-rolled directly in `useSyncSignal.ts`. Also closes a related gap where a `sync_changed` notification fired while disconnected was permanently lost (server's per-connection queue doesn't survive a drop) — reconnects now force a catch-up pull.
- **A successful push could permanently skip a concurrent change from another device.** The no-conflict success path advanced the sync cursor from a bare status timestamp instead of an actual pull — any record from another device landing in that window was silently dropped forever. With SSE actually working now, two devices editing around the same time will reliably hit this without the fix.

Plus, found while reading the sync internals closely:
- Sync push had no equivalent of the REST label-name uniqueness check — a same-name collision hit an uncaught `IntegrityError` at commit, 500ing (and, since the outbox retries forever, permanently wedging) the *entire* batch, not just that record.
- A task/template referencing a deleted-elsewhere `gantt_task_id` raised `NotFoundError`, which the push endpoint didn't catch (only `ValidationError`) — another unhandled 500, for a plausible everyday multi-device race.
- A client-generated UUID colliding with another user's record id 400'd the whole batch and doubled as a low-value id-ownership oracle; now a per-record conflict like an ordinary stale update.
- `client_updated_at` was trusted verbatim — a device with a badly wrong clock would win every future LWW comparison forever, including against its own later correction. Now clamped to ≤5 minutes ahead of the server's clock.
- Sync push had no `stop_time >= start_time` check (REST's `create_task` does); a client could push a negative-duration task.
- The outbox's exponential back-off only ever *gated* passive triggers (visibility/online) — nothing scheduled a retry when the window elapsed, so a tab left open and idle could stay unsynced indefinitely.

## Test plan

- [x] `uv run ruff check app tests` — clean
- [x] `uv run ty check app` — clean
- [x] `pnpm typecheck` / `pnpm lint` — clean
- [x] `pnpm vitest run tests/utils/syncClient.test.ts` — 91 passed
- [x] Full backend suite against a live Postgres instance, including the Alembic migration upgrade check — ran in CI (Backend CI job), all green
- [x] Frontend Test & Build — ran in CI, all green
- [x] `uv run pytest` (full suite, live Postgres, after every commit above) — 708 passed, 55 skipped
- [x] `pnpm vitest run` (full suite, after every commit above) — 1547 passed
- [x] `pnpm build` — clean, no bundling issues from the new `eventsource-parser` dependency
- [x] SSE auth fix verified directly against `worktime.tjor.im` before and after (401 confirmed broken; fix verified locally against a live backend + curl for the underlying redirect/auth mechanics)
- [ ] Caddyfile `encode gzip zstd` change in the infra repo still needs to be committed/applied there separately (out of scope for this repo)
- [ ] Android build not verified (no JDK in this environment) — the trailing-slash change is a literal two-string edit with no other code depending on the old value

🤖 Generated with [Claude Code](https://claude.com/claude-code)


