### PR TITLE
Combine Account and Sync settings sections; move user management out

### DIFF
--- a/frontend/src/components/settings/account/SettingsAccountSection.tsx
+++ b/frontend/src/components/settings/account/SettingsAccountSection.tsx
@@ -4,22 +4,8 @@ import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import ListGroup from "react-bootstrap/ListGroup";
-import Table from "react-bootstrap/Table";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import * as m from "@/paraglide/messages.js";
-import { getLocale } from "@/paraglide/runtime.js";
-
-const formatTimestamp = (value: string): string => {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  const locale = getLocale() === "nl" ? "nl-NL" : "en-US";
-  return new Intl.DateTimeFormat(locale, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(parsed);
-};
 
 interface SettingsAccountSectionProps {
   isValidating: boolean;
@@ -34,22 +20,10 @@ interface SettingsAccountSectionProps {
   profileDraft: string;
   isProfileSaving: boolean;
   hasProfileChanges: boolean;
-  adminUsers: Array<{
-    id: number;
-    username: string;
-    display_name: string;
-    created_at: string;
-    updated_at: string;
-  }>;
-  isAdminUsersLoading: boolean;
-  adminUsersError: string | null;
-  adminUsersDeleteError: string | null;
-  deletingAdminUserId: number | null;
   isDeletingAccount: boolean;
   deleteAccountError: string | null;
   onProfileDraftChange: (value: string) => void;
   onSaveProfile: () => void;
-  onDeleteAdminUser: (userId: number) => void;
   onDeleteAccount: () => void;
   onLogout: () => void;
   onSignup: () => void;
@@ -69,23 +43,15 @@ export function SettingsAccountSection({
   profileDraft,
   isProfileSaving,
   hasProfileChanges,
-  adminUsers,
-  isAdminUsersLoading,
-  adminUsersError,
-  adminUsersDeleteError,
-  deletingAdminUserId,
   isDeletingAccount,
   deleteAccountError,
   onProfileDraftChange,
   onSaveProfile,
-  onDeleteAdminUser,
   onDeleteAccount,
   onLogout,
   onSignup,
   onLogin,
 }: SettingsAccountSectionProps) {
-  const [pendingDeleteUserId, setPendingDeleteUserId] = useState<number | null>(null);
-  const pendingDeleteUser = adminUsers.find((user) => user.id === pendingDeleteUserId) ?? null;
   const [showDeleteAccountConfirm, setShowDeleteAccountConfirm] = useState(false);
 
   return (
@@ -187,81 +153,6 @@ export function SettingsAccountSection({
                       </Button>
                     </div>
 
-                    {isAdmin ? (
-                      <div className="pt-2 border-top">
-                        <h6 className="mb-2">{m.account_admin_users_title()}</h6>
-                        <p className="text-muted small mb-2">{m.account_admin_users_description()}</p>
-                        {isAdminUsersLoading ? (
-                          <div className="d-flex align-items-center gap-2 text-muted small">
-                            <span
-                              className="spinner-border spinner-border-sm"
-                              role="status"
-                              aria-hidden="true"
-                            ></span>
-                            <span>{m.account_admin_users_loading()}</span>
-                          </div>
-                        ) : adminUsersError ? (
-                          <Alert variant="warning" className="mb-0 py-2">
-                            {adminUsersError}
-                          </Alert>
-                        ) : (
-                          <>
-                            {adminUsersDeleteError ? (
-                              <Alert variant="danger" className="mb-2 py-2">
-                                {adminUsersDeleteError}
-                              </Alert>
-                            ) : null}
-                            {adminUsers.length === 0 ? (
-                              <p className="text-muted small mb-0">{m.account_admin_users_empty()}</p>
-                            ) : (
-                              <div className="table-responsive">
-                                <Table size="sm" striped hover className="mb-0 align-middle">
-                                  <thead>
-                                    <tr>
-                                      <th>{m.account_admin_users_user_id()}</th>
-                                      <th>{m.account_admin_users_username()}</th>
-                                      <th>{m.account_admin_users_display_name()}</th>
-                                      <th>{m.account_admin_users_created_at()}</th>
-                                      <th>{m.account_admin_users_updated_at()}</th>
-                                      <th className="text-end">{m.account_admin_users_actions()}</th>
-                                    </tr>
-                                  </thead>
-                                  <tbody>
-                                    {adminUsers.map((user) => (
-                                      <tr key={user.id}>
-                                        <td>{user.id}</td>
-                                        <td>{user.username}</td>
-                                        <td>{user.display_name}</td>
-                                        <td>{formatTimestamp(user.created_at)}</td>
-                                        <td>{formatTimestamp(user.updated_at)}</td>
-                                        <td className="text-end">
-                                          <Button
-                                            variant="outline-danger"
-                                            size="sm"
-                                            disabled={accountId === user.id || deletingAdminUserId !== null}
-                                            title={
-                                              accountId === user.id
-                                                ? m.account_admin_users_delete_self_blocked()
-                                                : undefined
-                                            }
-                                            onClick={() => setPendingDeleteUserId(user.id)}
-                                          >
-                                            {deletingAdminUserId === user.id
-                                              ? m.account_admin_users_delete_busy()
-                                              : m.delete()}
-                                          </Button>
-                                        </td>
-                                      </tr>
-                                    ))}
-                                  </tbody>
-                                </Table>
-                              </div>
-                            )}
-                          </>
-                        )}
-                      </div>
-                    ) : null}
-
                     <div className="pt-2 border-top">
                       <h6 className="mb-2 text-danger">{m.account_delete_section_title()}</h6>
                       <p className="text-muted small mb-2">{m.account_delete_description()}</p>
@@ -317,30 +208,6 @@ export function SettingsAccountSection({
           )}
         </ListGroup>
       </div>
-      <ConfirmationDialog
-        isOpen={pendingDeleteUser !== null}
-        title={m.account_admin_users_delete_confirm_title()}
-        message={
-          pendingDeleteUser
-            ? m.account_admin_users_delete_confirm_message({
-                name: pendingDeleteUser.display_name || pendingDeleteUser.username,
-                username: pendingDeleteUser.username,
-              })
-            : ""
-        }
-        confirmLabel={m.delete()}
-        cancelLabel={m.cancel()}
-        onConfirm={() => {
-          if (!pendingDeleteUser) {
-            return;
-          }
-          onDeleteAdminUser(pendingDeleteUser.id);
-          setPendingDeleteUserId(null);
-        }}
-        onCancel={() => setPendingDeleteUserId(null)}
-        variant="danger"
-        icon="bi-trash"
-      />
       <ConfirmationDialog
         isOpen={showDeleteAccountConfirm}
         title={m.account_delete_confirm_title()}

--- a/frontend/src/components/settings/admin/SettingsAdminUsersSection.tsx
+++ b/frontend/src/components/settings/admin/SettingsAdminUsersSection.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import ListGroup from "react-bootstrap/ListGroup";
+import Table from "react-bootstrap/Table";
+import { ConfirmationDialog } from "@/components/ConfirmationDialog";
+import * as m from "@/paraglide/messages.js";
+import { getLocale } from "@/paraglide/runtime.js";
+
+const formatTimestamp = (value: string): string => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  const locale = getLocale() === "nl" ? "nl-NL" : "en-US";
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(parsed);
+};
+
+interface SettingsAdminUsersSectionProps {
+  currentAccountId: number | null;
+  adminUsers: Array<{
+    id: number;
+    username: string;
+    display_name: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+  isAdminUsersLoading: boolean;
+  adminUsersError: string | null;
+  adminUsersDeleteError: string | null;
+  deletingAdminUserId: number | null;
+  onDeleteAdminUser: (userId: number) => void;
+}
+
+export function SettingsAdminUsersSection({
+  currentAccountId,
+  adminUsers,
+  isAdminUsersLoading,
+  adminUsersError,
+  adminUsersDeleteError,
+  deletingAdminUserId,
+  onDeleteAdminUser,
+}: SettingsAdminUsersSectionProps) {
+  const [pendingDeleteUserId, setPendingDeleteUserId] = useState<number | null>(null);
+  const pendingDeleteUser = adminUsers.find((user) => user.id === pendingDeleteUserId) ?? null;
+
+  return (
+    <div className="border-bottom">
+      <div className="p-3">
+        <h6 className="text-muted mb-3">
+          <i className="bi bi-people me-2"></i>
+          {m.account_admin_users_title()}
+        </h6>
+        <ListGroup variant="flush">
+          <ListGroup.Item>
+            <p className="text-muted small mb-2">{m.account_admin_users_description()}</p>
+            {isAdminUsersLoading ? (
+              <div className="d-flex align-items-center gap-2 text-muted small">
+                <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                <span>{m.account_admin_users_loading()}</span>
+              </div>
+            ) : adminUsersError ? (
+              <Alert variant="warning" className="mb-0 py-2">
+                {adminUsersError}
+              </Alert>
+            ) : (
+              <>
+                {adminUsersDeleteError ? (
+                  <Alert variant="danger" className="mb-2 py-2">
+                    {adminUsersDeleteError}
+                  </Alert>
+                ) : null}
+                {adminUsers.length === 0 ? (
+                  <p className="text-muted small mb-0">{m.account_admin_users_empty()}</p>
+                ) : (
+                  <div className="table-responsive">
+                    <Table size="sm" striped hover className="mb-0 align-middle">
+                      <thead>
+                        <tr>
+                          <th>{m.account_admin_users_user_id()}</th>
+                          <th>{m.account_admin_users_username()}</th>
+                          <th>{m.account_admin_users_display_name()}</th>
+                          <th>{m.account_admin_users_created_at()}</th>
+                          <th>{m.account_admin_users_updated_at()}</th>
+                          <th className="text-end">{m.account_admin_users_actions()}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {adminUsers.map((user) => (
+                          <tr key={user.id}>
+                            <td>{user.id}</td>
+                            <td>{user.username}</td>
+                            <td>{user.display_name}</td>
+                            <td>{formatTimestamp(user.created_at)}</td>
+                            <td>{formatTimestamp(user.updated_at)}</td>
+                            <td className="text-end">
+                              <Button
+                                variant="outline-danger"
+                                size="sm"
+                                disabled={currentAccountId === user.id || deletingAdminUserId !== null}
+                                title={
+                                  currentAccountId === user.id
+                                    ? m.account_admin_users_delete_self_blocked()
+                                    : undefined
+                                }
+                                onClick={() => setPendingDeleteUserId(user.id)}
+                              >
+                                {deletingAdminUserId === user.id
+                                  ? m.account_admin_users_delete_busy()
+                                  : m.delete()}
+                              </Button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </Table>
+                  </div>
+                )}
+              </>
+            )}
+          </ListGroup.Item>
+        </ListGroup>
+      </div>
+      <ConfirmationDialog
+        isOpen={pendingDeleteUser !== null}
+        title={m.account_admin_users_delete_confirm_title()}
+        message={
+          pendingDeleteUser
+            ? m.account_admin_users_delete_confirm_message({
+                name: pendingDeleteUser.display_name || pendingDeleteUser.username,
+                username: pendingDeleteUser.username,
+              })
+            : ""
+        }
+        confirmLabel={m.delete()}
+        cancelLabel={m.cancel()}
+        onConfirm={() => {
+          if (!pendingDeleteUser) {
+            return;
+          }
+          onDeleteAdminUser(pendingDeleteUser.id);
+          setPendingDeleteUserId(null);
+        }}
+        onCancel={() => setPendingDeleteUserId(null)}
+        variant="danger"
+        icon="bi-trash"
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -58,6 +58,15 @@ export function SettingsPage() {
   const activeSection = search.section ?? "general";
   const [isAdmin, setIsAdmin] = useState(false);
 
+  useEffect(() => {
+    // validateSearch remaps the deprecated ?section=sync value to "account" internally,
+    // but that doesn't rewrite the address bar — do that explicitly so copied
+    // links/bookmarks point at the canonical URL going forward.
+    if (new URLSearchParams(window.location.search).get("section") === "sync") {
+      void navigate({ to: "/settings", search: { section: "account" }, replace: true });
+    }
+  }, [navigate]);
+
   const visibleSections = useMemo(
     () => SETTINGS_SECTIONS.filter((section) => !section.adminOnly || isAdmin),
     [isAdmin],

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
 import { useVersionClickEasterEgg } from "@/pages/settings/hooks/useVersionClickEasterEgg";
 import Button from "react-bootstrap/Button";
@@ -19,6 +19,7 @@ import { ChangelogModal } from "@/components/ChangelogModal";
 import { DevOptionsPanel } from "@/components/DevOptionsPanel";
 import { ResetSettingsModal } from "@/components/settings/data/ResetSettingsModal";
 import { SettingsAccountSection } from "@/components/settings/account/SettingsAccountSection";
+import { SettingsAdminUsersSection } from "@/components/settings/admin/SettingsAdminUsersSection";
 import { SettingsAboutSection } from "@/components/settings/SettingsAboutSection";
 import { SettingsDataSection } from "@/components/settings/data/SettingsDataSection";
 import { SettingsFeaturesSection } from "@/components/settings/SettingsFeaturesSection";
@@ -29,6 +30,7 @@ import { useApiClient } from "@/hooks/useApiClient";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
 import { useOngoingSyncContext } from "@/contexts/OngoingSyncContext";
 import { useSettingsAccount } from "@/pages/settings/hooks/useSettingsAccount";
+import { useSettingsAdminUsers } from "@/pages/settings/hooks/useSettingsAdminUsers";
 import { useSettingsSyncStatus } from "@/pages/settings/hooks/useSettingsSyncStatus";
 import { useSettingsResetFlow } from "@/pages/settings/hooks/useSettingsResetFlow";
 import * as m from "@/paraglide/messages.js";
@@ -38,12 +40,13 @@ const SETTINGS_SECTIONS: Array<{
   key: SettingsSection;
   icon: string;
   label: () => string;
+  adminOnly?: boolean;
 }> = [
   { key: "general", icon: "bi-sliders", label: m.preferences_title },
   { key: "features", icon: "bi-grid", label: m.features_title },
   { key: "timeTracking", icon: "bi-clock-history", label: m.time_tracking_section_title },
   { key: "account", icon: "bi-person-circle", label: m.account_section_title },
-  { key: "sync", icon: "bi-cloud-check", label: m.sync_section_title },
+  { key: "admin", icon: "bi-people", label: m.account_admin_users_title, adminOnly: true },
   { key: "data", icon: "bi-database", label: m.quick_actions_title },
   { key: "about", icon: "bi-info-circle", label: m.information_title },
 ];
@@ -53,6 +56,12 @@ export function SettingsPage() {
   const search = useSearch({ from: "/settings" });
   const { openAbout, openShortcuts } = useAppShellContext();
   const activeSection = search.section ?? "general";
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  const visibleSections = useMemo(
+    () => SETTINGS_SECTIONS.filter((section) => !section.adminOnly || isAdmin),
+    [isAdmin],
+  );
 
   const sectionMeta = useMemo(() => {
     const matchedSection = SETTINGS_SECTIONS.find((section) => section.key === activeSection);
@@ -87,7 +96,7 @@ export function SettingsPage() {
                 </div>
               </div>
               <div className="p-2 d-grid gap-2">
-                {SETTINGS_SECTIONS.map((section) => {
+                {visibleSections.map((section) => {
                   const isActive = section.key === activeSection;
                   return (
                     <Button
@@ -116,6 +125,7 @@ export function SettingsPage() {
               onHide={() => void navigate({ to: "/" })}
               onShowAbout={openAbout}
               onShowShortcuts={openShortcuts}
+              onAdminStatusChange={setIsAdmin}
             />
           </div>
         </div>
@@ -129,7 +139,7 @@ export type SettingsSection =
   | "features"
   | "timeTracking"
   | "account"
-  | "sync"
+  | "admin"
   | "data"
   | "about";
 
@@ -147,11 +157,13 @@ export function SettingsContent({
   onShowAbout,
   onShowShortcuts,
   activeSection = "general",
+  onAdminStatusChange,
 }: {
   onHide: () => void;
   onShowAbout?: () => void;
   onShowShortcuts?: () => void;
   activeSection?: SettingsSection;
+  onAdminStatusChange?: (isAdmin: boolean) => void;
 }) {
   const [showChangelog, setShowChangelog] = useState(false);
   const [showDevOptions, setShowDevOptions] = useState(false);
@@ -192,12 +204,6 @@ export function SettingsContent({
     hasProfileChanges,
     resolvedDisplayName,
     handleSaveProfile,
-    adminUsers,
-    isAdminUsersLoading,
-    adminUsersError,
-    adminUsersDeleteError,
-    deletingAdminUserId,
-    handleDeleteAdminUser,
     isDeletingAccount,
     deleteAccountError,
     handleDeleteAccount,
@@ -208,6 +214,25 @@ export function SettingsContent({
     showSuccessToast: toast.showSuccess,
     onAccountDeleted: logout,
   });
+  const isAdmin = accountProfile?.is_admin ?? false;
+  const {
+    adminUsers,
+    isAdminUsersLoading,
+    adminUsersError,
+    adminUsersDeleteError,
+    deletingAdminUserId,
+    handleDeleteAdminUser,
+  } = useSettingsAdminUsers({
+    isAuthenticated,
+    isAdmin,
+    currentAccountId: accountProfile?.id ?? null,
+    fetchFn,
+    showSuccessToast: toast.showSuccess,
+  });
+
+  useEffect(() => {
+    onAdminStatusChange?.(isAdmin);
+  }, [isAdmin, onAdminStatusChange]);
   const { syncStatus, retryInSeconds, lastSyncedLabel, backupStatusLabel } = useSettingsSyncStatus({
     isAuthenticated,
     hasSyncError,
@@ -279,49 +304,55 @@ export function SettingsContent({
 
   const sectionRenderers: Record<SettingsSection, () => ReactNode> = {
     account: () => (
-      <SettingsAccountSection
-        isValidating={isValidating}
-        isAuthenticated={isAuthenticated}
-        resolvedDisplayName={resolvedDisplayName}
-        username={accountProfile?.username ?? null}
-        accountId={accountProfile?.id ?? null}
-        userId={userId}
-        isAdmin={accountProfile?.is_admin ?? false}
-        profileError={profileError}
-        isProfileLoading={isProfileLoading}
-        profileDraft={profileDraft}
-        isProfileSaving={isProfileSaving}
-        hasProfileChanges={hasProfileChanges}
-        onProfileDraftChange={setProfileDraft}
-        onSaveProfile={() => void handleSaveProfile()}
-        adminUsers={adminUsers}
-        isAdminUsersLoading={isAdminUsersLoading}
-        adminUsersError={adminUsersError}
-        adminUsersDeleteError={adminUsersDeleteError}
-        deletingAdminUserId={deletingAdminUserId}
-        onDeleteAdminUser={(userId) => void handleDeleteAdminUser(userId)}
-        isDeletingAccount={isDeletingAccount}
-        deleteAccountError={deleteAccountError}
-        onDeleteAccount={() => void handleDeleteAccount()}
-        onLogout={logout}
-        onSignup={triggerSignup}
-        onLogin={triggerLogin}
-      />
+      <>
+        <SettingsAccountSection
+          isValidating={isValidating}
+          isAuthenticated={isAuthenticated}
+          resolvedDisplayName={resolvedDisplayName}
+          username={accountProfile?.username ?? null}
+          accountId={accountProfile?.id ?? null}
+          userId={userId}
+          isAdmin={isAdmin}
+          profileError={profileError}
+          isProfileLoading={isProfileLoading}
+          profileDraft={profileDraft}
+          isProfileSaving={isProfileSaving}
+          hasProfileChanges={hasProfileChanges}
+          onProfileDraftChange={setProfileDraft}
+          onSaveProfile={() => void handleSaveProfile()}
+          isDeletingAccount={isDeletingAccount}
+          deleteAccountError={deleteAccountError}
+          onDeleteAccount={() => void handleDeleteAccount()}
+          onLogout={logout}
+          onSignup={triggerSignup}
+          onLogin={triggerLogin}
+        />
+        <SettingsSyncSection
+          isAuthenticated={isAuthenticated}
+          isSyncing={isSyncing}
+          syncStatus={syncStatus}
+          lastSyncedLabel={lastSyncedLabel}
+          outboxCount={outboxCount}
+          conflictCount={conflictCount}
+          backupStatusLabel={backupStatusLabel}
+          hasSyncError={hasSyncError}
+          retryInSeconds={retryInSeconds}
+          onTriggerPull={triggerPull}
+        />
+      </>
     ),
-    sync: () => (
-      <SettingsSyncSection
-        isAuthenticated={isAuthenticated}
-        isSyncing={isSyncing}
-        syncStatus={syncStatus}
-        lastSyncedLabel={lastSyncedLabel}
-        outboxCount={outboxCount}
-        conflictCount={conflictCount}
-        backupStatusLabel={backupStatusLabel}
-        hasSyncError={hasSyncError}
-        retryInSeconds={retryInSeconds}
-        onTriggerPull={triggerPull}
-      />
-    ),
+    admin: () =>
+      isAdmin ? (
+        <SettingsAdminUsersSection
+          currentAccountId={accountProfile?.id ?? null}
+          adminUsers={adminUsers}
+          isAdminUsersLoading={isAdminUsersLoading}
+          adminUsersError={adminUsersError}
+          adminUsersDeleteError={adminUsersDeleteError}
+          deletingAdminUserId={deletingAdminUserId}
+          onDeleteAdminUser={(userId) => void handleDeleteAdminUser(userId)}
+        />
+      ) : null,
     general: () => (
       <SettingsGeneralSection
         scheduleType={scheduleType}

--- a/frontend/src/pages/settings/hooks/useSettingsAccount.ts
+++ b/frontend/src/pages/settings/hooks/useSettingsAccount.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import * as m from "@/paraglide/messages.js";
 import { logger } from "@/utils/logger";
+import { readErrorDetail } from "@/utils/apiClient";
 
 interface AccountProfile {
   id: number;
@@ -12,14 +13,6 @@ interface AccountProfile {
   };
 }
 
-interface ManagedUser {
-  id: number;
-  username: string;
-  display_name: string;
-  created_at: string;
-  updated_at: string;
-}
-
 interface UseSettingsAccountParams {
   isAuthenticated: boolean;
   displayName: string | null;
@@ -27,17 +20,6 @@ interface UseSettingsAccountParams {
   showSuccessToast: (message: string, icon?: string) => void;
   onAccountDeleted: () => void;
 }
-
-const readErrorDetail = async (response: Response): Promise<string | null> => {
-  try {
-    const payload = (await response.json()) as { detail?: unknown };
-    return typeof payload.detail === "string" && payload.detail.trim() !== ""
-      ? payload.detail
-      : null;
-  } catch {
-    return null;
-  }
-};
 
 export function useSettingsAccount({
   isAuthenticated,
@@ -51,11 +33,6 @@ export function useSettingsAccount({
   const [isProfileLoading, setIsProfileLoading] = useState(false);
   const [isProfileSaving, setIsProfileSaving] = useState(false);
   const [profileError, setProfileError] = useState<string | null>(null);
-  const [adminUsers, setAdminUsers] = useState<ManagedUser[]>([]);
-  const [isAdminUsersLoading, setIsAdminUsersLoading] = useState(false);
-  const [adminUsersError, setAdminUsersError] = useState<string | null>(null);
-  const [adminUsersDeleteError, setAdminUsersDeleteError] = useState<string | null>(null);
-  const [deletingAdminUserId, setDeletingAdminUserId] = useState<number | null>(null);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null);
 
@@ -97,48 +74,6 @@ export function useSettingsAccount({
       isCancelled = true;
     };
   }, [isAuthenticated, fetchFn]);
-
-  useEffect(() => {
-    if (!isAuthenticated || !accountProfile?.is_admin) {
-      setAdminUsers([]);
-      setAdminUsersError(null);
-      setAdminUsersDeleteError(null);
-      setIsAdminUsersLoading(false);
-      setDeletingAdminUserId(null);
-      return;
-    }
-
-    let isCancelled = false;
-    setIsAdminUsersLoading(true);
-    setAdminUsersError(null);
-    setAdminUsersDeleteError(null);
-
-    fetchFn("/api/users/?limit=100")
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error(`Unexpected status: ${response.status}`);
-        }
-        const payload = (await response.json()) as {
-          items?: ManagedUser[];
-        };
-        if (isCancelled) return;
-        setAdminUsers(payload.items ?? []);
-      })
-      .catch((error) => {
-        if (isCancelled) return;
-        logger.error("Failed to load admin user list:", error);
-        setAdminUsersError(m.account_admin_users_load_failed());
-      })
-      .finally(() => {
-        if (!isCancelled) {
-          setIsAdminUsersLoading(false);
-        }
-      });
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [isAuthenticated, accountProfile?.is_admin, fetchFn]);
 
   const hasProfileChanges =
     accountProfile !== null &&
@@ -191,37 +126,6 @@ export function useSettingsAccount({
     }
   };
 
-  const handleDeleteAdminUser = async (userId: number) => {
-    if (accountProfile?.id === userId) {
-      setAdminUsersDeleteError(m.account_admin_users_delete_self_blocked());
-      return;
-    }
-
-    setDeletingAdminUserId(userId);
-    setAdminUsersDeleteError(null);
-
-    try {
-      const response = await fetchFn(`/api/users/${userId}`, {
-        method: "DELETE",
-      });
-      if (!response.ok) {
-        throw new Error((await readErrorDetail(response)) ?? m.account_admin_users_delete_failed());
-      }
-
-      setAdminUsers((current) => current.filter((user) => user.id !== userId));
-      showSuccessToast(m.account_admin_users_deleted(), "bi-trash");
-    } catch (error) {
-      logger.error("Failed to delete admin-managed user:", error);
-      setAdminUsersDeleteError(
-        error instanceof Error && error.message.trim() !== ""
-          ? error.message
-          : m.account_admin_users_delete_failed(),
-      );
-    } finally {
-      setDeletingAdminUserId(null);
-    }
-  };
-
   const handleDeleteAccount = async () => {
     setIsDeletingAccount(true);
     setDeleteAccountError(null);
@@ -254,12 +158,6 @@ export function useSettingsAccount({
     hasProfileChanges,
     resolvedDisplayName,
     handleSaveProfile,
-    adminUsers,
-    isAdminUsersLoading,
-    adminUsersError,
-    adminUsersDeleteError,
-    deletingAdminUserId,
-    handleDeleteAdminUser,
     isDeletingAccount,
     deleteAccountError,
     handleDeleteAccount,

--- a/frontend/src/pages/settings/hooks/useSettingsAdminUsers.ts
+++ b/frontend/src/pages/settings/hooks/useSettingsAdminUsers.ts
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import * as m from "@/paraglide/messages.js";
+import { logger } from "@/utils/logger";
+import { readErrorDetail } from "@/utils/apiClient";
+
+interface ManagedUser {
+  id: number;
+  username: string;
+  display_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface UseSettingsAdminUsersParams {
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  currentAccountId: number | null;
+  fetchFn: (input: string, init?: RequestInit) => Promise<Response>;
+  showSuccessToast: (message: string, icon?: string) => void;
+}
+
+export function useSettingsAdminUsers({
+  isAuthenticated,
+  isAdmin,
+  currentAccountId,
+  fetchFn,
+  showSuccessToast,
+}: UseSettingsAdminUsersParams) {
+  const [adminUsers, setAdminUsers] = useState<ManagedUser[]>([]);
+  const [isAdminUsersLoading, setIsAdminUsersLoading] = useState(false);
+  const [adminUsersError, setAdminUsersError] = useState<string | null>(null);
+  const [adminUsersDeleteError, setAdminUsersDeleteError] = useState<string | null>(null);
+  const [deletingAdminUserId, setDeletingAdminUserId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !isAdmin) {
+      setAdminUsers([]);
+      setAdminUsersError(null);
+      setAdminUsersDeleteError(null);
+      setIsAdminUsersLoading(false);
+      setDeletingAdminUserId(null);
+      return;
+    }
+
+    let isCancelled = false;
+    setIsAdminUsersLoading(true);
+    setAdminUsersError(null);
+    setAdminUsersDeleteError(null);
+
+    fetchFn("/api/users/?limit=100")
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Unexpected status: ${response.status}`);
+        }
+        const payload = (await response.json()) as {
+          items?: ManagedUser[];
+        };
+        if (isCancelled) return;
+        setAdminUsers(payload.items ?? []);
+      })
+      .catch((error) => {
+        if (isCancelled) return;
+        logger.error("Failed to load admin user list:", error);
+        setAdminUsersError(m.account_admin_users_load_failed());
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setIsAdminUsersLoading(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isAuthenticated, isAdmin, fetchFn]);
+
+  const handleDeleteAdminUser = async (userId: number) => {
+    if (currentAccountId === userId) {
+      setAdminUsersDeleteError(m.account_admin_users_delete_self_blocked());
+      return;
+    }
+
+    setDeletingAdminUserId(userId);
+    setAdminUsersDeleteError(null);
+
+    try {
+      const response = await fetchFn(`/api/users/${userId}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error((await readErrorDetail(response)) ?? m.account_admin_users_delete_failed());
+      }
+
+      setAdminUsers((current) => current.filter((user) => user.id !== userId));
+      showSuccessToast(m.account_admin_users_deleted(), "bi-trash");
+    } catch (error) {
+      logger.error("Failed to delete admin-managed user:", error);
+      setAdminUsersDeleteError(
+        error instanceof Error && error.message.trim() !== ""
+          ? error.message
+          : m.account_admin_users_delete_failed(),
+      );
+    } finally {
+      setDeletingAdminUserId(null);
+    }
+  };
+
+  return {
+    adminUsers,
+    isAdminUsersLoading,
+    adminUsersError,
+    adminUsersDeleteError,
+    deletingAdminUserId,
+    handleDeleteAdminUser,
+  };
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -22,15 +22,20 @@ const settingsRoute = createRoute({
   validateSearch: (
     search: Record<string, unknown>,
   ): {
-    section?: "general" | "features" | "timeTracking" | "account" | "sync" | "data" | "about";
+    section?: "general" | "features" | "timeTracking" | "account" | "admin" | "data" | "about";
   } => {
     const section = typeof search.section === "string" ? search.section : undefined;
+    // "sync" was folded into "account" when the two settings sections were combined;
+    // keep old bookmarks/links working by redirecting them there.
+    if (section === "sync") {
+      return { section: "account" };
+    }
     if (
       section === "general" ||
       section === "features" ||
       section === "timeTracking" ||
       section === "account" ||
-      section === "sync" ||
+      section === "admin" ||
       section === "data" ||
       section === "about"
     ) {

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -45,6 +45,23 @@ export function getRequestId(response: Response): string | null {
  * @param clientOptions - Error callbacks.
  * @returns The fetch Response on success (non-401/403 status).
  */
+/**
+ * Extract the `detail` field from a JSON error response body, if present.
+ *
+ * Returns null when the body isn't JSON or has no non-empty `detail` string,
+ * so callers can fall back to a generic error message.
+ */
+export async function readErrorDetail(response: Response): Promise<string | null> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    return typeof payload.detail === "string" && payload.detail.trim() !== ""
+      ? payload.detail
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function apiFetch(
   url: string,
   init: RequestInit = {},

--- a/frontend/tests/components/SettingsPage.test.tsx
+++ b/frontend/tests/components/SettingsPage.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as oidcContext from "react-oidc-context";
 import { SettingsContent } from "@/pages/SettingsPage";
 import { SettingsAccountSection } from "@/components/settings/account/SettingsAccountSection";
+import { SettingsAdminUsersSection } from "@/components/settings/admin/SettingsAdminUsersSection";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { DeveloperOptionsProvider } from "@/contexts/DeveloperOptionsContext";
 import { EventStoreProvider } from "@/contexts/EventStoreContext";
@@ -15,6 +16,7 @@ import { server } from "@/mocks/server";
 import { labelsCollection } from "@/db/collections";
 import { USER_STATE_STORAGE_KEY } from "@/constants/storageKeys";
 import { useSettingsAccount } from "@/pages/settings/hooks/useSettingsAccount";
+import { useSettingsAdminUsers } from "@/pages/settings/hooks/useSettingsAdminUsers";
 import * as m from "@/paraglide/messages.js";
 
 // Stub <Link> so tests don't need a RouterProvider context.
@@ -123,12 +125,6 @@ function renderSettingsAccountHarness({
       hasProfileChanges,
       resolvedDisplayName,
       handleSaveProfile,
-      adminUsers,
-      isAdminUsersLoading,
-      adminUsersError,
-      adminUsersDeleteError,
-      deletingAdminUserId,
-      handleDeleteAdminUser,
       isDeletingAccount,
       deleteAccountError,
       handleDeleteAccount,
@@ -154,20 +150,56 @@ function renderSettingsAccountHarness({
         profileDraft={profileDraft}
         isProfileSaving={isProfileSaving}
         hasProfileChanges={hasProfileChanges}
+        isDeletingAccount={isDeletingAccount}
+        deleteAccountError={deleteAccountError}
+        onProfileDraftChange={setProfileDraft}
+        onSaveProfile={() => void handleSaveProfile()}
+        onDeleteAccount={() => void handleDeleteAccount()}
+        onLogout={vi.fn()}
+        onSignup={vi.fn()}
+        onLogin={vi.fn()}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return { showSuccessToast };
+}
+
+function renderSettingsAdminUsersHarness({
+  fetchFn,
+  showSuccessToast = vi.fn(),
+  currentAccountId = null,
+}: {
+  fetchFn: (input: string, init?: RequestInit) => Promise<Response>;
+  showSuccessToast?: (message: string, icon?: string) => void;
+  currentAccountId?: number | null;
+}) {
+  function Harness() {
+    const {
+      adminUsers,
+      isAdminUsersLoading,
+      adminUsersError,
+      adminUsersDeleteError,
+      deletingAdminUserId,
+      handleDeleteAdminUser,
+    } = useSettingsAdminUsers({
+      isAuthenticated: true,
+      isAdmin: true,
+      currentAccountId,
+      fetchFn,
+      showSuccessToast,
+    });
+
+    return (
+      <SettingsAdminUsersSection
+        currentAccountId={currentAccountId}
         adminUsers={adminUsers}
         isAdminUsersLoading={isAdminUsersLoading}
         adminUsersError={adminUsersError}
         adminUsersDeleteError={adminUsersDeleteError}
         deletingAdminUserId={deletingAdminUserId}
-        isDeletingAccount={isDeletingAccount}
-        deleteAccountError={deleteAccountError}
-        onProfileDraftChange={setProfileDraft}
-        onSaveProfile={() => void handleSaveProfile()}
         onDeleteAdminUser={(userId) => void handleDeleteAdminUser(userId)}
-        onDeleteAccount={() => void handleDeleteAccount()}
-        onLogout={vi.fn()}
-        onSignup={vi.fn()}
-        onLogin={vi.fn()}
       />
     );
   }
@@ -250,211 +282,6 @@ describe("SettingsPage Account Section", () => {
 
     expect(await screen.findByText(/trusted-server model/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Learn more" })).toHaveAttribute("href", "/privacy");
-  });
-
-  it("does not fetch admin users or render user management for non-admin accounts", async () => {
-    let adminUsersRequestCount = 0;
-    server.use(
-      http.get("*/api/users/", () => {
-        adminUsersRequestCount += 1;
-        return HttpResponse.json({ items: [], total: 0 });
-      }),
-    );
-
-    mockAuthenticatedUser("Alice");
-    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
-
-    expect(await screen.findByDisplayValue("Dev User")).toBeInTheDocument();
-    expect(screen.queryByText("User management")).not.toBeInTheDocument();
-    expect(adminUsersRequestCount).toBe(0);
-  });
-
-  it("renders admin-only user management list for admin accounts", async () => {
-    let usersCalled = false;
-    server.use(
-      http.get("*/api/me", () =>
-        HttpResponse.json({
-          id: 1,
-          username: "admin-user",
-          display_name: "Admin User",
-          is_admin: true,
-          capabilities: { backup_enabled: true },
-        }),
-      ),
-      http.get(/.*\/api\/users\/?$/, () => {
-        usersCalled = true;
-        return HttpResponse.json({ items: [], total: 0 });
-      }),
-    );
-
-    mockAuthenticatedUser("Alice");
-    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
-
-    expect(await screen.findByText("User management")).toBeInTheDocument();
-    expect(screen.getByText("No users found.")).toBeInTheDocument();
-    await waitFor(() => {
-      expect(usersCalled).toBe(true);
-    });
-  });
-
-  it("deletes another user from the admin user management table after confirmation", async () => {
-    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
-      if (input === "/api/me") {
-        return jsonResponse({
-          id: 1,
-          username: "admin-user",
-          display_name: "Admin User",
-          is_admin: true,
-          capabilities: { backup_enabled: true },
-        });
-      }
-      if (input === "/api/users/?limit=100") {
-        return jsonResponse({
-          items: [
-            {
-              id: 1,
-              username: "admin-user",
-              display_name: "Admin User",
-              created_at: "2026-01-01T00:00:00Z",
-              updated_at: "2026-01-02T00:00:00Z",
-            },
-            {
-              id: 2,
-              username: "member-user",
-              display_name: "Member User",
-              created_at: "2026-01-03T00:00:00Z",
-              updated_at: "2026-01-04T00:00:00Z",
-            },
-          ],
-          total: 2,
-        });
-      }
-      if (input === "/api/users/2" && init?.method === "DELETE") {
-        return new Response(null, { status: 204 });
-      }
-      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${input}`);
-    });
-    const showSuccessToast = vi.fn();
-
-    const user = userEvent.setup();
-    renderSettingsAccountHarness({ fetchFn, showSuccessToast });
-
-    const memberRow = (await screen.findByText("member-user")).closest("tr");
-    expect(memberRow).not.toBeNull();
-
-    await user.click(within(memberRow!).getByRole("button", { name: "Delete" }));
-
-    const dialog = await screen.findByRole("dialog");
-    expect(within(dialog).getByText("Delete account?")).toBeInTheDocument();
-    expect(
-      within(dialog).getByText(
-        "This permanently deletes the account for Member User (@member-user). This action cannot be undone.",
-      ),
-    ).toBeInTheDocument();
-
-    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
-
-    await waitFor(() => {
-      expect(screen.queryByText("member-user")).not.toBeInTheDocument();
-    });
-    expect(showSuccessToast).toHaveBeenCalledWith("Account deleted.", "bi-trash");
-    expect(fetchFn).toHaveBeenCalledWith("/api/users/2", { method: "DELETE" });
-  });
-
-  it("shows an inline error when deleting a managed user fails", async () => {
-    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
-      if (input === "/api/me") {
-        return jsonResponse({
-          id: 1,
-          username: "admin-user",
-          display_name: "Admin User",
-          is_admin: true,
-          capabilities: { backup_enabled: true },
-        });
-      }
-      if (input === "/api/users/?limit=100") {
-        return jsonResponse({
-          items: [
-            {
-              id: 1,
-              username: "admin-user",
-              display_name: "Admin User",
-              created_at: "2026-01-01T00:00:00Z",
-              updated_at: "2026-01-02T00:00:00Z",
-            },
-            {
-              id: 2,
-              username: "member-user",
-              display_name: "Member User",
-              created_at: "2026-01-03T00:00:00Z",
-              updated_at: "2026-01-04T00:00:00Z",
-            },
-          ],
-          total: 2,
-        });
-      }
-      if (input === "/api/users/2" && init?.method === "DELETE") {
-        return jsonResponse({ detail: "Could not delete user." }, { status: 500 });
-      }
-      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${input}`);
-    });
-
-    const user = userEvent.setup();
-    renderSettingsAccountHarness({ fetchFn });
-
-    const memberRow = (await screen.findByText("member-user")).closest("tr");
-    expect(memberRow).not.toBeNull();
-
-    await user.click(within(memberRow!).getByRole("button", { name: "Delete" }));
-    const dialog = await screen.findByRole("dialog");
-    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
-
-    expect(await screen.findByText("Could not delete user.")).toBeInTheDocument();
-    expect(screen.getByText("member-user")).toBeInTheDocument();
-  });
-
-  it("disables self-delete for the current admin in the user management table", async () => {
-    const fetchFn = vi.fn(async (input: string) => {
-      if (input === "/api/me") {
-        return jsonResponse({
-          id: 1,
-          username: "admin-user",
-          display_name: "Admin User",
-          is_admin: true,
-          capabilities: { backup_enabled: true },
-        });
-      }
-      if (input === "/api/users/?limit=100") {
-        return jsonResponse({
-          items: [
-            {
-              id: 1,
-              username: "admin-user",
-              display_name: "Admin User",
-              created_at: "2026-01-01T00:00:00Z",
-              updated_at: "2026-01-02T00:00:00Z",
-            },
-            {
-              id: 2,
-              username: "member-user",
-              display_name: "Member User",
-              created_at: "2026-01-03T00:00:00Z",
-              updated_at: "2026-01-04T00:00:00Z",
-            },
-          ],
-          total: 2,
-        });
-      }
-      throw new Error(`Unexpected request: GET ${input}`);
-    });
-
-    renderSettingsAccountHarness({ fetchFn });
-
-    const adminRow = (await screen.findAllByRole("row")).find((row) =>
-      within(row).queryByText("admin-user"),
-    );
-    expect(adminRow).not.toBeNull();
-    expect(within(adminRow!).getByRole("button", { name: "Delete" })).toBeDisabled();
   });
 
   it("renders a self-service account deletion danger zone", async () => {
@@ -604,16 +431,14 @@ describe("SettingsPage Account Section", () => {
     expect(screen.getByText("Automatic cloud backup")).toBeInTheDocument();
     expect(screen.getByText("Cross-device access")).toBeInTheDocument();
   });
-});
 
-describe("SettingsPage Sync Section", () => {
-  it("shows signed-out messaging when unauthenticated", () => {
-    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
+  it("shows signed-out sync messaging when unauthenticated", () => {
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
     expect(screen.getByText(m.sync_signed_out_description())).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: m.sync_manual_pull_btn() })).not.toBeInTheDocument();
   });
 
-  it("renders signed-in status and calls pull action when button is enabled", async () => {
+  it("renders sync status alongside the account profile and calls pull action when enabled", async () => {
     const triggerPullMock = vi.fn();
     mockAuthenticatedUser("Alice");
     useOngoingSyncContextSpy = vi
@@ -627,8 +452,9 @@ describe("SettingsPage Sync Section", () => {
       );
 
     const user = userEvent.setup();
-    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
 
+    expect(await screen.findByDisplayValue("Dev User")).toBeInTheDocument();
     expect(screen.getByText(/Last synced:/i)).toBeInTheDocument();
     const pullButton = screen.getByRole("button", { name: m.sync_manual_pull_btn() });
     expect(pullButton).toBeEnabled();
@@ -642,8 +468,191 @@ describe("SettingsPage Sync Section", () => {
       .spyOn(await import("@/contexts/OngoingSyncContext"), "useOngoingSyncContext")
       .mockReturnValue(createMockSyncContext({ isSyncing: true }));
 
-    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="sync" />);
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
     expect(screen.getByRole("button", { name: m.sync_manual_pull_busy() })).toBeDisabled();
+  });
+});
+
+describe("SettingsPage Admin Section", () => {
+  it("does not fetch admin users or render user management for non-admin accounts", async () => {
+    let adminUsersRequestCount = 0;
+    server.use(
+      http.get("*/api/users/", () => {
+        adminUsersRequestCount += 1;
+        return HttpResponse.json({ items: [], total: 0 });
+      }),
+    );
+
+    mockAuthenticatedUser("Alice");
+    // useSettingsAdminUsers mounts regardless of activeSection, so rendering the
+    // account section (whose profile-loaded state we can await) is enough to
+    // prove a non-admin viewing Settings never triggers the admin users fetch.
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="account" />);
+
+    expect(await screen.findByDisplayValue("Dev User")).toBeInTheDocument();
+    expect(screen.queryByText("User management")).not.toBeInTheDocument();
+    expect(adminUsersRequestCount).toBe(0);
+  });
+
+  it("renders the user management list for admin accounts", async () => {
+    let usersCalled = false;
+    server.use(
+      http.get("*/api/me", () =>
+        HttpResponse.json({
+          id: 1,
+          username: "admin-user",
+          display_name: "Admin User",
+          is_admin: true,
+          capabilities: { backup_enabled: true },
+        }),
+      ),
+      http.get(/.*\/api\/users\/?$/, () => {
+        usersCalled = true;
+        return HttpResponse.json({ items: [], total: 0 });
+      }),
+    );
+
+    mockAuthenticatedUser("Alice");
+    renderWithProviders(<SettingsContent onHide={vi.fn()} activeSection="admin" />);
+
+    expect(await screen.findByText("User management")).toBeInTheDocument();
+    expect(await screen.findByText("No users found.")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(usersCalled).toBe(true);
+    });
+  });
+
+  it("deletes another user from the admin user management table after confirmation", async () => {
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input === "/api/users/?limit=100") {
+        return jsonResponse({
+          items: [
+            {
+              id: 1,
+              username: "admin-user",
+              display_name: "Admin User",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-02T00:00:00Z",
+            },
+            {
+              id: 2,
+              username: "member-user",
+              display_name: "Member User",
+              created_at: "2026-01-03T00:00:00Z",
+              updated_at: "2026-01-04T00:00:00Z",
+            },
+          ],
+          total: 2,
+        });
+      }
+      if (input === "/api/users/2" && init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${input}`);
+    });
+    const showSuccessToast = vi.fn();
+
+    const user = userEvent.setup();
+    renderSettingsAdminUsersHarness({ fetchFn, showSuccessToast, currentAccountId: 1 });
+
+    const memberRow = (await screen.findByText("member-user")).closest("tr");
+    expect(memberRow).not.toBeNull();
+
+    await user.click(within(memberRow!).getByRole("button", { name: "Delete" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Delete account?")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        "This permanently deletes the account for Member User (@member-user). This action cannot be undone.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("member-user")).not.toBeInTheDocument();
+    });
+    expect(showSuccessToast).toHaveBeenCalledWith("Account deleted.", "bi-trash");
+    expect(fetchFn).toHaveBeenCalledWith("/api/users/2", { method: "DELETE" });
+  });
+
+  it("shows an inline error when deleting a managed user fails", async () => {
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input === "/api/users/?limit=100") {
+        return jsonResponse({
+          items: [
+            {
+              id: 1,
+              username: "admin-user",
+              display_name: "Admin User",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-02T00:00:00Z",
+            },
+            {
+              id: 2,
+              username: "member-user",
+              display_name: "Member User",
+              created_at: "2026-01-03T00:00:00Z",
+              updated_at: "2026-01-04T00:00:00Z",
+            },
+          ],
+          total: 2,
+        });
+      }
+      if (input === "/api/users/2" && init?.method === "DELETE") {
+        return jsonResponse({ detail: "Could not delete user." }, { status: 500 });
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${input}`);
+    });
+
+    const user = userEvent.setup();
+    renderSettingsAdminUsersHarness({ fetchFn, currentAccountId: 1 });
+
+    const memberRow = (await screen.findByText("member-user")).closest("tr");
+    expect(memberRow).not.toBeNull();
+
+    await user.click(within(memberRow!).getByRole("button", { name: "Delete" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    expect(await screen.findByText("Could not delete user.")).toBeInTheDocument();
+    expect(screen.getByText("member-user")).toBeInTheDocument();
+  });
+
+  it("disables self-delete for the current admin in the user management table", async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (input === "/api/users/?limit=100") {
+        return jsonResponse({
+          items: [
+            {
+              id: 1,
+              username: "admin-user",
+              display_name: "Admin User",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-02T00:00:00Z",
+            },
+            {
+              id: 2,
+              username: "member-user",
+              display_name: "Member User",
+              created_at: "2026-01-03T00:00:00Z",
+              updated_at: "2026-01-04T00:00:00Z",
+            },
+          ],
+          total: 2,
+        });
+      }
+      throw new Error(`Unexpected request: GET ${input}`);
+    });
+
+    renderSettingsAdminUsersHarness({ fetchFn, currentAccountId: 1 });
+
+    const adminRow = (await screen.findAllByRole("row")).find((row) =>
+      within(row).queryByText("admin-user"),
+    );
+    expect(adminRow).not.toBeNull();
+    expect(within(adminRow!).getByRole("button", { name: "Delete" })).toBeDisabled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Combine the `Account` and `Sync` Settings sections into a single "Account" nav entry (`SettingsAccountSection` + `SettingsSyncSection` now render stacked together under `?section=account`), since both are about the signed-in user's account state.
- Pull the admin-only "User management" table out of `SettingsAccountSection` into its own `SettingsAdminUsersSection` component, shown as a separate nav entry that only appears for admins.
- `?section=sync` links/bookmarks now redirect to `account` for backward compatibility.

## Implementation notes

- New hook `useSettingsAdminUsers` extracts the admin users fetch/delete logic that used to live in `useSettingsAccount`.
- `SettingsPage`'s nav list is filtered by admin status, which `SettingsContent` reports up via an `onAdminStatusChange` callback (derived from the existing `/api/me` profile fetch — no extra network calls).
- Visiting the admin section directly while not an admin renders nothing, matching the previous inline-hidden behavior.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (full suite, 1549 tests passing)
- [x] Manually verified in the browser (dev server + mocked auth/API): non-admin sees a single "Account" section with profile + sync status stacked together and no "User management" entry in the nav; admin sees both "Account" and a separate "User management" nav entry, with the admin table rendering in its own section

Closes #1001
