### PR TITLE
Potential fix for code scanning alert no. 120: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/android/app/src/main/java/com/worktime/android/core/auth/BiometricAuthenticator.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/BiometricAuthenticator.kt
@@ -113,6 +113,6 @@ class BiometricAuthenticator(private val activity: FragmentActivity) {
         const val KEYSTORE_PROVIDER = "AndroidKeyStore"
         const val KEY_ALIAS = "worktime_biometric_gate_key"
         const val TRANSFORMATION =
-            "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_CBC}/${KeyProperties.ENCRYPTION_PADDING_PKCS7}"
+            "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_GCM}/${KeyProperties.ENCRYPTION_PADDING_NONE}"
     }
 }

--- a/android/app/src/main/java/com/worktime/android/core/auth/BiometricAuthenticator.kt
+++ b/android/app/src/main/java/com/worktime/android/core/auth/BiometricAuthenticator.kt
@@ -100,8 +100,8 @@ class BiometricAuthenticator(private val activity: FragmentActivity) {
         val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER)
         val spec =
             KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
-                .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .setUserAuthenticationRequired(true)
                 .setInvalidatedByBiometricEnrollment(true)
                 .build()


### PR DESCRIPTION
Potential fix for [https://github.com/tjorim/worktime/security/code-scanning/120](https://github.com/tjorim/worktime/security/code-scanning/120)

Use AES-GCM instead of AES-CBC-PKCS7 for the biometric auth cipher transformation.

Best minimal fix in this file:
- Update the `TRANSFORMATION` constant in `android/app/src/main/java/com/worktime/android/core/auth/BiometricAuthenticator.kt` to:
  - `AES/GCM/NoPadding` via `KeyProperties.BLOCK_MODE_GCM` and `KeyProperties.ENCRYPTION_PADDING_NONE`.
- Keep key algorithm (`AES`), keystore provider, alias, and existing flow unchanged.
- No additional methods/imports are required because `KeyProperties` already provides the needed constants.

This preserves behavior (crypto-backed biometric prompt) while removing the risky mode/padding combination flagged by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
