### PR TITLE
Fix false "no roster configured" warning in Unified Calendar

### DIFF
--- a/frontend/src/features/calendar/CalendarView.tsx
+++ b/frontend/src/features/calendar/CalendarView.tsx
@@ -22,6 +22,7 @@ import { buildCalendarConfig } from "@/features/calendar/mapToScheduleXEvents";
 import { useCalendarRangeData, type CalendarRange } from "@/features/calendar/useCalendarRangeData";
 import { useTimeTrackingStorage } from "@/hooks/useTimeTrackingStorage";
 import { dayjs } from "@/utils/dateTimeUtils";
+import { getEffectiveTeam } from "@/utils/scheduleUtils";
 import "@schedule-x/theme-default/dist/index.css";
 import "@/features/calendar/calendar.css";
 
@@ -71,6 +72,9 @@ export function CalendarView({ onChangeSchedule, onChangeTeam }: CalendarViewPro
   const [range, setRange] = useState<CalendarRange>(currentMonthRange);
   const events = useCalendarRangeData(range);
   const { scheduleType, myTeam } = useSettings();
+  // Mirrors useCalendarRangeData's own effective-team check so single-user schedules
+  // (e.g. "9-5", teamCount === 1) don't trigger a false "no roster configured" warning.
+  const effectiveTeam = scheduleType ? getEffectiveTeam(myTeam, scheduleType) : null;
   const toast = useToast();
   const { tasks, labels, addTask, updateTaskTimes } = useTimeTrackingStorage();
   const [selectedTask, setSelectedTask] = useState<StoredTimeTrackingTask | null>(null);
@@ -258,7 +262,7 @@ export function CalendarView({ onChangeSchedule, onChangeTeam }: CalendarViewPro
         Shifts, time off, and time tracking are shown together. Drag a time-tracking task to
         reschedule it.
       </Alert>
-      {(!scheduleType || myTeam === null) && (
+      {effectiveTeam === null && (
         <Alert variant="warning" className="d-flex align-items-center gap-2 py-2">
           <i className="bi bi-exclamation-triangle" aria-hidden="true"></i>
           <span>

--- a/frontend/tests/features/calendar/CalendarView.test.tsx
+++ b/frontend/tests/features/calendar/CalendarView.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CalendarView } from "@/features/calendar/CalendarView";
+import { TestProviders } from "../../utils/testProviders";
+
+function setUserState(overrides: { myTeam: number | null; scheduleType: string | null }) {
+  localStorage.setItem(
+    "worktime_user_state",
+    JSON.stringify({
+      hasCompletedOnboarding: true,
+      myTeam: overrides.myTeam,
+      scheduleType: overrides.scheduleType,
+      settings: {
+        timeFormat: "24h",
+        theme: "system",
+        notifications: "off",
+        vacationAllowance: { yearlyAmounts: {}, unit: "days", hoursPerDay: 8 },
+        enableTimeOff: false,
+        enableTimeTracking: false,
+      },
+      lastUsed: {
+        activeTab: "calendar",
+        scheduleView: "today",
+        otherSchedule: null,
+        timeOffView: "table",
+        timeTrackingView: "daily",
+        otherTeam: null,
+      },
+    }),
+  );
+}
+
+describe("CalendarView (unified calendar) roster warning", () => {
+  it("does not warn for a single-team schedule even when myTeam is null", () => {
+    setUserState({ myTeam: null, scheduleType: "9-5" });
+
+    render(
+      <TestProviders>
+        <CalendarView />
+      </TestProviders>,
+    );
+
+    expect(screen.queryByText(/No roster configured/i)).not.toBeInTheDocument();
+  });
+
+  it("warns when no schedule is selected", () => {
+    setUserState({ myTeam: null, scheduleType: null });
+
+    render(
+      <TestProviders>
+        <CalendarView />
+      </TestProviders>,
+    );
+
+    expect(screen.getByText(/No roster configured/i)).toBeInTheDocument();
+  });
+
+  it("warns for a multi-team schedule when no team is selected", () => {
+    setUserState({ myTeam: null, scheduleType: "5-shift" });
+
+    render(
+      <TestProviders>
+        <CalendarView />
+      </TestProviders>,
+    );
+
+    expect(screen.getByText(/No roster configured/i)).toBeInTheDocument();
+  });
+
+  it("does not warn for a multi-team schedule once a team is selected", () => {
+    setUserState({ myTeam: 1, scheduleType: "5-shift" });
+
+    render(
+      <TestProviders>
+        <CalendarView />
+      </TestProviders>,
+    );
+
+    expect(screen.queryByText(/No roster configured/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/features/calendar/CalendarView.test.tsx
+++ b/frontend/tests/features/calendar/CalendarView.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { USER_STATE_STORAGE_KEY } from "@/constants/storageKeys";
 import { CalendarView } from "@/features/calendar/CalendarView";
 import { TestProviders } from "../../utils/testProviders";
 
 function setUserState(overrides: { myTeam: number | null; scheduleType: string | null }) {
   localStorage.setItem(
-    "worktime_user_state",
+    USER_STATE_STORAGE_KEY,
     JSON.stringify({
       hasCompletedOnboarding: true,
       myTeam: overrides.myTeam,


### PR DESCRIPTION
## Summary

- The Unified Calendar (`frontend/src/features/calendar/CalendarView.tsx`) gated its "No roster configured" warning on `!scheduleType || myTeam === null`, requiring a team pick even for single-team schedules (e.g. `9-5`, `teamCount === 1`) where there's no meaningful team to pick.
- The underlying `useCalendarRangeData` hook already renders shifts correctly in this case via `getEffectiveTeam(myTeam, scheduleType)`, which returns team `1` for single-team schedules regardless of `myTeam`.
- `CalendarView` now computes the same effective team and gates the warning on `effectiveTeam === null`, matching the actual shift-fetching logic (and how `TodayView` treats `myTeam` as highlight-only, not a prerequisite).

## Test plan

- [x] Added `frontend/tests/features/calendar/CalendarView.test.tsx` covering: no warning for single-team schedule (`9-5`) with `myTeam: null`, warning when no schedule is selected, warning for multi-team schedule with no team selected, no warning for multi-team schedule with a team selected.
- [x] `pnpm test` (full suite, 1553 tests passed)
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm typecheck` (clean)

Fixes #1000

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee2bx2QzPTGuoqDZmv4A75)_