### PR TITLE
Drop redundant Up Next tile for single-team schedules

### DIFF
--- a/frontend/src/components/status/PersonalizedStatus.tsx
+++ b/frontend/src/components/status/PersonalizedStatus.tsx
@@ -157,9 +157,11 @@ export function PersonalizedStatusContent({
   // Tooltip details for current shift badge
   const shiftTooltipDetails = `${currentShift.shift.emoji} ${currentShift.shift.name} shift (${formattedShiftTime})`;
 
+  // Single-team schedules (e.g. 9-5) have nothing meaningful to show in "Up Next" —
+  // it's the same shift every day. Drop that tile and let "Today" take the full width.
   return (
     <Row>
-      <Col md={6}>
+      <Col md={hasTeams ? 6 : 12}>
         <Card className="h-100">
           <Card.Body className="d-flex flex-column">
             <Card.Title as="h6" className="mb-2 text-primary">
@@ -324,44 +326,50 @@ export function PersonalizedStatusContent({
           </Card.Body>
         </Card>
       </Col>
-      <Col md={6}>
-        <Card className="h-100">
-          <Card.Body className="d-flex flex-column">
-            <Card.Title as="h6" className="mb-2 text-success">
-              <i className="bi bi-arrow-right-circle me-1" aria-hidden="true"></i>
-              {m.personalized_status_up_next()}
-            </Card.Title>
-            <div className="text-muted flex-grow-1">
-              {nextShift ? (
-                <div>
-                  <div className="fw-semibold">
-                    {nextShift.date.isSame(today, "day")
-                      ? m.today()
-                      : nextShift.date.isSame(today.add(1, "day"), "day")
-                        ? m.personalized_status_tomorrow()
-                        : typeof (nextShift.date as { toDate?: () => Date }).toDate === "function"
-                          ? weekdayDateFormatter.format(
-                              (nextShift.date as { toDate: () => Date }).toDate(),
-                            )
-                          : nextShift.date.format("ddd, MMM D")}{" "}
-                    - {nextShift.shift.name}
+      {hasTeams && (
+        <Col md={6}>
+          <Card className="h-100">
+            <Card.Body className="d-flex flex-column">
+              <Card.Title as="h6" className="mb-2 text-success">
+                <i className="bi bi-arrow-right-circle me-1" aria-hidden="true"></i>
+                {m.personalized_status_up_next()}
+              </Card.Title>
+              <div className="text-muted flex-grow-1">
+                {nextShift ? (
+                  <div>
+                    <div className="fw-semibold">
+                      {nextShift.date.isSame(today, "day")
+                        ? m.today()
+                        : nextShift.date.isSame(today.add(1, "day"), "day")
+                          ? m.personalized_status_tomorrow()
+                          : typeof (nextShift.date as { toDate?: () => Date }).toDate === "function"
+                            ? weekdayDateFormatter.format(
+                                (nextShift.date as { toDate: () => Date }).toDate(),
+                              )
+                            : nextShift.date.format("ddd, MMM D")}{" "}
+                      - {nextShift.shift.name}
+                    </div>
+                    <ShiftTimeDisplay shift={nextShift.shift} className="small text-muted" />
+                    {shiftStartCountdown.isExpired && shiftEndCountdown.isExpired && (
+                      <CountdownBadge
+                        countdown={countdown}
+                        startTime={nextShiftStartTime}
+                        urgency
+                      />
+                    )}
                   </div>
-                  <ShiftTimeDisplay shift={nextShift.shift} className="small text-muted" />
-                  {shiftStartCountdown.isExpired && shiftEndCountdown.isExpired && (
-                    <CountdownBadge countdown={countdown} startTime={nextShiftStartTime} urgency />
-                  )}
-                </div>
-              ) : (
-                <EmptyState
-                  icon="bi-calendar-x"
-                  title={m.personalized_status_no_next_title()}
-                  description={m.personalized_status_no_next_desc()}
-                />
-              )}
-            </div>
-          </Card.Body>
-        </Card>
-      </Col>
+                ) : (
+                  <EmptyState
+                    icon="bi-calendar-x"
+                    title={m.personalized_status_no_next_title()}
+                    description={m.personalized_status_no_next_desc()}
+                  />
+                )}
+              </div>
+            </Card.Body>
+          </Card>
+        </Col>
+      )}
     </Row>
   );
 }

--- a/frontend/tests/components/CurrentStatus.test.tsx
+++ b/frontend/tests/components/CurrentStatus.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CurrentStatus } from "@/components/CurrentStatus";
-import { SettingsProvider } from "@/contexts/SettingsContext";
+import { SettingsProvider, useSettings } from "@/contexts/SettingsContext";
 import { ToastProvider } from "@/contexts/ToastContext";
 import * as useCountdownHook from "@/hooks/useCountdown";
 import { dayjs, formatYYWWD } from "@/utils/dateTimeUtils";
@@ -326,6 +326,51 @@ describe("CurrentStatus Component", () => {
       expect(screen.getByText("Up Next")).toBeInTheDocument();
       expect(screen.getByText(/2024-01-15.*Evening/)).toBeInTheDocument();
       expect(screen.getByText("15:00–23:00")).toBeInTheDocument();
+    });
+  });
+
+  describe("Single-team schedule (9-5)", () => {
+    const defaultSettingsValue = {
+      settings: {
+        timeFormat: "24h" as const,
+        theme: "auto" as const,
+        notifications: "off" as const,
+        vacationAllowance: { yearlyAmounts: {}, unit: "days" as const, hoursPerDay: 8 },
+        enableTimeOff: false,
+        enableTimeTracking: false,
+      },
+      lastUsed: {
+        activeTab: "calendar" as const,
+        scheduleView: "today" as const,
+        otherSchedule: null,
+        timeOffView: "table" as const,
+        timeTrackingView: "daily" as const,
+        otherTeam: null,
+      },
+      scheduleType: "5-shift" as const,
+      myTeam: null,
+    };
+
+    afterEach(() => {
+      // Restore the file-wide default ("5-shift") so later tests aren't affected.
+      vi.mocked(useSettings).mockReturnValue(
+        defaultSettingsValue as ReturnType<typeof useSettings>,
+      );
+    });
+
+    it("should hide the redundant Up Next tile and let Today take the full width", () => {
+      vi.mocked(useSettings).mockReturnValue({
+        ...defaultSettingsValue,
+        scheduleType: "9-5",
+      } as ReturnType<typeof useSettings>);
+
+      renderWithProviders(<CurrentStatus myTeam={null} onChangeTeam={mockOnChangeTeam} />);
+
+      expect(screen.getByText("Today")).toBeInTheDocument();
+      expect(screen.queryByText("Up Next")).not.toBeInTheDocument();
+
+      const todayCard = screen.getByText("Today").closest(".col-md-12");
+      expect(todayCard).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Issue #969 observed that for single-team 9-5 schedules, the Current Status card's "Up Next" tile is pure noise — it always shows the same shift, on the same days, at the same time ("Tomorrow · Day · 09:00–17:00"). The issue framed the fix as subtraction, not addition.

- `PersonalizedStatusContent` now checks `hasTeams` (`teamCount > 1`, same signal `ShiftTimeline` already uses) to decide layout:
  - **Single-team (9-5):** only the "Today" tile renders, at full width (`Col md={12}`).
  - **Multi-team/rotating (2-shift, weekend-shift, 5-shift):** unchanged — "Today" and "Up Next" side by side, plus the shift timeline.
- The date/code (`YYWW.D`) line and shift timeline logic are untouched, per the issue's open questions (kept as-is / already self-hiding respectively).

## Test plan

- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1554/1554 passing, added a test asserting the Up Next tile is hidden and Today spans full width for a 9-5 schedule
- [x] Manually ran the dev server and verified both layouts in a browser (single-team shows only the full-width Today tile; multi-team is unchanged with Today + Up Next side by side) — screenshots shared in chat, not attached here

Closes #969 (the layout-adaptation part; other open questions from the issue — e.g. whether the date/code line should simplify further — were intentionally left as-is per discussion).
