### PR TITLE
API: standardize trailing slashes, add rate limiting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -187,3 +187,15 @@ OIDC_ALGORITHMS=RS256
 # Tokens expire after 60 seconds to prevent replay attacks.
 #
 METRICS_HMAC_SECRET=
+
+# -----------------------------------------------------------------------------
+# Rate Limiting
+# -----------------------------------------------------------------------------
+# Per-client-IP rate limit applied to every /api route (health probes are
+# exempt). Set RATE_LIMIT_ENABLED=false to disable entirely.
+#
+# RATE_LIMIT_DEFAULT uses the flask-limiter/slowapi rate string format, e.g.
+# "200/minute", "10/second", "5000/hour".
+#
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_DEFAULT=200/minute

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -78,6 +78,11 @@ class Settings(BaseSettings):
     # OIDC_ALGORITHMS: Comma-separated list of accepted signing algorithms
     OIDC_ALGORITHMS: str = "RS256"
 
+    # Per-client-IP rate limiting (slowapi). RATE_LIMIT_DEFAULT applies to every
+    # /api route unless explicitly exempted (e.g. health probes).
+    RATE_LIMIT_ENABLED: bool = True
+    RATE_LIMIT_DEFAULT: str = "200/minute"
+
     @field_validator("DATABASE_URL")
     @classmethod
     def validate_database_url(cls, v: str) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,11 +15,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from fastmcp.utilities.lifespan import combine_lifespans
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 from .cache.warm_cache import warm_cache
 from .config import settings
 from .config.cors import get_cors_origins
 from .database import init_db
+from .middleware.rate_limit import handle_rate_limit_exceeded, limiter
 from .middleware.request_id import RequestIdMiddleware
 from .middleware.timing import TimingMiddleware
 from .routers.auth import router as auth_router
@@ -209,6 +212,17 @@ if _mcp_app is not None:
     app.add_middleware(_MCPAwareCORSMiddleware, **_cors_kwargs)
 else:
     app.add_middleware(CORSMiddleware, **_cors_kwargs)
+
+# Per-client-IP rate limiting. `limiter.enabled` (RATE_LIMIT_ENABLED) gates
+# actual enforcement; the middleware is always registered so a 429 still gets
+# a request ID, timing header, and access-log entry like any other response.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, handle_rate_limit_exceeded)
+app.add_middleware(SlowAPIMiddleware)
+if settings.RATE_LIMIT_ENABLED:
+    logger.info(f"✓ Rate limiting enabled ({settings.RATE_LIMIT_DEFAULT} per client IP)")
+else:
+    logger.info("Rate limiting disabled (RATE_LIMIT_ENABLED=false)")
 
 # TimingMiddleware records metrics and sets X-Total-Ms.
 app.add_middleware(TimingMiddleware)

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -1,0 +1,47 @@
+"""Per-client-IP rate limiting for the public API, via slowapi."""
+
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from starlette.requests import Request
+from starlette.responses import Response
+
+from ..config import settings
+
+
+def get_client_ip(request: Request) -> str:
+    """Return the client IP, preferring the ``X-Real-IP`` header set by Caddy.
+
+    slowapi's built-in key functions read either ``request.client.host`` (the
+    reverse proxy's own address behind Caddy, which would bucket every real
+    client together) or a malformed ``X-Forwarded-For`` lookup. Caddy already
+    resolves the true client IP (trusting Cloudflare's edge) and forwards it
+    via ``X-Real-IP``, so prefer that and fall back to ``request.client.host``
+    for local development without a proxy in front.
+    """
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+limiter = Limiter(
+    key_func=get_client_ip,
+    default_limits=[settings.RATE_LIMIT_DEFAULT],
+    enabled=settings.RATE_LIMIT_ENABLED,
+    headers_enabled=True,
+)
+
+
+def handle_rate_limit_exceeded(request: Request, exc: Exception) -> Response:
+    """Adapt slowapi's handler to Starlette's ``ExceptionHandler`` signature.
+
+    ``app.add_exception_handler`` types the handler's second parameter as the
+    base ``Exception``, while slowapi's own handler narrows it to
+    ``RateLimitExceeded``. Starlette only invokes this for that registered
+    exception type, so the isinstance check just satisfies the type checker.
+    """
+    if not isinstance(exc, RateLimitExceeded):
+        raise exc
+    return _rate_limit_exceeded_handler(request, exc)

--- a/backend/app/routers/db_time_off.py
+++ b/backend/app/routers/db_time_off.py
@@ -30,7 +30,7 @@ from app.utils.timing import time_operation
 router = APIRouter(prefix="/time-off", tags=["Time Off"])
 
 
-@router.post("/", response_model=TimeOffEntryRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=TimeOffEntryRead, status_code=status.HTTP_201_CREATED)
 async def create_or_update_time_off_endpoint(
     payload: TimeOffEntryCreate,
     authenticated_user_id: int = Depends(get_authenticated_user_id),
@@ -44,7 +44,7 @@ async def create_or_update_time_off_endpoint(
     )
 
 
-@router.get("/", response_model=TimeOffEntryListResponse)
+@router.get("", response_model=TimeOffEntryListResponse)
 async def list_time_off_entries_endpoint(
     authenticated_user_id: int = Depends(get_authenticated_user_id),
     start_date: date | None = None,

--- a/backend/app/routers/db_work_locations.py
+++ b/backend/app/routers/db_work_locations.py
@@ -28,7 +28,7 @@ from app.utils.timing import time_operation
 router = APIRouter(prefix="/work-locations", tags=["Work Locations"])
 
 
-@router.post("/", response_model=WorkLocationRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=WorkLocationRead, status_code=status.HTTP_201_CREATED)
 async def create_or_update_work_location_endpoint(
     payload: WorkLocationCreate,
     user_id: int = Query(..., ge=1),
@@ -47,7 +47,7 @@ async def create_or_update_work_location_endpoint(
     return WorkLocationRead.model_validate(location, from_attributes=True)
 
 
-@router.get("/", response_model=WorkLocationListResponse)
+@router.get("", response_model=WorkLocationListResponse)
 async def list_work_locations_endpoint(
     user_id: int = Query(..., ge=1),
     authenticated_user_id: int = Depends(get_authenticated_user_id),

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..config import settings
 from ..config.oidc_config import OIDCTokenError, _resolve_jwks_uri
 from ..database.engine import get_session
+from ..middleware.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ async def _jwks_reachable() -> bool:
 
 
 @router.get("/health/liveness")
+@limiter.exempt
 async def liveness() -> JSONResponse:
     """Liveness probe — returns 200 immediately with no external I/O.
 
@@ -90,6 +92,7 @@ async def liveness() -> JSONResponse:
 
 
 @router.get("/health/readiness")
+@limiter.exempt
 async def readiness(
     db: Annotated[AsyncSession | None, Depends(_get_db_if_enabled)],
 ) -> JSONResponse:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "python-dotenv==1.2.2",
   "sqlalchemy==2.0.51",
   "uvicorn[standard]==0.51.0",
+  "slowapi==0.1.10",
 ]
 
 [dependency-groups]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -69,6 +69,17 @@ def reset_cache() -> Generator[None, None, None]:
     yield
 
 
+@pytest.fixture(autouse=True)
+def reset_rate_limiter() -> Generator[None, None, None]:
+    """Clear the rate limiter's in-memory storage before each test.
+
+    TestClient requests all share the same client IP, so without this every
+    test in the suite would draw down the same RATE_LIMIT_DEFAULT bucket.
+    """
+    app.state.limiter.reset()
+    yield
+
+
 @pytest_asyncio.fixture(scope="session")
 async def _schema_engine() -> AsyncGenerator[AsyncEngine, None]:
     """Session-scoped engine: create schema once, drop it after all tests."""

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -26,6 +26,8 @@ def test_default_settings():
     assert settings.OIDC_ISSUER_URL == "http://localhost:9000/application/o/worktime"
     assert settings.OIDC_AUDIENCE == ""
     assert settings.OIDC_ALGORITHMS == "RS256"
+    assert settings.RATE_LIMIT_ENABLED is True
+    assert settings.RATE_LIMIT_DEFAULT == "200/minute"
 
 
 def test_custom_settings():

--- a/backend/tests/test_db_api_endpoints.py
+++ b/backend/tests/test_db_api_endpoints.py
@@ -443,11 +443,11 @@ def test_work_location_endpoints_require_auth_and_user_match(db_client: TestClie
         headers=admin_headers,
     ).json()["id"]
 
-    unauthenticated = client.get(f"/api/work-locations/?user_id={owner_id}")
+    unauthenticated = client.get(f"/api/work-locations?user_id={owner_id}")
     assert unauthenticated.status_code == 401
 
     forbidden = client.get(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         headers=_auth_headers(other_id),
     )
     assert forbidden.status_code == 403
@@ -465,7 +465,7 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     headers = _auth_headers(user_id)
 
     create_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-01-02", "country_code": "nl", "label": "Home"},
         headers=headers,
     )
@@ -473,7 +473,7 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     assert create_response.json()["country_code"] == "NL"
 
     update_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-01-02", "country_code": "BE", "label": "Client"},
         headers=headers,
     )
@@ -481,7 +481,7 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     assert update_response.json()["label"] == "Client"
 
     list_response = client.get(
-        f"/api/work-locations/?user_id={user_id}&start_date=2026-01-01&end_date=2026-01-03",
+        f"/api/work-locations?user_id={user_id}&start_date=2026-01-01&end_date=2026-01-03",
         headers=headers,
     )
     assert list_response.status_code == 200
@@ -508,14 +508,14 @@ def test_work_location_endpoints(db_client: TestClient) -> None:
     assert missing_response.status_code == 404
 
     invalid_country_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-01-03", "country_code": "ZZ", "label": None},
         headers=headers,
     )
     assert invalid_country_response.status_code == 422
 
     missing_body_response = client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         headers=headers,
     )
     assert missing_body_response.status_code == 422

--- a/backend/tests/test_db_time_off.py
+++ b/backend/tests/test_db_time_off.py
@@ -13,7 +13,7 @@ def _create_entry(
     payload: dict | None = None,
 ) -> dict:
     response = client.post(
-        "/api/time-off/",
+        "/api/time-off",
         json=payload or {"date": "2026-06-01", "entry_type": "vacation"},
         headers=headers,
     )
@@ -23,11 +23,11 @@ def _create_entry(
 
 class TestTimeOffAuth:
     def test_list_requires_auth(self, db_client: TestClient) -> None:
-        assert db_client.get("/api/time-off/").status_code == 401
+        assert db_client.get("/api/time-off").status_code == 401
 
     def test_create_requires_auth(self, db_client: TestClient) -> None:
         assert db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-06-01", "entry_type": "vacation"},
         ).status_code == 401
 
@@ -76,7 +76,7 @@ class TestCreateTimeOff:
         headers = auth_headers(user_id)
 
         resp = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-07-14", "entry_type": "vacation", "entry_flag": "half_am", "note": "summer"},
             headers=headers,
         )
@@ -104,14 +104,14 @@ class TestCreateTimeOff:
         entry_id = "timeoff-upsert-1"
 
         first = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"entry_id": entry_id, "date": "2026-08-01", "entry_type": "vacation"},
             headers=headers,
         )
         assert first.status_code == 201
 
         second = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={
                 "entry_id": entry_id,
                 "entry_kind": "range",
@@ -148,7 +148,7 @@ class TestTimeOffValidation:
         headers = auth_headers(user_id)
 
         resp = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-07-14", "entry_type": "sick"},
             headers=headers,
         )
@@ -165,7 +165,7 @@ class TestTimeOffValidation:
         headers = auth_headers(user_id)
 
         resp = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"date": "2026-07-14", "entry_type": "vacation", "entry_flag": "unknown_flag"},
             headers=headers,
         )
@@ -183,7 +183,7 @@ class TestListTimeOff:
         user_id = create_user_factory(db_client, admin_h, "to-list-empty")
         headers = auth_headers(user_id)
 
-        resp = db_client.get("/api/time-off/", headers=headers)
+        resp = db_client.get("/api/time-off", headers=headers)
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
         assert resp.json()["items"] == []
@@ -210,7 +210,7 @@ class TestListTimeOff:
             {"entry_kind": "weekly", "weekday": 1, "entry_type": "in", "note": "Mondays"},
         )
 
-        resp = db_client.get("/api/time-off/", headers=headers)
+        resp = db_client.get("/api/time-off", headers=headers)
         assert resp.status_code == 200
         assert resp.json()["total"] == 3
 
@@ -234,7 +234,7 @@ class TestListTimeOff:
         _create_entry(db_client, headers, {"date": "2026-06-20", "entry_type": "vacation"})
 
         resp = db_client.get(
-            "/api/time-off/?start_date=2026-06-10&end_date=2026-06-15",
+            "/api/time-off?start_date=2026-06-10&end_date=2026-06-15",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -255,7 +255,7 @@ class TestListTimeOff:
 
         _create_entry(db_client, headers_a, {"date": "2026-07-01", "entry_type": "vacation"})
 
-        resp = db_client.get("/api/time-off/", headers=headers_b)
+        resp = db_client.get("/api/time-off", headers=headers_b)
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
 
@@ -296,7 +296,7 @@ class TestGetPatchDeleteTimeOff:
         delete_resp = db_client.delete(f"/api/time-off/{entry_id}", headers=headers)
         assert delete_resp.status_code == 204
 
-        list_resp = db_client.get("/api/time-off/", headers=headers)
+        list_resp = db_client.get("/api/time-off", headers=headers)
         assert list_resp.json()["total"] == 0
 
     def test_returns_404_when_entry_is_missing(
@@ -336,7 +336,7 @@ class TestGetPatchDeleteTimeOff:
         assert db_client.delete(f"/api/time-off/{entry_id}", headers=headers).status_code == 204
 
         recreate = db_client.post(
-            "/api/time-off/",
+            "/api/time-off",
             json={"entry_id": entry_id, "date": "2026-11-11", "entry_type": "ill"},
             headers=headers,
         )

--- a/backend/tests/test_db_work_locations.py
+++ b/backend/tests/test_db_work_locations.py
@@ -20,14 +20,14 @@ def test_work_location_upsert_and_filtering(
     other_headers = auth_headers(other_id)
 
     first_create = db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-01", "country_code": "nl", "label": "Home"},
         headers=owner_headers,
     )
     assert first_create.status_code == 201
 
     upsert_update = db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-01", "country_code": "BE", "label": "Client office"},
         headers=owner_headers,
     )
@@ -37,14 +37,14 @@ def test_work_location_upsert_and_filtering(
     assert upsert_update.json()["label"] == "Client office"
 
     other_user_location = db_client.post(
-        f"/api/work-locations/?user_id={other_id}",
+        f"/api/work-locations?user_id={other_id}",
         json={"date": "2026-02-01", "country_code": "DE", "label": "HQ"},
         headers=other_headers,
     )
     assert other_user_location.status_code == 201
 
     owner_filtered = db_client.get(
-        f"/api/work-locations/?user_id={owner_id}&start_date=2026-02-01&end_date=2026-02-01",
+        f"/api/work-locations?user_id={owner_id}&start_date=2026-02-01&end_date=2026-02-01",
         headers=owner_headers,
     )
     assert owner_filtered.status_code == 200
@@ -52,7 +52,7 @@ def test_work_location_upsert_and_filtering(
     assert owner_filtered.json()["items"][0]["date"] == "2026-02-01"
 
     owner_out_of_range = db_client.get(
-        f"/api/work-locations/?user_id={owner_id}&start_date=2026-02-02&end_date=2026-02-03",
+        f"/api/work-locations?user_id={owner_id}&start_date=2026-02-02&end_date=2026-02-03",
         headers=owner_headers,
     )
     assert owner_out_of_range.status_code == 200
@@ -69,7 +69,7 @@ def test_work_location_country_code_validation(
     headers = auth_headers(user_id)
 
     invalid_country_code = db_client.post(
-        f"/api/work-locations/?user_id={user_id}",
+        f"/api/work-locations?user_id={user_id}",
         json={"date": "2026-02-02", "country_code": "ZZ", "label": "Unknown"},
         headers=headers,
     )
@@ -89,7 +89,7 @@ def test_cross_user_cannot_read_modify_or_delete_work_locations(
     other_headers = auth_headers(other_id)
 
     create_response = db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-05", "country_code": "NL", "label": "Home"},
         headers=owner_headers,
     )
@@ -100,7 +100,7 @@ def test_cross_user_cannot_read_modify_or_delete_work_locations(
         headers=other_headers,
     ).status_code == 403
     assert db_client.post(
-        f"/api/work-locations/?user_id={owner_id}",
+        f"/api/work-locations?user_id={owner_id}",
         json={"date": "2026-02-05", "country_code": "BE", "label": "Office"},
         headers=other_headers,
     ).status_code == 403

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,90 @@
+"""Tests for the per-client-IP rate limiting middleware (app.middleware.rate_limit)."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from starlette.requests import Request
+
+from app.middleware.rate_limit import get_client_ip, handle_rate_limit_exceeded
+
+
+def _build_app(*, limit: str = "2/minute", enabled: bool = True) -> FastAPI:
+    """Build a throwaway app wired the same way as the real one, but with a tiny limit."""
+    limiter = Limiter(key_func=get_client_ip, default_limits=[limit], enabled=enabled)
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, handle_rate_limit_exceeded)
+    app.add_middleware(SlowAPIMiddleware)
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    @app.get("/health")
+    @limiter.exempt
+    async def health():
+        return {"ok": True}
+
+    return app
+
+
+def test_requests_within_limit_succeed():
+    client = TestClient(_build_app())
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+
+
+def test_requests_over_limit_are_rejected_with_429():
+    client = TestClient(_build_app())
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+
+    response = client.get("/ping")
+
+    assert response.status_code == 429
+    assert "Rate limit exceeded" in response.json()["error"]
+
+
+def test_exempt_route_is_never_limited():
+    client = TestClient(_build_app())
+    for _ in range(5):
+        assert client.get("/health").status_code == 200
+
+
+def test_disabled_limiter_never_rejects():
+    client = TestClient(_build_app(enabled=False))
+    for _ in range(5):
+        assert client.get("/ping").status_code == 200
+
+
+def test_different_client_ips_get_independent_buckets():
+    client = TestClient(_build_app())
+    assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 200
+    assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 200
+    assert client.get("/ping", headers={"X-Real-IP": "1.1.1.1"}).status_code == 429
+
+    # A different client IP draws from its own, untouched bucket.
+    assert client.get("/ping", headers={"X-Real-IP": "2.2.2.2"}).status_code == 200
+
+
+def test_get_client_ip_prefers_x_real_ip_header():
+    """Behind Caddy, request.client.host is Caddy's own address, not the real client's."""
+    scope = {
+        "type": "http",
+        "headers": [(b"x-real-ip", b"9.9.9.9")],
+        "client": ("127.0.0.1", 12345),
+    }
+    request = Request(scope)
+
+    assert get_client_ip(request) == "9.9.9.9"
+
+
+def test_get_client_ip_falls_back_to_request_client():
+    scope = {"type": "http", "headers": [], "client": ("10.0.0.5", 12345)}
+    request = Request(scope)
+
+    assert get_client_ip(request) == "10.0.0.5"

--- a/backend/tests/test_read_models.py
+++ b/backend/tests/test_read_models.py
@@ -52,7 +52,7 @@ def test_dashboard_returns_reusable_read_models(
     _seed_work_context(db_client, headers, schedule_type="5-shift", team_number=1)
 
     first_time_off = db_client.post(
-        "/api/time-off/",
+        "/api/time-off",
         json={
             "entry_id": "summer-trip",
             "entry_kind": "date",
@@ -66,7 +66,7 @@ def test_dashboard_returns_reusable_read_models(
     assert first_time_off.status_code == 201, first_time_off.text
 
     second_time_off = db_client.post(
-        "/api/time-off/",
+        "/api/time-off",
         json={
             "entry_id": "training-week",
             "entry_kind": "range",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -322,6 +322,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -727,6 +739,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1457,6 +1483,18 @@ fastapi = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -1798,6 +1836,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
+    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1826,6 +1865,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "slowapi", specifier = "==0.1.10" },
     { name = "sqlalchemy", specifier = "==2.0.51" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
 ]
@@ -1839,4 +1879,68 @@ dev = [
     { name = "ruff", specifier = "==0.15.22" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.66.0" },
     { name = "ty", specifier = "==0.0.60" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/frontend/src/mocks/handlers/workLocations.ts
+++ b/frontend/src/mocks/handlers/workLocations.ts
@@ -16,7 +16,7 @@ export const workLocationHandlers = [
     });
   }),
 
-  http.post("*/api/work-locations/", async ({ request }) => {
+  http.post("*/api/work-locations", async ({ request }) => {
     const authFailure = buildAuthFailureResponse();
     if (authFailure) return authFailure;
     const scenario = getMockScenario();


### PR DESCRIPTION
## Summary

Closes #988 (both findings, split as it turned out to be more nuanced than "confirm and standardize"):

**Trailing-slash standardization**
- `work-locations` and `time-off` registered their collection routes with a trailing slash (`@router.post("/")`) while `gantt-tasks`/`time-tracking` didn't. FastAPI's `redirect_slashes` masked this (307 instead of a hard failure), but every mismatch was a wasted round-trip.
- Standardized on **no trailing slash**, matching the more recently added routers. Updated the MSW mock in `frontend/src/mocks/handlers/workLocations.ts` and the hardcoded test URLs that assumed the old form.

**Compression & rate limiting** — neither was confirmed at the Caddy or FastAPI layer:
- Compression: added `encode gzip zstd` to the `worktime.tjor.im` block in the infra repo's Caddyfile (`/opt/apps/infra`, outside this repo — not part of this diff, applied there separately). Core Caddy directive, no image rebuild needed.
- Rate limiting: `caddy-ratelimit` is a third-party Caddy module and the infra repo pins the stock `caddy:2` image (no xcaddy build), so enabling it in Caddy would mean introducing a custom image build — out of scope for a low-priority hardening issue. Added `slowapi` as ASGI middleware instead (`backend/app/middleware/rate_limit.py`), default `200/minute` per client IP:
  - In-memory backend is safe here because `backend/Dockerfile` runs uvicorn with no `--workers` flag (single process — no cross-worker counter split).
  - Keys by the `X-Real-IP` header Caddy sets, not `request.client.host` — behind the reverse proxy that would otherwise be Caddy's own container address for every request, collapsing all real clients into one bucket.
  - `/api/health/liveness` and `/api/health/readiness` are exempted so infra probes are never affected.
  - Configurable via `RATE_LIMIT_ENABLED` / `RATE_LIMIT_DEFAULT`.

## Test plan

- [x] `uv run ruff check app tests` — clean
- [x] `uv run ty check app` — clean
- [x] `uv run pytest` (full suite, live Postgres) — 676 passed, 55 skipped
- [x] `pnpm typecheck` / `pnpm lint` — clean
- [x] `pnpm vitest run` (full suite) — 1536 passed
- [ ] Caddyfile `encode gzip zstd` change in the infra repo still needs to be committed/applied there separately (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)