### PR TITLE
Adopt DB_PASSWORD_FILE secret pattern and TrustedHostMiddleware

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -90,6 +90,23 @@ SHARE_DIR=./data/hday_files
 CORS_ORIGINS=http://localhost:5173
 
 # -----------------------------------------------------------------------------
+# Trusted Hosts Configuration
+# -----------------------------------------------------------------------------
+# Validates the incoming Host header (TrustedHostMiddleware) to guard against
+# Host header attacks (e.g. cache poisoning, password-reset link spoofing).
+#
+# Format: Comma-separated list of allowed hostnames (no scheme/port), e.g.
+#   TRUSTED_HOSTS=worktime.tjor.im
+#
+# Development:
+#   - "*" (default) disables validation entirely
+#
+# Production:
+#   - MUST set explicit hostname(s) matching the domain(s) this API is served on
+#
+TRUSTED_HOSTS=*
+
+# -----------------------------------------------------------------------------
 # Cache Configuration
 # -----------------------------------------------------------------------------
 # Controls caching behavior for file system operations and API responses.
@@ -116,7 +133,9 @@ CACHE_TTL=10
 #   - true: Initialize database at startup
 #   - false: Skip DB initialization (for phased rollouts or troubleshooting)
 #
-# DATABASE_URL: PostgreSQL connection URL (async asyncpg driver)
+# DATABASE_URL: full PostgreSQL connection URL (async asyncpg driver) override.
+#   Kept for local dev convenience — when set, it takes precedence over the
+#   DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD(_FILE) fields below.
 #   - Format: postgresql+asyncpg://user:password@host:port/dbname
 #   - Example (local dev): postgresql+asyncpg://worktime:worktime@localhost/worktime
 #   - Example (Docker):    postgresql+asyncpg://worktime:worktime@db/worktime
@@ -128,12 +147,22 @@ CACHE_TTL=10
 # DATABASE_POOL_SIZE: Number of persistent connections in the pool (default: 5)
 # DATABASE_POOL_MAX_OVERFLOW: Extra connections allowed beyond pool size (default: 10)
 #
+# DB_HOST / DB_PORT / DB_NAME / DB_USER / DB_PASSWORD / DB_PASSWORD_FILE:
+#   Preferred production alternative to DATABASE_URL. The connection URL is
+#   built from these fields when DATABASE_URL is unset. Set DB_PASSWORD_FILE
+#   to the path of a Docker/Compose secret file so the actual password never
+#   sits in a plaintext env file; DB_PASSWORD_FILE takes precedence over
+#   DB_PASSWORD when both are set.
+#
 DATABASE_ENABLED=true
 # Local dev (matches docker-compose.yml) — change before using in production:
 # DATABASE_URL=postgresql+asyncpg://worktime:worktime@localhost/worktime
-# Production (dedicated user — credentials managed in infra repo):
-# DATABASE_URL=postgresql+asyncpg://worktime_user:CHANGE_ME@postgres:5432/worktime
 DATABASE_ECHO=false
+# DB_HOST=postgres
+# DB_PORT=5432
+# DB_NAME=worktime
+# DB_USER=worktime_user
+# DB_PASSWORD_FILE=/run/secrets/worktime_db_password
 
 # -----------------------------------------------------------------------------
 # Authentication (OIDC)

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -253,9 +253,16 @@ class Settings(BaseSettings):
         else:
             logger.info(f"CORS Origins:    {', '.join(cors_origins)}")
 
-        # Log trusted hosts configuration
-        trusted_hosts = self.get_trusted_hosts_list()
-        logger.info(f"Trusted Hosts:   {', '.join(trusted_hosts)}")
+        # Log trusted hosts configuration. Deliberately not logging the
+        # configured value itself: CodeQL's clear-text-logging query treats
+        # TRUSTED_HOSTS as a sensitive name (substring match on "TRUST",
+        # likely inherited from Java's truststore/keystore naming
+        # conventions) even though a hostname allowlist isn't actually
+        # secret. Logging only a status avoids that false positive.
+        if self.TRUSTED_HOSTS.strip() in ("", "*"):
+            logger.info("Trusted Hosts:   * (Host header validation disabled)")
+        else:
+            logger.info("Trusted Hosts:   configured (Host header validation enabled)")
 
         # Log cache configuration
         cache_status = "enabled" if self.CACHE_ENABLED else "disabled"

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -213,6 +213,23 @@ class Settings(BaseSettings):
         password = quote(self.resolved_db_password(), safe="")
         return f"postgresql+asyncpg://{user}:{password}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
 
+    def masked_database_url(self) -> str:
+        """Return the effective database URL with the password redacted, safe to log.
+
+        Never reads DB_PASSWORD/DB_PASSWORD_FILE — the redacted placeholder is
+        substituted directly instead of resolving and then masking the real
+        secret, so the actual password is never assembled on this code path.
+        """
+        if self.DATABASE_URL:
+            try:
+                from sqlalchemy.engine.url import make_url
+
+                return make_url(self.DATABASE_URL).render_as_string(hide_password=True)
+            except Exception:
+                return "<unparseable>"
+        user = quote(self.DB_USER, safe="")
+        return f"postgresql+asyncpg://{user}:***@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+
     def get_share_dir_path(self) -> Path:
         """Get SHARE_DIR as a Path object."""
         return Path(self.SHARE_DIR).resolve()
@@ -262,13 +279,7 @@ class Settings(BaseSettings):
         logger.info(f"Cache:           {cache_status} (TTL: {self.CACHE_TTL}s)")
 
         db_status = "enabled" if self.DATABASE_ENABLED else "disabled"
-        # Mask credentials from DATABASE_URL before logging.
-        try:
-            from sqlalchemy.engine.url import make_url
-            parsed = make_url(self.resolved_database_url())
-            safe_url = parsed.render_as_string(hide_password=True)
-        except Exception:
-            safe_url = "<unparseable>"
+        safe_url = self.masked_database_url()
         logger.info(f"Database:        {db_status} (echo: {self.DATABASE_ECHO}, url: {safe_url})")
         logger.info(f"OIDC Issuer:     {self.OIDC_ISSUER_URL}")
         sentry_status = f"enabled (traces_sample_rate={self.SENTRY_TRACES_SAMPLE_RATE})" if self.SENTRY_DSN else "disabled"

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 from urllib.parse import quote
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -139,6 +139,19 @@ class Settings(BaseSettings):
             raise ValueError(f"CACHE_TTL must be non-negative, got: {v}")
         return v
 
+    @model_validator(mode="after")
+    def validate_production_trusted_hosts(self) -> "Settings":
+        """Refuse to start in production without an explicit TRUSTED_HOSTS.
+
+        A silently-wildcarded Host header check is worse than no deployment at
+        all, so this fails startup the same way champagnefestival and daynest
+        require their production-critical settings, instead of only logging
+        a warning and leaving Host validation disabled.
+        """
+        if self.ENVIRONMENT == "production" and self.TRUSTED_HOSTS.strip() in ("", "*"):
+            raise ValueError("TRUSTED_HOSTS must be set in production.")
+        return self
+
     def get_cors_origins_list(self) -> list[str]:
         """Parse CORS_ORIGINS into a list of allowed origins.
         
@@ -169,16 +182,12 @@ class Settings(BaseSettings):
 
         Returns:
             List of allowed hostnames. Falls back to ["*"] (no restriction) when
-            empty or wildcard, logging a warning in production since that
-            disables Host-header validation.
+            empty or wildcard — only reachable in development, since
+            validate_production_trusted_hosts() refuses to start in production
+            with an empty or wildcard value.
         """
         trusted = self.TRUSTED_HOSTS.strip()
         if not trusted or trusted == "*":
-            if self.ENVIRONMENT == "production":
-                logger.warning(
-                    "⚠️  TRUSTED_HOSTS is not set in production - Host header "
-                    "validation is disabled. Set TRUSTED_HOSTS to your production hostname(s)."
-                )
             return ["*"]
         return [host.strip() for host in trusted.split(",") if host.strip()]
 

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -213,23 +213,6 @@ class Settings(BaseSettings):
         password = quote(self.resolved_db_password(), safe="")
         return f"postgresql+asyncpg://{user}:{password}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
 
-    def masked_database_url(self) -> str:
-        """Return the effective database URL with the password redacted, safe to log.
-
-        Never reads DB_PASSWORD/DB_PASSWORD_FILE — the redacted placeholder is
-        substituted directly instead of resolving and then masking the real
-        secret, so the actual password is never assembled on this code path.
-        """
-        if self.DATABASE_URL:
-            try:
-                from sqlalchemy.engine.url import make_url
-
-                return make_url(self.DATABASE_URL).render_as_string(hide_password=True)
-            except Exception:
-                return "<unparseable>"
-        user = quote(self.DB_USER, safe="")
-        return f"postgresql+asyncpg://{user}:***@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
-
     def get_share_dir_path(self) -> Path:
         """Get SHARE_DIR as a Path object."""
         return Path(self.SHARE_DIR).resolve()
@@ -279,8 +262,12 @@ class Settings(BaseSettings):
         logger.info(f"Cache:           {cache_status} (TTL: {self.CACHE_TTL}s)")
 
         db_status = "enabled" if self.DATABASE_ENABLED else "disabled"
-        safe_url = self.masked_database_url()
-        logger.info(f"Database:        {db_status} (echo: {self.DATABASE_ECHO}, url: {safe_url})")
+        # Deliberately not logging any form of the database URL/host, even
+        # redacted — DB_HOST/DB_PORT/DB_NAME/DB_USER are logged individually
+        # below, but never anything derived from DB_PASSWORD/DB_PASSWORD_FILE.
+        logger.info(f"Database:        {db_status} (echo: {self.DATABASE_ECHO})")
+        if self.DATABASE_ENABLED and not self.DATABASE_URL:
+            logger.info(f"  DB Host:       {self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME} (user: {self.DB_USER})")
         logger.info(f"OIDC Issuer:     {self.OIDC_ISSUER_URL}")
         sentry_status = f"enabled (traces_sample_rate={self.SENTRY_TRACES_SAMPLE_RATE})" if self.SENTRY_DSN else "disabled"
         logger.info(f"Sentry:          {sentry_status}")

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -6,6 +6,7 @@ settings with sensible defaults for development and production environments.
 
 import logging
 from pathlib import Path
+from urllib.parse import quote
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -36,7 +37,12 @@ class Settings(BaseSettings):
     
     # CORS configuration
     CORS_ORIGINS: str = "http://localhost:5173"
-    
+
+    # Trusted hosts for Host-header validation (TrustedHostMiddleware).
+    # Comma-separated hostnames, e.g. "worktime.tjor.im". "*" (the development
+    # default) disables validation — production should set this explicitly.
+    TRUSTED_HOSTS: str = "*"
+
     # Environment mode
     ENVIRONMENT: str = "development"
     
@@ -49,12 +55,25 @@ class Settings(BaseSettings):
     CACHE_ENABLED: bool = True
     HOLIDAY_CACHE_TTL: int = 86400  # 24 hours — holiday data doesn't change intra-year
 
-    # Database configuration
-    DATABASE_URL: str = "postgresql+asyncpg://worktime:worktime@localhost/worktime"
+    # Database configuration.
+    # DATABASE_URL is a full-URL override kept for local dev convenience. When
+    # unset (the default), the URL is built from DB_HOST/DB_PORT/DB_NAME/DB_USER
+    # + the resolved password below — the preferred production pattern, since
+    # DB_PASSWORD_FILE keeps the actual secret out of the plaintext env file.
+    DATABASE_URL: str = ""
     DATABASE_ECHO: bool = False
     DATABASE_ENABLED: bool = True
     DATABASE_POOL_SIZE: int = 5
     DATABASE_POOL_MAX_OVERFLOW: int = 10
+
+    DB_HOST: str = "localhost"
+    DB_PORT: int = 5432
+    DB_NAME: str = "worktime"
+    DB_USER: str = "worktime"
+    # DB_PASSWORD is a local-dev convenience default (matches docker-compose.yml).
+    # Production should use DB_PASSWORD_FILE to point at a Docker secret instead.
+    DB_PASSWORD: str = "worktime"
+    DB_PASSWORD_FILE: str = ""
 
     # HMAC secret for the /api/metrics endpoint.
     # When empty the metrics endpoint returns 404 so it stays invisible to scanners.
@@ -86,10 +105,8 @@ class Settings(BaseSettings):
     @field_validator("DATABASE_URL")
     @classmethod
     def validate_database_url(cls, v: str) -> str:
-        """Validate DATABASE_URL uses the postgresql+asyncpg async driver."""
-        if not v or not v.strip():
-            raise ValueError("DATABASE_URL cannot be empty")
-        if not v.startswith("postgresql+asyncpg://"):
+        """Validate DATABASE_URL uses the postgresql+asyncpg async driver, if set."""
+        if v and not v.startswith("postgresql+asyncpg://"):
             raise ValueError(
                 "DATABASE_URL must use the asyncpg driver: postgresql+asyncpg://..."
             )
@@ -147,6 +164,55 @@ class Settings(BaseSettings):
         origins = [origin.strip() for origin in cors_env.split(",") if origin.strip()]
         return origins
     
+    def get_trusted_hosts_list(self) -> list[str]:
+        """Parse TRUSTED_HOSTS into a list of allowed hostnames for TrustedHostMiddleware.
+
+        Returns:
+            List of allowed hostnames. Falls back to ["*"] (no restriction) when
+            empty or wildcard, logging a warning in production since that
+            disables Host-header validation.
+        """
+        trusted = self.TRUSTED_HOSTS.strip()
+        if not trusted or trusted == "*":
+            if self.ENVIRONMENT == "production":
+                logger.warning(
+                    "⚠️  TRUSTED_HOSTS is not set in production - Host header "
+                    "validation is disabled. Set TRUSTED_HOSTS to your production hostname(s)."
+                )
+            return ["*"]
+        return [host.strip() for host in trusted.split(",") if host.strip()]
+
+    def resolved_db_password(self) -> str:
+        """Resolve the database password, preferring DB_PASSWORD_FILE when set.
+
+        DB_PASSWORD_FILE is expected to point at a Docker/Compose secret file
+        containing just the password, so the real value never has to sit in a
+        plaintext env file.
+        """
+        if self.DB_PASSWORD_FILE:
+            try:
+                return Path(self.DB_PASSWORD_FILE).read_text(encoding="utf-8").strip()
+            except OSError as e:
+                raise ValueError(
+                    f"Could not read DB_PASSWORD_FILE at {self.DB_PASSWORD_FILE}: {e}"
+                ) from e
+        return self.DB_PASSWORD
+
+    def resolved_database_url(self) -> str:
+        """Return the effective database URL.
+
+        DATABASE_URL, when set, is used verbatim (local dev convenience — matches
+        docker-compose.yml). Otherwise the URL is built from DB_HOST/DB_PORT/
+        DB_NAME/DB_USER plus the resolved password, which is the preferred
+        pattern in production since it keeps the password out of the plaintext
+        env file via DB_PASSWORD_FILE.
+        """
+        if self.DATABASE_URL:
+            return self.DATABASE_URL
+        user = quote(self.DB_USER, safe="")
+        password = quote(self.resolved_db_password(), safe="")
+        return f"postgresql+asyncpg://{user}:{password}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+
     def get_share_dir_path(self) -> Path:
         """Get SHARE_DIR as a Path object."""
         return Path(self.SHARE_DIR).resolve()
@@ -186,7 +252,11 @@ class Settings(BaseSettings):
             )
         else:
             logger.info(f"CORS Origins:    {', '.join(cors_origins)}")
-        
+
+        # Log trusted hosts configuration
+        trusted_hosts = self.get_trusted_hosts_list()
+        logger.info(f"Trusted Hosts:   {', '.join(trusted_hosts)}")
+
         # Log cache configuration
         cache_status = "enabled" if self.CACHE_ENABLED else "disabled"
         logger.info(f"Cache:           {cache_status} (TTL: {self.CACHE_TTL}s)")
@@ -195,7 +265,7 @@ class Settings(BaseSettings):
         # Mask credentials from DATABASE_URL before logging.
         try:
             from sqlalchemy.engine.url import make_url
-            parsed = make_url(self.DATABASE_URL)
+            parsed = make_url(self.resolved_database_url())
             safe_url = parsed.render_as_string(hide_password=True)
         except Exception:
             safe_url = "<unparseable>"

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -141,15 +141,19 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_production_trusted_hosts(self) -> "Settings":
-        """Refuse to start in production without an explicit TRUSTED_HOSTS.
+        """Refuse to start in production without a real TRUSTED_HOSTS allowlist.
 
         A silently-wildcarded Host header check is worse than no deployment at
         all, so this fails startup the same way champagnefestival and daynest
         require their production-critical settings, instead of only logging
-        a warning and leaving Host validation disabled.
+        a warning and leaving Host validation disabled. Checks the *parsed*
+        value rather than the raw string: a separator-only value like ","
+        passes a raw non-empty check but parses down to zero real hostnames,
+        which would otherwise silently lock out all production traffic once
+        TrustedHostMiddleware is wired up with an effectively empty allowlist.
         """
-        if self.ENVIRONMENT == "production" and self.TRUSTED_HOSTS.strip() in ("", "*"):
-            raise ValueError("TRUSTED_HOSTS must be set in production.")
+        if self.ENVIRONMENT == "production" and self._parse_trusted_hosts() == ["*"]:
+            raise ValueError("TRUSTED_HOSTS must be set to a real hostname allowlist in production.")
         return self
 
     def get_cors_origins_list(self) -> list[str]:
@@ -177,19 +181,36 @@ class Settings(BaseSettings):
         origins = [origin.strip() for origin in cors_env.split(",") if origin.strip()]
         return origins
     
-    def get_trusted_hosts_list(self) -> list[str]:
-        """Parse TRUSTED_HOSTS into a list of allowed hostnames for TrustedHostMiddleware.
+    def _parse_trusted_hosts(self) -> list[str]:
+        """Parse the raw TRUSTED_HOSTS value into real hostnames.
 
-        Returns:
-            List of allowed hostnames. Falls back to ["*"] (no restriction) when
-            empty or wildcard — only reachable in development, since
-            validate_production_trusted_hosts() refuses to start in production
-            with an empty or wildcard value.
+        Returns ["*"] when unset, wildcarded, or when the comma-separated
+        value parses down to zero real hostnames (e.g. a separator-only value
+        like ",") — all three mean "no allowlist configured".
         """
         trusted = self.TRUSTED_HOSTS.strip()
         if not trusted or trusted == "*":
             return ["*"]
-        return [host.strip() for host in trusted.split(",") if host.strip()]
+        hosts = [host.strip() for host in trusted.split(",") if host.strip()]
+        return hosts or ["*"]
+
+    def get_trusted_hosts_list(self) -> list[str]:
+        """Parse TRUSTED_HOSTS into the effective allowlist for TrustedHostMiddleware.
+
+        Returns:
+            List of allowed hostnames. Falls back to ["*"] (no restriction) when
+            empty, wildcarded, or unparseable — only reachable in development,
+            since validate_production_trusted_hosts() refuses to start in
+            production with such a value. Otherwise always includes
+            "localhost": Docker's own HEALTHCHECK curls
+            http://localhost:PORT/health from inside the container, and that
+            must keep working regardless of the configured production
+            allowlist.
+        """
+        hosts = self._parse_trusted_hosts()
+        if hosts != ["*"] and "localhost" not in hosts:
+            hosts = [*hosts, "localhost"]
+        return hosts
 
     def resolved_db_password(self) -> str:
         """Resolve the database password, preferring DB_PASSWORD_FILE when set.
@@ -220,7 +241,12 @@ class Settings(BaseSettings):
             return self.DATABASE_URL
         user = quote(self.DB_USER, safe="")
         password = quote(self.resolved_db_password(), safe="")
-        return f"postgresql+asyncpg://{user}:{password}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+        host = self.DB_HOST
+        if ":" in host and not host.startswith("["):
+            # Bracket IPv6 literals (e.g. "::1") — otherwise the host can't be
+            # told apart from the following ":<port>" in the URL authority.
+            host = f"[{host}]"
+        return f"postgresql+asyncpg://{user}:{password}@{host}:{self.DB_PORT}/{self.DB_NAME}"
 
     def get_share_dir_path(self) -> Path:
         """Get SHARE_DIR as a Path object."""

--- a/backend/app/database/engine.py
+++ b/backend/app/database/engine.py
@@ -21,7 +21,7 @@ def _build_engine():
     if _engine is None:
         logger.info("Creating PostgreSQL async engine")
         _engine = create_async_engine(
-            settings.DATABASE_URL,
+            settings.resolved_database_url(),
             echo=settings.DATABASE_ECHO,
             # Pool defaults: size=5, max_overflow=10, timeout=30s.
             # Override via DATABASE_POOL_SIZE / DATABASE_POOL_MAX_OVERFLOW env vars if needed.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from fastapi.responses import PlainTextResponse
 from fastmcp.utilities.lifespan import combine_lifespans
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from .cache.warm_cache import warm_cache
 from .config import settings
@@ -148,7 +149,7 @@ async def lifespan(app: FastAPI):
             raise
 
         # Start Postgres LISTEN/NOTIFY for cross-process SSE broadcast
-        await sync_event_manager.start_pg_listener(settings.DATABASE_URL)
+        await sync_event_manager.start_pg_listener(settings.resolved_database_url())
     else:
         logger.info("Database initialization skipped (DATABASE_ENABLED=false)")
 
@@ -240,10 +241,15 @@ else:
 
 # TimingMiddleware records metrics and sets X-Total-Ms.
 app.add_middleware(TimingMiddleware)
-# RequestIdMiddleware is outermost: it sets/echoes X-Request-ID and emits structured
-# access logs after every response, with user_id included for authenticated requests.
+# RequestIdMiddleware sets/echoes X-Request-ID and emits structured access logs
+# after every response, with user_id included for authenticated requests.
 app.add_middleware(RequestIdMiddleware)
 
+# TrustedHostMiddleware is outermost: it rejects requests with an unrecognized
+# Host header before any other middleware runs. TRUSTED_HOSTS="*" (development
+# default) disables validation; production should set explicit hostnames.
+trusted_hosts = settings.get_trusted_hosts_list()
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=trusted_hosts)
 
 # Register API routers — all backend routes are served under /api
 app.include_router(auth_router, prefix="/api")

--- a/backend/app/utils/sse_manager.py
+++ b/backend/app/utils/sse_manager.py
@@ -26,6 +26,24 @@ logger = logging.getLogger(__name__)
 _NOTIFY_CHANNEL = "worktime_sync_changed"
 
 
+def _redact_credentials(db_url: object) -> str:
+    """Return db_url with any embedded userinfo credentials redacted, safe to log."""
+    if not isinstance(db_url, str):
+        return repr(db_url)
+    try:
+        parsed = urlparse(db_url)
+    except ValueError:
+        return "<unparseable>"
+    if not (parsed.username or parsed.password):
+        return db_url
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    if parsed.username:
+        netloc = f"{parsed.username}:***@{netloc}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
 def _build_sse_message(event: str, data: dict) -> str:
     """Format a single SSE frame: ``event: <name>\\ndata: <json>\\n\\n``."""
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
@@ -187,14 +205,14 @@ class SyncEventManager:
         if not isinstance(db_url, str) or not db_url:
             logger.warning(
                 "SSE: DATABASE_URL is not a valid string (%r); LISTEN/NOTIFY will not be started",
-                db_url,
+                _redact_credentials(db_url),
             )
             return
         parsed = urlparse(db_url)
         if parsed.scheme != "postgresql+asyncpg":
             logger.warning(
                 "SSE: DATABASE_URL does not start with 'postgresql+asyncpg://' (%r); LISTEN/NOTIFY will not be started",
-                db_url,
+                _redact_credentials(db_url),
             )
             return
         asyncpg_url = urlunparse(parsed._replace(scheme="postgresql"))

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,14 +1,13 @@
 """Alembic environment — sync psycopg3 for migrations, asyncpg for the app."""
 
-import os
 from logging.config import fileConfig
 
+from alembic import context
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Connection
 from sqlalchemy.engine.url import make_url
 
-from alembic import context
-
+from app.config import settings
 from app.database.models import Base  # noqa: F401 — registers all tables with Base.metadata
 
 config = context.config
@@ -17,9 +16,11 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
-# Allow DATABASE_URL env var to override alembic.ini.
+# Resolve the database URL the same way the app does (DATABASE_URL override,
+# or DB_HOST/DB_PORT/DB_NAME/DB_USER + DB_PASSWORD(_FILE)), falling back to
+# alembic.ini's sqlalchemy.url only if that resolution is unavailable.
 # Replace the async driver with psycopg3 (sync) for migrations.
-_raw_url = os.environ.get("DATABASE_URL") or config.get_main_option("sqlalchemy.url")
+_raw_url = settings.resolved_database_url() or config.get_main_option("sqlalchemy.url")
 if _raw_url:
     _parsed = make_url(_raw_url)
     _sync_drivername = _parsed.drivername.replace("+asyncpg", "+psycopg")

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -16,11 +16,13 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
-# Resolve the database URL the same way the app does (DATABASE_URL override,
-# or DB_HOST/DB_PORT/DB_NAME/DB_USER + DB_PASSWORD(_FILE)), falling back to
-# alembic.ini's sqlalchemy.url only if that resolution is unavailable.
-# Replace the async driver with psycopg3 (sync) for migrations.
-_raw_url = settings.resolved_database_url() or config.get_main_option("sqlalchemy.url")
+# Resolve the database URL the same way the app does. An explicit DATABASE_URL
+# override wins first; otherwise prefer alembic.ini's sqlalchemy.url when a
+# caller has configured one explicitly, since resolved_database_url() always
+# returns a URL (built from DB_HOST/DB_PORT/DB_NAME/DB_USER defaults when
+# nothing else is set) and would otherwise make that alembic.ini setting
+# unreachable. Replace the async driver with psycopg3 (sync) for migrations.
+_raw_url = settings.DATABASE_URL or config.get_main_option("sqlalchemy.url") or settings.resolved_database_url()
 if _raw_url:
     _parsed = make_url(_raw_url)
     _sync_drivername = _parsed.drivername.replace("+asyncpg", "+psycopg")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -21,13 +21,15 @@ def test_default_settings():
     assert settings.CACHE_ENABLED is True
     assert settings.CACHE_TTL == 10
     assert settings.DATABASE_ENABLED is True
-    assert settings.DATABASE_URL.startswith("postgresql+asyncpg://")
+    assert settings.DATABASE_URL == ""
+    assert settings.resolved_database_url().startswith("postgresql+asyncpg://")
     assert settings.DATABASE_ECHO is False
     assert settings.OIDC_ISSUER_URL == "http://localhost:9000/application/o/worktime"
     assert settings.OIDC_AUDIENCE == ""
     assert settings.OIDC_ALGORITHMS == "RS256"
     assert settings.RATE_LIMIT_ENABLED is True
     assert settings.RATE_LIMIT_DEFAULT == "200/minute"
+    assert settings.TRUSTED_HOSTS == "*"
 
 
 def test_custom_settings():
@@ -211,3 +213,85 @@ def test_oidc_custom_values() -> None:
     assert settings.OIDC_ISSUER_URL == "https://auth.example.com/application/o/worktime"
     assert settings.OIDC_AUDIENCE == "worktime"
     assert settings.OIDC_ALGORITHMS == "RS256,RS512"
+
+
+def test_resolved_database_url_uses_database_url_override_when_set():
+    """DATABASE_URL, when set, takes precedence over the DB_* fields."""
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="postgresql+asyncpg://user:pass@dbhost/mydb",
+        DB_HOST="ignored-host",
+    )
+    assert settings.resolved_database_url() == "postgresql+asyncpg://user:pass@dbhost/mydb"
+
+
+def test_resolved_database_url_builds_from_db_fields_when_unset():
+    """Without DATABASE_URL, the URL is built from DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD."""
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="",
+        DB_HOST="dbhost",
+        DB_PORT=5433,
+        DB_NAME="mydb",
+        DB_USER="user",
+        DB_PASSWORD="pass",
+    )
+    assert settings.resolved_database_url() == "postgresql+asyncpg://user:pass@dbhost:5433/mydb"
+
+
+def test_resolved_database_url_reads_db_password_file(tmp_path):
+    """DB_PASSWORD_FILE takes precedence over DB_PASSWORD when both are set."""
+    password_file = tmp_path / "db_password"
+    password_file.write_text("secret-from-file\n")
+
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="",
+        DB_HOST="dbhost",
+        DB_NAME="mydb",
+        DB_USER="user",
+        DB_PASSWORD="unused",
+        DB_PASSWORD_FILE=str(password_file),
+    )
+    assert settings.resolved_db_password() == "secret-from-file"
+    assert settings.resolved_database_url() == "postgresql+asyncpg://user:secret-from-file@dbhost:5432/mydb"
+
+
+def test_resolved_db_password_file_missing_raises(tmp_path):
+    """A DB_PASSWORD_FILE pointing at a missing file raises instead of silently falling back."""
+    settings = Settings(
+        _env_file=None,
+        DB_PASSWORD_FILE=str(tmp_path / "does-not-exist"),
+    )
+    with pytest.raises(ValueError, match="Could not read DB_PASSWORD_FILE"):
+        settings.resolved_db_password()
+
+
+def test_database_url_validation_allows_empty():
+    """DATABASE_URL may be left empty (falls back to DB_* fields)."""
+    settings = Settings(_env_file=None, DATABASE_URL="")
+    assert settings.DATABASE_URL == ""
+
+
+def test_database_url_validation_rejects_wrong_driver():
+    """A non-empty DATABASE_URL must still use the asyncpg driver."""
+    with pytest.raises(ValueError, match="must use the asyncpg driver"):
+        Settings(_env_file=None, DATABASE_URL="postgresql://user:pass@host/db")
+
+
+def test_trusted_hosts_default_wildcard():
+    """TRUSTED_HOSTS defaults to '*' (no Host-header restriction)."""
+    settings = Settings(_env_file=None)
+    assert settings.get_trusted_hosts_list() == ["*"]
+
+
+def test_trusted_hosts_parses_comma_separated_list():
+    """TRUSTED_HOSTS parses a comma-separated hostname list."""
+    settings = Settings(_env_file=None, TRUSTED_HOSTS="worktime.tjor.im, api.worktime.tjor.im")
+    assert settings.get_trusted_hosts_list() == ["worktime.tjor.im", "api.worktime.tjor.im"]
+
+
+def test_trusted_hosts_wildcard_in_production_still_returns_wildcard():
+    """Wildcard TRUSTED_HOSTS in production only warns, it doesn't lock out all hosts."""
+    settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="*")
+    assert settings.get_trusted_hosts_list() == ["*"]

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -295,3 +295,31 @@ def test_trusted_hosts_wildcard_in_production_still_returns_wildcard():
     """Wildcard TRUSTED_HOSTS in production only warns, it doesn't lock out all hosts."""
     settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="*")
     assert settings.get_trusted_hosts_list() == ["*"]
+
+
+def test_masked_database_url_redacts_password_from_database_url_override():
+    """masked_database_url() never reveals the password from a DATABASE_URL override."""
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="postgresql+asyncpg://user:supersecret@dbhost/mydb",
+    )
+    masked = settings.masked_database_url()
+    assert "supersecret" not in masked
+    assert masked.startswith("postgresql+asyncpg://user:")
+    assert "@dbhost/mydb" in masked
+
+
+def test_masked_database_url_redacts_password_from_db_fields():
+    """masked_database_url() never resolves or reveals DB_PASSWORD/DB_PASSWORD_FILE."""
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="",
+        DB_HOST="dbhost",
+        DB_PORT=5433,
+        DB_NAME="mydb",
+        DB_USER="user",
+        DB_PASSWORD="supersecret",
+    )
+    masked = settings.masked_database_url()
+    assert "supersecret" not in masked
+    assert masked == "postgresql+asyncpg://user:***@dbhost:5433/mydb"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -51,10 +51,11 @@ def test_custom_settings():
         os.environ["DATABASE_URL"] = "postgresql+asyncpg://user:pass@dbhost/mydb"
         os.environ["DATABASE_ECHO"] = "true"
         os.environ["OIDC_ISSUER_URL"] = "https://auth.example.com/application/o/worktime"
-        
+        os.environ["TRUSTED_HOSTS"] = "worktime.tjor.im"
+
         # Create new settings instance
         settings = Settings()
-        
+
         assert settings.ENVIRONMENT == "production"
         assert settings.HOST == "127.0.0.1"
         assert settings.PORT == 9000
@@ -66,6 +67,7 @@ def test_custom_settings():
         assert settings.DATABASE_URL == "postgresql+asyncpg://user:pass@dbhost/mydb"
         assert settings.DATABASE_ECHO is True
         assert settings.OIDC_ISSUER_URL == "https://auth.example.com/application/o/worktime"
+        assert settings.TRUSTED_HOSTS == "worktime.tjor.im"
     finally:
         # Restore original environment
         os.environ.clear()
@@ -107,9 +109,10 @@ def test_cors_origins_wildcard_production():
     settings = Settings(
         ENVIRONMENT="production",
         CORS_ORIGINS="*",
+        TRUSTED_HOSTS="worktime.tjor.im",
     )
     origins = settings.get_cors_origins_list()
-    
+
     # Wildcard should be rejected in production
     assert origins == []
 
@@ -119,8 +122,8 @@ def test_environment_validation():
     # Valid environments
     settings_dev = Settings(ENVIRONMENT="development")
     assert settings_dev.ENVIRONMENT == "development"
-    
-    settings_prod = Settings(ENVIRONMENT="production")
+
+    settings_prod = Settings(ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im")
     assert settings_prod.ENVIRONMENT == "production"
     
     # Invalid environment should raise error
@@ -292,10 +295,23 @@ def test_trusted_hosts_parses_comma_separated_list():
     assert settings.get_trusted_hosts_list() == ["worktime.tjor.im", "api.worktime.tjor.im"]
 
 
-def test_trusted_hosts_wildcard_in_production_still_returns_wildcard():
-    """Wildcard TRUSTED_HOSTS in production only warns, it doesn't lock out all hosts."""
-    settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="*")
-    assert settings.get_trusted_hosts_list() == ["*"]
+def test_trusted_hosts_wildcard_in_production_raises():
+    """A wildcard TRUSTED_HOSTS refuses to start in production rather than silently
+    leaving Host-header validation disabled."""
+    with pytest.raises(ValueError, match="TRUSTED_HOSTS must be set in production"):
+        Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="*")
+
+
+def test_trusted_hosts_empty_in_production_raises():
+    """An empty TRUSTED_HOSTS refuses to start in production, same as a wildcard."""
+    with pytest.raises(ValueError, match="TRUSTED_HOSTS must be set in production"):
+        Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="")
+
+
+def test_trusted_hosts_explicit_in_production_succeeds():
+    """An explicit TRUSTED_HOSTS value starts normally in production."""
+    settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im")
+    assert settings.get_trusted_hosts_list() == ["worktime.tjor.im"]
 
 
 def test_log_configuration_never_logs_the_password(caplog):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -328,3 +328,26 @@ def test_log_configuration_never_logs_password_from_database_url_override(caplog
     with caplog.at_level(logging.INFO):
         settings.log_configuration()
     assert "supersecret" not in caplog.text
+
+
+def test_log_configuration_never_logs_configured_trusted_hosts(caplog):
+    """log_configuration() must never emit the configured TRUSTED_HOSTS value itself.
+
+    Only a status ("configured" / disabled) is logged — CodeQL's clear-text
+    logging heuristic flags TRUSTED_HOSTS as sensitive-by-name even though a
+    hostname allowlist is not a secret.
+    """
+    settings = Settings(_env_file=None, TRUSTED_HOSTS="worktime.tjor.im,internal.example.com")
+    with caplog.at_level(logging.INFO):
+        settings.log_configuration()
+    assert "worktime.tjor.im" not in caplog.text
+    assert "internal.example.com" not in caplog.text
+    assert "Trusted Hosts:   configured (Host header validation enabled)" in caplog.text
+
+
+def test_log_configuration_reports_disabled_trusted_hosts(caplog):
+    """A wildcard TRUSTED_HOSTS is reported as disabled, not as a hostname list."""
+    settings = Settings(_env_file=None, TRUSTED_HOSTS="*")
+    with caplog.at_level(logging.INFO):
+        settings.log_configuration()
+    assert "Trusted Hosts:   * (Host header validation disabled)" in caplog.text

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -243,6 +243,35 @@ def test_resolved_database_url_builds_from_db_fields_when_unset():
     assert settings.resolved_database_url() == "postgresql+asyncpg://user:pass@dbhost:5433/mydb"
 
 
+def test_resolved_database_url_brackets_ipv6_host():
+    """An IPv6 literal DB_HOST must be bracketed, or the host can't be told
+    apart from the trailing ":<port>" in the URL authority."""
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="",
+        DB_HOST="::1",
+        DB_PORT=5432,
+        DB_NAME="mydb",
+        DB_USER="user",
+        DB_PASSWORD="pass",
+    )
+    assert settings.resolved_database_url() == "postgresql+asyncpg://user:pass@[::1]:5432/mydb"
+
+
+def test_resolved_database_url_does_not_double_bracket_ipv6_host():
+    """An already-bracketed IPv6 DB_HOST is left as-is."""
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="",
+        DB_HOST="[::1]",
+        DB_PORT=5432,
+        DB_NAME="mydb",
+        DB_USER="user",
+        DB_PASSWORD="pass",
+    )
+    assert settings.resolved_database_url() == "postgresql+asyncpg://user:pass@[::1]:5432/mydb"
+
+
 def test_resolved_database_url_reads_db_password_file(tmp_path):
     """DB_PASSWORD_FILE takes precedence over DB_PASSWORD when both are set."""
     password_file = tmp_path / "db_password"
@@ -290,28 +319,45 @@ def test_trusted_hosts_default_wildcard():
 
 
 def test_trusted_hosts_parses_comma_separated_list():
-    """TRUSTED_HOSTS parses a comma-separated hostname list."""
+    """TRUSTED_HOSTS parses a comma-separated hostname list, plus the always-allowed localhost."""
     settings = Settings(_env_file=None, TRUSTED_HOSTS="worktime.tjor.im, api.worktime.tjor.im")
-    assert settings.get_trusted_hosts_list() == ["worktime.tjor.im", "api.worktime.tjor.im"]
+    assert settings.get_trusted_hosts_list() == ["worktime.tjor.im", "api.worktime.tjor.im", "localhost"]
+
+
+def test_trusted_hosts_always_allows_localhost_for_healthcheck():
+    """get_trusted_hosts_list() always allows "localhost" so Docker's own
+    HEALTHCHECK (curling http://localhost:PORT/health from inside the
+    container) keeps working regardless of the configured production allowlist."""
+    settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im")
+    assert "localhost" in settings.get_trusted_hosts_list()
 
 
 def test_trusted_hosts_wildcard_in_production_raises():
     """A wildcard TRUSTED_HOSTS refuses to start in production rather than silently
     leaving Host-header validation disabled."""
-    with pytest.raises(ValueError, match="TRUSTED_HOSTS must be set in production"):
+    with pytest.raises(ValueError, match="TRUSTED_HOSTS must be set"):
         Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="*")
 
 
 def test_trusted_hosts_empty_in_production_raises():
     """An empty TRUSTED_HOSTS refuses to start in production, same as a wildcard."""
-    with pytest.raises(ValueError, match="TRUSTED_HOSTS must be set in production"):
+    with pytest.raises(ValueError, match="TRUSTED_HOSTS must be set"):
         Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="")
+
+
+def test_trusted_hosts_separator_only_in_production_raises():
+    """A separator-only TRUSTED_HOSTS (e.g. ",") parses down to zero real
+    hostnames and must refuse to start in production — otherwise
+    TrustedHostMiddleware would be wired up with an empty allowlist and
+    silently reject all production traffic instead of failing at startup."""
+    with pytest.raises(ValueError, match="TRUSTED_HOSTS must be set"):
+        Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS=",")
 
 
 def test_trusted_hosts_explicit_in_production_succeeds():
     """An explicit TRUSTED_HOSTS value starts normally in production."""
     settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im")
-    assert settings.get_trusted_hosts_list() == ["worktime.tjor.im"]
+    assert settings.get_trusted_hosts_list() == ["worktime.tjor.im", "localhost"]
 
 
 def test_log_configuration_never_logs_the_password(caplog):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for configuration settings."""
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -297,20 +298,13 @@ def test_trusted_hosts_wildcard_in_production_still_returns_wildcard():
     assert settings.get_trusted_hosts_list() == ["*"]
 
 
-def test_masked_database_url_redacts_password_from_database_url_override():
-    """masked_database_url() never reveals the password from a DATABASE_URL override."""
-    settings = Settings(
-        _env_file=None,
-        DATABASE_URL="postgresql+asyncpg://user:supersecret@dbhost/mydb",
-    )
-    masked = settings.masked_database_url()
-    assert "supersecret" not in masked
-    assert masked.startswith("postgresql+asyncpg://user:")
-    assert "@dbhost/mydb" in masked
+def test_log_configuration_never_logs_the_password(caplog):
+    """log_configuration() must never emit DB_PASSWORD or a DATABASE_URL containing it.
 
-
-def test_masked_database_url_redacts_password_from_db_fields():
-    """masked_database_url() never resolves or reveals DB_PASSWORD/DB_PASSWORD_FILE."""
+    Matches daynest's approach: never log any form of the database URL, masked
+    or otherwise — only the individual non-secret DB_HOST/DB_PORT/DB_NAME/DB_USER
+    fields are logged.
+    """
     settings = Settings(
         _env_file=None,
         DATABASE_URL="",
@@ -320,6 +314,17 @@ def test_masked_database_url_redacts_password_from_db_fields():
         DB_USER="user",
         DB_PASSWORD="supersecret",
     )
-    masked = settings.masked_database_url()
-    assert "supersecret" not in masked
-    assert masked == "postgresql+asyncpg://user:***@dbhost:5433/mydb"
+    with caplog.at_level(logging.INFO):
+        settings.log_configuration()
+    assert "supersecret" not in caplog.text
+
+
+def test_log_configuration_never_logs_password_from_database_url_override(caplog):
+    """A DATABASE_URL override containing a password must not appear in the logs either."""
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="postgresql+asyncpg://user:supersecret@dbhost/mydb",
+    )
+    with caplog.at_level(logging.INFO):
+        settings.log_configuration()
+    assert "supersecret" not in caplog.text

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,7 +12,7 @@ from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
-from app.utils.sse_manager import SyncEventManager
+from app.utils.sse_manager import SyncEventManager, _redact_credentials
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1667,6 +1668,40 @@ class TestSyncEventManager:
             conn=MagicMock(), pid=12345, channel="worktime_sync_changed", payload="not-an-int"
         )
         assert queue.empty()
+
+    async def test_start_pg_listener_does_not_log_password_for_empty_url(self, caplog) -> None:
+        """An empty db_url is rejected without ever logging a password."""
+        manager = SyncEventManager()
+        with caplog.at_level(logging.WARNING):
+            await manager.start_pg_listener("")
+        assert "hunter2" not in caplog.text
+
+    async def test_start_pg_listener_does_not_log_password_for_wrong_scheme(self, caplog) -> None:
+        """A malformed URL with embedded credentials is rejected without leaking the password."""
+        manager = SyncEventManager()
+        with caplog.at_level(logging.WARNING):
+            await manager.start_pg_listener("postgresql://user:hunter2@host:5432/db")
+        assert "hunter2" not in caplog.text
+        assert "does not start with" in caplog.text
+
+
+class TestRedactCredentials:
+    """Unit tests for the _redact_credentials logging helper."""
+
+    def test_redacts_password_from_url(self) -> None:
+        redacted = _redact_credentials("postgresql+asyncpg://user:hunter2@host:5432/db")
+        assert "hunter2" not in redacted
+        assert redacted == "postgresql+asyncpg://user:***@host:5432/db"
+
+    def test_passes_through_url_without_credentials(self) -> None:
+        assert _redact_credentials("postgresql+asyncpg://host:5432/db") == "postgresql+asyncpg://host:5432/db"
+
+    def test_handles_non_string_input(self) -> None:
+        assert _redact_credentials(None) == "None"
+
+    def test_handles_unparseable_input(self) -> None:
+        # A lone '[' is invalid per RFC 3986 bracket-matching and raises in urlparse.
+        assert _redact_credentials("postgresql://[") == "<unparseable>"
 
 
 class TestSyncEventsEndpoint:

--- a/infra/worktime.env.example
+++ b/infra/worktime.env.example
@@ -31,6 +31,12 @@ SHARE_DIR=/data/hday_files
 CORS_ORIGINS=https://worktime.tjor.im
 
 # -----------------------------------------------------------------------------
+# Trusted Hosts — validates the incoming Host header (TrustedHostMiddleware)
+# -----------------------------------------------------------------------------
+# Comma-separated hostname(s) this API is served on (no scheme/port).
+TRUSTED_HOSTS=worktime.tjor.im
+
+# -----------------------------------------------------------------------------
 # Cache
 # -----------------------------------------------------------------------------
 CACHE_ENABLED=true
@@ -39,8 +45,14 @@ CACHE_TTL=10
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
+# The password is not stored here in plaintext: DB_PASSWORD_FILE points at a
+# Docker secret mounted into the container, and is resolved at startup.
 DATABASE_ENABLED=true
-DATABASE_URL=postgresql+asyncpg://worktime:CHANGE_ME@postgres:5432/worktime
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=worktime
+DB_USER=worktime_user
+DB_PASSWORD_FILE=/run/secrets/worktime_db_password
 DATABASE_ECHO=false
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adopt daynest's `DB_PASSWORD_FILE` secret pattern instead of embedding the DB password in plaintext `DATABASE_URL`. `Settings` now supports `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER` + `DB_PASSWORD`/`DB_PASSWORD_FILE`, and builds the connection URL from these fields via `resolved_database_url()`. `DATABASE_URL` is kept as a full-URL override for local dev convenience (matches `docker-compose.yml`) and still takes precedence when set.
- Add `TrustedHostMiddleware` (configured via a new `TRUSTED_HOSTS` setting, comma-separated hostnames, default `"*"` for dev) to validate the `Host` header at the app layer. It's registered as the outermost middleware so unrecognized hosts are rejected before any other processing.
- Update `infra/worktime.env.example` and `backend/.env.example` to document the new `DB_*`/`TRUSTED_HOSTS` variables and drop the plaintext password example.
- Update `engine.py`, `main.py` (SSE Postgres LISTEN/NOTIFY), and `migrations/env.py` (Alembic) to resolve the database URL through `settings.resolved_database_url()` instead of reading `DATABASE_URL` directly, so the secret-file pattern applies everywhere a DB connection is made.

## Test plan

- [x] `uv run ruff check` on changed files
- [x] `uv run ty check app`
- [x] `uv run pytest tests/test_config.py` (23 passed) — added coverage for `resolved_database_url`, `resolved_db_password` (including a `DB_PASSWORD_FILE` fixture and missing-file error case), and `get_trusted_hosts_list`
- [x] Verified `TrustedHostMiddleware` is wired as the outermost middleware and rejects an unrecognized `Host` header (400) while allowing a trusted one (200), via a standalone script
- [ ] Full suite (`uv run pytest`) requires a running PostgreSQL instance, which wasn't available in this sandbox — CI should cover this

Closes #990


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQoeWuFz1G13ikjA4JyAjq)_