### PR TITLE
feat(pebble): offline dashboard glance, emulator runbook, and mock backend

### DIFF
--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -4,13 +4,15 @@ on:
   pull_request:
     paths:
       - "pebble/**"
-      - "frontend/public/pebble-config.html"
+      - "frontend/src/pages/PebblePairPage.tsx"
+      - "backend/app/services/access_token_service.py"
       - ".github/workflows/pebble.yml"
   push:
     branches: [main]
     paths:
       - "pebble/**"
-      - "frontend/public/pebble-config.html"
+      - "frontend/src/pages/PebblePairPage.tsx"
+      - "backend/app/services/access_token_service.py"
       - ".github/workflows/pebble.yml"
 
 permissions:
@@ -29,3 +31,8 @@ jobs:
       - name: Validate Alloy package contract
         working-directory: pebble
         run: node scripts/validate.mjs
+      # Watch-app logic against stubbed Alloy globals. This is not an Alloy
+      # build — CI has no Pebble SDK, so on-device behavior is still unverified.
+      - name: Test watch app logic
+        working-directory: pebble
+        run: node --test "tests/*.test.mjs"

--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -37,4 +37,64 @@ jobs:
       # build — CI has no Pebble SDK, so on-device behavior is still unverified.
       - name: Test watch app logic
         working-directory: pebble
-        run: node --test "tests/*.test.mjs"
+        run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 22
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Install emulator runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libsdl2-2.0-0 libglib2.0-0 libpixman-1-0 zlib1g
+      - name: Install the Pebble SDK
+        run: |
+          uv tool install pebble-tool
+          pebble sdk install latest
+      - name: Build the Alloy package
+        working-directory: pebble
+        run: pebble build
+      - name: Upload the .pbw
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: worktime-pebble-pbw
+          path: pebble/build/*.pbw
+          if-no-files-found: error
+      - name: Pin pypkjs to an IPv4 bind
+        run: |
+          runner=$(ls "$(uv tool dir)"/pebble-tool/lib/python*/site-packages/pypkjs/runner/websocket.py)
+          sed -i 's/pywsgi.WSGIServer(("", self.port)/pywsgi.WSGIServer(("127.0.0.1", self.port)/' "$runner"
+          grep -q '"127.0.0.1", self.port' "$runner"
+      - name: Install and run on the Emery emulator
+        working-directory: pebble
+        run: |
+          for attempt in 1 2; do
+            if pebble install --emulator emery; then
+              sleep 10
+              if pebble screenshot --emulator emery --no-open screenshot.png; then exit 0; fi
+            fi
+            pebble kill || true
+            sleep 5
+          done
+          exit 1
+      - name: Check the watchapp actually rendered
+        working-directory: pebble
+        run: python3 scripts/check-screenshot.py screenshot.png --background light
+      - name: Upload the screenshot
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: worktime-pebble-screenshot
+          path: pebble/screenshot.png
+          if-no-files-found: warn

--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "pebble/**"
       - "frontend/src/pages/PebblePairPage.tsx"
+      - "backend/app/routers/pebble.py"
       - "backend/app/services/access_token_service.py"
       - ".github/workflows/pebble.yml"
   push:
@@ -12,6 +13,7 @@ on:
     paths:
       - "pebble/**"
       - "frontend/src/pages/PebblePairPage.tsx"
+      - "backend/app/routers/pebble.py"
       - "backend/app/services/access_token_service.py"
       - ".github/workflows/pebble.yml"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@
 
 - `frontend/` contains the web app
 - `backend/` contains the FastAPI service
-- `pebble/` contains the Pebble (Alloy) companion watch app — see `pebble/README.md`. Not built or tested
-  in CI; requires the Pebble SDK/CLI, which isn't vendored in this repo.
+- `pebble/` contains the Pebble (Alloy) companion watch app — see `pebble/README.md`.
+  CI installs the Pebble SDK, builds the package, boots it on Emery, checks a
+  screenshot, and runs the watch-logic tests.
 - Production hosting for `worktime.tjor.im` is handled by the separate infra stack in `/opt/apps/infra`
 - Frontend builds write to `frontend/dist`; in production, Caddy serves this content from `/srv/worktime`
 

--- a/TODO.md
+++ b/TODO.md
@@ -122,7 +122,9 @@ To-do list and development roadmap for Worktime. Audited against the codebase on
 - **What exists**: `pebble/` — an Alloy watch app for clock in/out + active-task glance (issue #996), talking
   to the existing time-tracking endpoints via a phone-side (`pkjs`) companion. Its `/pebble-pair` webview
   authenticates the user with OIDC, then rotates a Pebble-only personal access token; the watch never
-  receives the OIDC access or refresh token.
+  receives the OIDC access or refresh token. The watch keeps a display-only cache of the last dashboard
+  read so shift/task info survives a phone disconnect; clocking stays online-only with no offline queue
+  (issue #1025).
 - **What's missing**: Real device/emulator testing — written against the published Alloy docs, but this repo
   has no Pebble SDK/CLI, so nothing here has actually been built or run on hardware yet. Tokens are already
   scoped to `pebble:read`/`pebble:write` (not full account access), and sensitive account/token-management

--- a/pebble/EMULATOR.md
+++ b/pebble/EMULATOR.md
@@ -4,10 +4,9 @@ A runbook for the Emery QEMU emulator.
 
 **Provenance:** the toolchain findings here come from the sibling Daynest Pebble
 companion's emulator work — same SDK, same Alloy runtime, same emulator — and
-transfer directly. Worktime's own watchapp **has not been run in the emulator
-yet**; the checklist in [`README.md`](README.md) is still open. Treat everything
-below as "how to run it", not "results of running it", except where it says
-otherwise.
+transfer directly. Pebble CI now performs the build, install, screenshot, and
+rendered-screen check on every relevant change; the commands below are also
+useful for local diagnosis.
 
 ## What the emulator can and cannot prove
 
@@ -22,7 +21,7 @@ written after a successful read), and the mutation-replay guards. Watch-side
 `fetch()` never completes under QEMU. See [The `fetch()` dead
 end](#the-fetch-dead-end) for why, and don't spend a day rediscovering it.
 
-That gap is why [`tests/`](tests) exists: `node --test "tests/*.test.mjs"` runs
+That gap is why [`tests/`](tests) exists: `npm test` runs
 `src/embeddedjs/main.js` against stubbed Alloy globals — including four tests
 that drive it over real HTTP against [`scripts/mock-server.py`](scripts/mock-server.py) —
 and covers exactly the request, caching, and replay logic the emulator cannot

--- a/pebble/EMULATOR.md
+++ b/pebble/EMULATOR.md
@@ -1,0 +1,212 @@
+# Testing the Pebble app without a watch
+
+A runbook for the Emery QEMU emulator.
+
+**Provenance:** the toolchain findings here come from the sibling Daynest Pebble
+companion's emulator work — same SDK, same Alloy runtime, same emulator — and
+transfer directly. Worktime's own watchapp **has not been run in the emulator
+yet**; the checklist in [`README.md`](README.md) is still open. Treat everything
+below as "how to run it", not "results of running it", except where it says
+otherwise.
+
+## What the emulator can and cannot prove
+
+It can prove: the package builds; the watchapp launches and stays running; Piu
+renders what you expect at the real screen size; fonts and glyphs resolve;
+`localStorage` works; and configuration sent from the phone side arrives and is
+read back correctly.
+
+It cannot prove anything requiring a live HTTP round-trip — so for Worktime that
+rules out the dashboard load, clock in/out, the offline cache (which is only
+written after a successful read), and the mutation-replay guards. Watch-side
+`fetch()` never completes under QEMU. See [The `fetch()` dead
+end](#the-fetch-dead-end) for why, and don't spend a day rediscovering it.
+
+That gap is why [`tests/`](tests) exists: `node --test "tests/*.test.mjs"` runs
+`src/embeddedjs/main.js` against stubbed Alloy globals — including four tests
+that drive it over real HTTP against [`scripts/mock-server.py`](scripts/mock-server.py) —
+and covers exactly the request, caching, and replay logic the emulator cannot
+reach. The two are complements: the emulator covers rendering and the SDK, the
+node tests cover the network path, and only hardware covers both at once.
+
+## One-time setup
+
+```sh
+sudo apt install nodejs npm libsdl2-2.0-0 libglib2.0-0 libpixman-1-0 zlib1g
+uv tool install pebble-tool     # Python 3.10+; https://docs.astral.sh/uv/
+pebble sdk install latest       # SDK 4.17 + ARM and Moddable toolchains
+```
+
+Two environment notes that cost time:
+
+- `qemu-pebble` is not on `PATH`. It lives in the SDK toolchain, at
+  `~/.local/share/pebble-sdk/SDKs/4.17/toolchain/bin/qemu-pebble`. You only
+  need it directly if you are booting the emulator by hand.
+- **If the host has no IPv6**, pypkjs cannot start. It binds its websocket with
+  `pywsgi.WSGIServer(("", port), ...)`, which resolves to `AF_INET6` and fails
+  with `OSError: [Errno 97] Address family not supported by protocol`; the
+  `pebble` CLI reports this only as a bare `[Errno 111] Connection refused`.
+  Patch the installed copy to bind IPv4:
+
+  ```sh
+  # ~/.local/share/uv/tools/pebble-tool/lib/python3.11/site-packages/pypkjs/runner/websocket.py
+  -  self.server = pywsgi.WSGIServer(("", self.port), ...)
+  +  self.server = pywsgi.WSGIServer(("127.0.0.1", self.port), ...)
+  ```
+
+## Running the app
+
+```sh
+cd pebble
+export SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy   # headless hosts only
+pebble build
+pebble install --emulator emery                      # boots the emulator if needed
+pebble logs --emulator emery
+pebble screenshot --emulator emery --no-open shot.png
+```
+
+`pebble install` launches the app as a side effect, so reinstalling is the
+normal way to restart it.
+
+## Debugging when there is nothing in the logs
+
+**Watch-side `console.log` does not reach `pebble logs` in a release build.**
+Only PKJS output does. A watchapp that throws during startup therefore shows a
+blank screen and produces no diagnostic whatsoever — on Daynest that is exactly
+how a bad font specifier presented, so if Worktime's `18px Gothic` /
+`bold 24px Gothic` / `28px Gothic` styles are not valid on Emery, expect a blank
+screen rather than an error.
+
+The technique that worked is to treat the screen as the console: render
+diagnostics into a Piu `Text` and take a screenshot.
+
+```js
+import {} from "piu/MC";
+const application = new Application(null, { skin: new Skin({ fill: "black" }) });
+// ...then set application.content("status").string = <whatever you want to see>
+```
+
+From there, bisect. A minimal Piu app with a black fill renders, so Piu works;
+add a `Style` with the app's font and it dies, so the font is the problem. It is
+also worth swapping in the stock `pebble new-project --alloy` watchface as a
+control — if that renders inside your package, the toolchain and your
+`package.json` are fine and the fault is in your own `main.js`.
+
+The alternative is `pebble build --debug` plus an xsbug session, which gives
+real exceptions but needs a debugger attached.
+
+## Driving the app
+
+**Configuration.** You do not need the pairing webview. Message keys are
+assigned numerically by the build — read them from `build/*.pbw`'s
+`appinfo.json`. Daynest's package declares two keys and got 10000 and 10001
+(clear of the proxy's 15000+ range); this package declares `API_BASE_URL` and
+`AUTH_TOKEN` in that order in `package.json`, so expect the same, but check
+rather than assume:
+
+```sh
+pebble send-app-message --emulator emery \
+  --string 10000=http://127.0.0.1:8899 10001=wtpat_test
+```
+
+`--string KEY=VALUE` requires the numeric key; passing the symbolic name is
+rejected. This exercises the real path — `Message`'s `onReadable`, the
+`payload.get("API_BASE_URL")` lookup, the `localStorage` write, and the cache
+clear that fires when the token changes.
+
+**Buttons.** Worktime binds UP (refresh) and SELECT (clock in/out):
+
+```sh
+pebble emu-button --emulator emery click up      # or select, down, back
+```
+
+**Other state.** `pebble emu-bt-connection --connected no|yes` toggles the
+Bluetooth connection, which is what drives `watch.connected.pebblekit` and the
+`Phone offline` path, and `pebble emu-set-time` moves the clock.
+
+**Seeing the offline states at all.** Because `fetch()` never completes here,
+the app never writes a `lastDashboard` snapshot, so disconnecting Bluetooth only
+ever shows the empty `Phone offline` screen. To screenshot the cached glance and
+its `Phone offline · HH:MM` line, temporarily seed the snapshot at the top of
+`main.js` (and remove it before committing):
+
+```js
+localStorage.setItem("lastDashboard", JSON.stringify({
+  version: 1,
+  fetchedAt: Math.floor(Date.now() / 1000),
+  shift: "Today: Morning",
+  task: { text: "Working", start_time: new Date(Date.now() - 3600e3).toISOString() },
+}));
+```
+
+## The mock backend
+
+[`scripts/mock-server.py`](scripts/mock-server.py) implements the three routes
+from `backend/app/routers/pebble.py` — dashboard, clock-in, clock-out — with the
+same bearer-token check, the same status codes (201 on clock-in, 409 on a double
+clock-in or a clock-out with nothing running), and payloads that validate
+against the real `PebbleDashboardRead` and `TaskRead` models. It logs every
+request with a timestamp to `requests.log`, which is the point: the
+mutation-replay acceptance criteria are about what the server received, not
+about what the watch displayed. Three rapid SELECT presses should produce
+exactly one `POST clock-in` line.
+
+```sh
+python3 pebble/scripts/mock-server.py 8899
+python3 pebble/scripts/mock-server.py 8899 --latency 3     # time to press SELECT repeatedly
+python3 pebble/scripts/mock-server.py 8899 --fail-with 503 # check the state stays retryable
+python3 pebble/scripts/mock-server.py 8899 --clocked-in    # start mid-task, to clock out first
+```
+
+Requests are served on threads, so genuinely overlapping mutations would appear
+as interleaved log lines rather than being serialized by the server.
+
+It is equally useful for the hardware run — point `API_BASE_URL` at a laptop on
+the same network (`--host <lan-ip>`) instead of at a real Worktime server, and
+you get an exact record of what the watch actually submitted, without touching
+real time-tracking data.
+
+## The `fetch()` dead end
+
+Watch-side `fetch()` never completes under QEMU + pypkjs. The promise never
+settles, and no request reaches the server.
+
+What happens: `httpclient-pebble.js` opens its own AppMessage channel and only
+writes a queued request when that channel reports writable. In
+`pebble-appmessage.c`, writability is granted by `updateActive()`, which is
+driven by a PebbleOS comm-session event gated on
+`sys_app_pp_get_comm_session()` — a *system* session that pypkjs never
+establishes. So the request sits in the queue forever.
+
+Things that look like the cause but are not: `watch.connected.pebblekit` is
+`true` throughout, and the proxy handshake completes (enable
+`moddableProxy.log = true` in `src/pkjs/index.js` and you will see
+`readyReceived` and the watch's `15025` probe). Toggling
+`emu-bt-connection` to force a session event does not help either.
+
+A fetch-only app containing no Worktime code stalls identically, so this is an
+emulator limitation, not an app bug. Confirm that first if you ever suspect
+otherwise.
+
+One consequence worth recognising: each stalled fetch is retained, so repeatedly
+pressing UP eventually aborts the app with `fxAbort memory full` in the log.
+That is a symptom of the stall, not an independent memory bug.
+
+## Gotchas
+
+- **`pkill -f mock-server.py` (or `qemu-pebble`) can kill the shell running
+  it.** If the pattern appears in the enclosing `bash -c` command line, `pkill
+  -f` matches that process too and the script dies silently with a nonzero exit
+  and no output. Confirmed here while writing the tests. Use `pkill -x`, or put
+  the commands in a script file.
+- **A wedged emulator reports `libpebble2.exceptions.TimeoutError` or
+  `Connection refused`**, and `pebble install` may log `QEMU is already
+  running` while nothing responds. `pebble kill` and start again; this happens
+  after an `fxAbort` or a Bluetooth toggle.
+- **The emulator persists app storage across installs**, under
+  `~/.local/share/pebble-sdk/4.17/emery`. Worktime keeps `apiBaseUrl`,
+  `authToken`, and `lastDashboard` in `localStorage`, and all three survive a
+  reinstall — so a token from an earlier run will make the app skip its "Not
+  configured" screen. Use `pebble wipe` for a genuinely clean device.
+- **Screenshots need `SDL_VIDEODRIVER=dummy`** on a headless host, or QEMU fails
+  to start with an SDL error.

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -51,6 +51,10 @@ node scripts/validate.mjs         # package contract
 node --test "tests/*.test.mjs"    # watch-app logic against stubbed Alloy globals
 ```
 
+Without a watch, [`EMULATOR.md`](EMULATOR.md) covers the Emery QEMU emulator — what it can
+and cannot prove, how to drive the app, and the mock backend in
+[`scripts/mock-server.py`](scripts/mock-server.py).
+
 ## Configuration
 
 1. On the phone, open the Worktime app's settings from the Pebble mobile app.
@@ -88,33 +92,48 @@ offline queue:
 All watch → server work is serialized by a single in-flight guard, so repeated SELECT
 presses are dropped while a clock mutation is running rather than queued behind it.
 
-## On-device validation
+## Validation status
 
-CI checks the package contract (`node scripts/validate.mjs`) and runs the watch app's logic —
-caching, staleness, and clock-action serialization — against stubbed Alloy globals
-(`node --test "tests/*.test.mjs"`, harness in `tests/harness.mjs`). Both are deliberately
-separate from an actual Alloy build: CI has no Pebble SDK, and neither one exercises Piu,
-AppMessage, or the phone proxy. **The app has not been compiled, installed, or run on a
-Pebble Time 2 or in the emulator yet** (tracked in
-[#1025](https://github.com/tjorim/worktime/issues/1025)). The Alloy APIs used here (Piu,
-`pebble/message`, `pebble/button`, `fetch()`, watch-side `localStorage`) follow the published
-[Pebble Developer docs](https://developer.repebble.com/guides/alloy/); expect some iteration
-once someone with the hardware runs through:
+Three layers, none of which substitutes for the next:
+
+| Layer | Covers | Where |
+|-------|--------|-------|
+| CI (no SDK) | Package contract; the app's request, caching, and replay logic against stubbed Alloy globals, including four tests driving it over real HTTP against the mock backend | `scripts/validate.mjs`, `tests/` |
+| Emulator | Build, startup, Piu layout, fonts, `localStorage`, AppMessage configuration. **Not** anything needing HTTP — watch-side `fetch()` never completes under QEMU | [`EMULATOR.md`](EMULATOR.md) |
+| Hardware | Everything at once, and the only place the phone proxy runs for real | — |
+
+**The app has not been compiled, installed, or run on a Pebble Time 2 or in the emulator
+yet** (tracked in [#1025](https://github.com/tjorim/worktime/issues/1025)). The Alloy APIs
+used here (Piu, `pebble/message`, `pebble/button`, `fetch()`, watch-side `localStorage`)
+follow the published [Pebble Developer docs](https://developer.repebble.com/guides/alloy/);
+expect some iteration once someone runs through the list below. Record any SDK
+compatibility changes here as they are found.
+
+Doable in the emulator ([`EMULATOR.md`](EMULATOR.md) has the commands):
 
 - [ ] `pebble build` succeeds against the current SDK.
-- [ ] App installs and starts on a Pebble Time 2 (Emery).
+- [ ] The watchapp launches and stays running on Emery.
+- [ ] Shift, status, timer, and hint labels render and fit; the `Gothic` styles resolve.
+- [ ] `pebble send-app-message` configuration is stored and survives a restart.
+- [ ] Disconnecting Bluetooth shows the `Phone offline` path (seed a cached snapshot first
+      to see the stale glance — `fetch()` never populates one under QEMU).
+
+Hardware only:
+
+- [ ] App installs and starts on a Pebble Time 2.
 - [ ] Configuration opens from the stock Pebble phone app, and the paired credential reaches
       the watch.
 - [ ] `GET /api/pebble/dashboard` loads through the phone proxy with a `pebble:read` token.
-- [ ] Shift, task, and elapsed timer render correctly.
+- [ ] The elapsed timer counts from the task's `start_time` (a `Date` parse failure on the
+      backend's `+00:00` offsets would show up here).
 - [ ] UP refreshes; SELECT clocks in and out.
-- [ ] Repeated SELECT presses do not submit overlapping mutations.
+- [ ] Repeated SELECT presses do not submit overlapping mutations — point the watch at
+      `scripts/mock-server.py --latency 3 --host <lan-ip>` and check `requests.log` shows one
+      `POST clock-in`.
 - [ ] 401/403 shows `Sign-in needed`; 429/5xx shows `Try again later (<status>)` and stays
-      retryable.
+      retryable (`--fail-with 503`).
 - [ ] Airplane mode shows the cached glance with its timestamp, and SELECT is a no-op until
       the phone reconnects.
-
-Record any SDK compatibility changes here as they are found.
 
 ## Known limitations
 

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -73,9 +73,13 @@ The watch caches the **last successful dashboard read** (`lastDashboard` in the 
 the read). While the phone link is down — or a request fails — the app keeps showing that
 glance, with the bottom line replaced by the reason and the time it was read, for example
 `Phone offline · 08:12`. The elapsed timer keeps counting from the cached start time, so it
-is an estimate rather than a confirmed value. Snapshots older than 12 hours are discarded
-instead of displayed, and the snapshot is cleared whenever a new pairing credential arrives
-(it may belong to a different account).
+is an estimate rather than a confirmed value. Snapshots older than 12 hours — or stamped in
+the future, after the watch clock moves back — are discarded instead of displayed.
+
+Pairing a new credential clears the snapshot, since it may belong to a different account. A
+read still in flight from the previous credential is discarded when it lands rather than
+being cached or rendered, and the refresh owed to the new credential runs once the in-flight
+request finishes, so the two accounts' state cannot mix.
 
 The cache is **display-only** — clocking in and out remains online-only, and there is no
 offline queue:

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -43,6 +43,14 @@ pebble build
 pebble install --emulator emery   # or: pebble install --phone <phone-ip>
 ```
 
+The checks that do run without the SDK (and in CI) are:
+
+```bash
+cd pebble
+node scripts/validate.mjs         # package contract
+node --test "tests/*.test.mjs"    # watch-app logic against stubbed Alloy globals
+```
+
 ## Configuration
 
 1. On the phone, open the Worktime app's settings from the Pebble mobile app.
@@ -54,13 +62,64 @@ pebble install --emulator emery   # or: pebble install --phone <phone-ip>
 `https://worktime.tjor.im/pebble-pair`. If self-hosting elsewhere, change it to
 your deployment's URL before building.
 
+## Offline behavior
+
+The watch caches the **last successful dashboard read** (`lastDashboard` in the watch's
+`localStorage`: the shift line, the running task's label and start time, and the time of
+the read). While the phone link is down — or a request fails — the app keeps showing that
+glance, with the bottom line replaced by the reason and the time it was read, for example
+`Phone offline · 08:12`. The elapsed timer keeps counting from the cached start time, so it
+is an estimate rather than a confirmed value. Snapshots older than 12 hours are discarded
+instead of displayed, and the snapshot is cleared whenever a new pairing credential arrives
+(it may belong to a different account).
+
+The cache is **display-only** — clocking in and out remains online-only, and there is no
+offline queue:
+
+- SELECT while the phone is disconnected shows the cached glance and does nothing else.
+- If the rendered state came from the cache (or from a failed read), SELECT re-reads
+  `/api/pebble/dashboard` first and acts only on that fresh result, so a stale task can
+  never decide between clock-in and clock-out.
+- After a mutation, the cached state is marked non-authoritative until the follow-up read
+  lands, so a reconnect never replays a request that already succeeded.
+- A `409` from either action means the server moved on (clocked in or out elsewhere); the
+  watch re-reads the dashboard rather than retrying the mutation.
+
+All watch → server work is serialized by a single in-flight guard, so repeated SELECT
+presses are dropped while a clock mutation is running rather than queued behind it.
+
+## On-device validation
+
+CI checks the package contract (`node scripts/validate.mjs`) and runs the watch app's logic —
+caching, staleness, and clock-action serialization — against stubbed Alloy globals
+(`node --test "tests/*.test.mjs"`, harness in `tests/harness.mjs`). Both are deliberately
+separate from an actual Alloy build: CI has no Pebble SDK, and neither one exercises Piu,
+AppMessage, or the phone proxy. **The app has not been compiled, installed, or run on a
+Pebble Time 2 or in the emulator yet** (tracked in
+[#1025](https://github.com/tjorim/worktime/issues/1025)). The Alloy APIs used here (Piu,
+`pebble/message`, `pebble/button`, `fetch()`, watch-side `localStorage`) follow the published
+[Pebble Developer docs](https://developer.repebble.com/guides/alloy/); expect some iteration
+once someone with the hardware runs through:
+
+- [ ] `pebble build` succeeds against the current SDK.
+- [ ] App installs and starts on a Pebble Time 2 (Emery).
+- [ ] Configuration opens from the stock Pebble phone app, and the paired credential reaches
+      the watch.
+- [ ] `GET /api/pebble/dashboard` loads through the phone proxy with a `pebble:read` token.
+- [ ] Shift, task, and elapsed timer render correctly.
+- [ ] UP refreshes; SELECT clocks in and out.
+- [ ] Repeated SELECT presses do not submit overlapping mutations.
+- [ ] 401/403 shows `Sign-in needed`; 429/5xx shows `Try again later (<status>)` and stays
+      retryable.
+- [ ] Airplane mode shows the cached glance with its timestamp, and SELECT is a no-op until
+      the phone reconnects.
+
+Record any SDK compatibility changes here as they are found.
+
 ## Known limitations
 
-- Not build- or device-tested: this environment has no Pebble SDK/emulator, so the Alloy APIs used here
-  (Piu, `pebble/message`, `pebble/button`, `fetch()`) are implemented against the published
-  [Pebble Developer docs](https://developer.repebble.com/guides/alloy/) but haven't been run on real
-  hardware or the emulator. Expect some iteration once tested on-device.
-- Layout is a simple centered stack (`left: 0, right: 0`); it isn't tuned separately for the round Gabbro
-  (Pebble Round 2) display.
+- Layout is a simple centered stack (`left: 4, right: 4`); it isn't tuned separately for the round
+  Gabbro (Pebble Round 2) display.
 - Clock actions use server time and the fixed task label "Working". Configure
   labels or edit task details later in the web or Android app.
+- No offline queue: see "Offline behavior" above.

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -34,8 +34,9 @@ The watch uses this narrow API surface:
 
 ## Building and installing
 
-Requires the [Alloy-enabled Pebble SDK/CLI](https://developer.repebble.com/sdk/). This repo does not vendor
-that tooling, so it isn't run in CI:
+Requires the [Alloy-enabled Pebble SDK/CLI](https://developer.repebble.com/sdk/).
+The repo does not vendor it; Pebble CI installs it with `uv`, builds the `.pbw`,
+boots Emery, and checks a screenshot:
 
 ```bash
 cd pebble
@@ -43,12 +44,12 @@ pebble build
 pebble install --emulator emery   # or: pebble install --phone <phone-ip>
 ```
 
-The checks that do run without the SDK (and in CI) are:
+The checks that also run without the SDK are:
 
 ```bash
 cd pebble
 node scripts/validate.mjs         # package contract
-node --test "tests/*.test.mjs"    # watch-app logic against stubbed Alloy globals
+npm test                         # watch-app logic against stubbed Alloy globals
 ```
 
 Without a watch, [`EMULATOR.md`](EMULATOR.md) covers the Emery QEMU emulator — what it can
@@ -73,13 +74,14 @@ The watch caches the **last successful dashboard read** (`lastDashboard` in the 
 the read). While the phone link is down — or a request fails — the app keeps showing that
 glance, with the bottom line replaced by the reason and the time it was read, for example
 `Phone offline · 08:12`. The elapsed timer keeps counting from the cached start time, so it
-is an estimate rather than a confirmed value. Snapshots older than 12 hours — or stamped in
-the future, after the watch clock moves back — are discarded instead of displayed.
+is an estimate rather than a confirmed value. Snapshots older than 12 hours —
+or stamped in the future after the watch clock moves back — are discarded.
 
-Pairing a new credential clears the snapshot, since it may belong to a different account. A
-read still in flight from the previous credential is discarded when it lands rather than
-being cached or rendered, and the refresh owed to the new credential runs once the in-flight
-request finishes, so the two accounts' state cannot mix.
+A new credential or server URL clears the snapshot because it may select a
+different account or deployment. A read still in flight for the previous
+identity is discarded when it lands rather than being cached or rendered, and
+the refresh owed to the new identity runs once the in-flight request finishes,
+so state cannot mix across accounts or deployments.
 
 The cache is **display-only** — clocking in and out remains online-only, and there is no
 offline queue:
@@ -102,16 +104,14 @@ Three layers, none of which substitutes for the next:
 
 | Layer | Covers | Where |
 |-------|--------|-------|
-| CI (no SDK) | Package contract; the app's request, caching, and replay logic against stubbed Alloy globals, including four tests driving it over real HTTP against the mock backend | `scripts/validate.mjs`, `tests/` |
-| Emulator | Build, startup, Piu layout, fonts, `localStorage`, AppMessage configuration. **Not** anything needing HTTP — watch-side `fetch()` never completes under QEMU | [`EMULATOR.md`](EMULATOR.md) |
+| CI logic | Package contract; the app's request, caching, and replay logic against stubbed Alloy globals, including four tests driving it over real HTTP against the mock backend | `scripts/validate.mjs`, `tests/` |
+| CI emulator | SDK build, startup, Piu layout/fonts, and a rendered-screen check. **Not** anything needing HTTP — watch-side `fetch()` never completes under QEMU | `.github/workflows/pebble.yml`, [`EMULATOR.md`](EMULATOR.md) |
 | Hardware | Everything at once, and the only place the phone proxy runs for real | — |
 
-**The app has not been compiled, installed, or run on a Pebble Time 2 or in the emulator
-yet** (tracked in [#1025](https://github.com/tjorim/worktime/issues/1025)). The Alloy APIs
-used here (Piu, `pebble/message`, `pebble/button`, `fetch()`, watch-side `localStorage`)
-follow the published [Pebble Developer docs](https://developer.repebble.com/guides/alloy/);
-expect some iteration once someone runs through the list below. Record any SDK
-compatibility changes here as they are found.
+The CI workflow now performs the build/emulator portion automatically, but a
+Pebble Time 2 run is still open (tracked in
+[#1025](https://github.com/tjorim/worktime/issues/1025)). Record any additional
+SDK or hardware compatibility changes here as they are found.
 
 Doable in the emulator ([`EMULATOR.md`](EMULATOR.md) has the commands):
 

--- a/pebble/package.json
+++ b/pebble/package.json
@@ -5,6 +5,7 @@
   "keywords": ["pebble-app"],
   "private": true,
   "scripts": {
+    "test": "node --test \"tests/*.test.mjs\"",
     "validate": "node scripts/validate.mjs"
   },
   "dependencies": {

--- a/pebble/package.json
+++ b/pebble/package.json
@@ -5,7 +5,7 @@
   "keywords": ["pebble-app"],
   "private": true,
   "scripts": {
-    "test": "node --test \"tests/*.test.mjs\"",
+    "test": "node --test tests/offline.test.mjs tests/live.test.mjs",
     "validate": "node scripts/validate.mjs"
   },
   "dependencies": {

--- a/pebble/scripts/check-screenshot.py
+++ b/pebble/scripts/check-screenshot.py
@@ -1,0 +1,96 @@
+"""Assert that an emulator screenshot contains the expected app background and text."""
+
+import argparse
+import struct
+import sys
+import zlib
+from collections import Counter
+from pathlib import Path
+
+
+def read_png_rgba(path):
+    data = path.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError(f"{path} is not a PNG")
+    width = height = None
+    compressed = bytearray()
+    position = 8
+    while position < len(data):
+        (length,) = struct.unpack(">I", data[position : position + 4])
+        kind = data[position + 4 : position + 8]
+        payload = data[position + 8 : position + 8 + length]
+        position += 12 + length
+        if kind == b"IHDR":
+            width, height, depth, color = struct.unpack(">IIBB", payload[:10])
+            if (depth, color) != (8, 6):
+                raise ValueError(f"expected 8-bit RGBA, got depth {depth} color type {color}")
+        elif kind == b"IDAT":
+            compressed += payload
+        elif kind == b"IEND":
+            break
+    if width is None:
+        raise ValueError(f"{path} has no IHDR")
+
+    raw = zlib.decompress(bytes(compressed))
+    stride = width * 4
+    previous = bytearray(stride)
+    pixels = []
+    position = 0
+    for _ in range(height):
+        filter_type = raw[position]
+        line = bytearray(raw[position + 1 : position + 1 + stride])
+        position += 1 + stride
+        for index in range(stride):
+            left = line[index - 4] if index >= 4 else 0
+            up = previous[index]
+            up_left = previous[index - 4] if index >= 4 else 0
+            if filter_type == 0:
+                value = line[index]
+            elif filter_type == 1:
+                value = line[index] + left
+            elif filter_type == 2:
+                value = line[index] + up
+            elif filter_type == 3:
+                value = line[index] + (left + up) // 2
+            elif filter_type == 4:
+                estimate = left + up - up_left
+                distances = (
+                    abs(estimate - left),
+                    abs(estimate - up),
+                    abs(estimate - up_left),
+                )
+                value = line[index] + (left, up, up_left)[distances.index(min(distances))]
+            else:
+                raise ValueError(f"unsupported PNG filter {filter_type}")
+            line[index] = value & 0xFF
+        pixels.extend((line[i], line[i + 1], line[i + 2]) for i in range(0, stride, 4))
+        previous = line
+    return pixels
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("screenshot", type=Path)
+    parser.add_argument("--background", choices=("dark", "light"), required=True)
+    parser.add_argument("--min-ink", type=float, default=0.5)
+    args = parser.parse_args()
+
+    pixels = read_png_rgba(args.screenshot)
+    counts = Counter(pixels)
+    background, count = counts.most_common(1)[0]
+    level = sum(background) / 3
+    ink = 100.0 * (len(pixels) - count) / len(pixels)
+    expected = level <= 120 if args.background == "dark" else level >= 180
+    print(f"{args.screenshot}: background rgb{background}, ink {ink:.2f}%")
+    if not expected:
+        print(f"FAIL: dominant color is not the expected {args.background} app background", file=sys.stderr)
+        return 1
+    if ink < args.min_ink:
+        print(f"FAIL: only {ink:.2f}% non-background pixels; the app did not draw text", file=sys.stderr)
+        return 1
+    print("OK: the watchapp rendered.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pebble/scripts/mock-server.py
+++ b/pebble/scripts/mock-server.py
@@ -1,0 +1,256 @@
+"""Mock of Worktime's Pebble routes, for testing the watchapp.
+
+Mirrors backend/app/routers/pebble.py:
+
+    GET  /api/pebble/dashboard              (pebble:read)
+    POST /api/pebble/actions/clock-in       (pebble:write)  201, or 409 if already running
+    POST /api/pebble/actions/clock-out      (pebble:write)  200, or 409 if nothing running
+
+Every request is appended to a timestamped log file, which is the point: the
+acceptance criteria about repeated button presses and cache replay are claims
+about what the server received, not about what the watch displayed. Three rapid
+SELECT presses should leave exactly one "POST clock-in" line behind.
+
+    python3 pebble/scripts/mock-server.py [port] [--host H] [--token T]
+
+Point the watch at it through the pairing flow, or push the configuration
+straight to the emulator (see ../EMULATOR.md for the numeric message keys):
+
+    pebble send-app-message --emulator emery \
+      --string 10000=http://127.0.0.1:8899 10001=wtpat_test
+
+Useful flags:
+
+    --latency 3          hold every response, so there is time to press SELECT
+                         repeatedly while a mutation is in flight
+    --fail-with 503      make every request fail, to check that the watch keeps
+                         the state retryable (401/403 should ask for pairing)
+    --clocked-in         start with a running task, to exercise clock-out first
+
+Responses are served on threads, so a genuinely overlapping mutation would show
+up as interleaved log lines rather than being serialized by the server.
+"""
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from time import sleep
+
+DASHBOARD_PATH = "/api/pebble/dashboard"
+CLOCK_IN_PATH = "/api/pebble/actions/clock-in"
+CLOCK_OUT_PATH = "/api/pebble/actions/clock-out"
+
+# Shaped like read_models.ReadModelShift.
+MORNING = {
+    "code": "M",
+    "display_code": "M",
+    "name": "Morning",
+    "start_hour": 6.0,
+    "end_hour": 14.0,
+    "is_working": True,
+}
+EVENING = {
+    "code": "E",
+    "display_code": "E",
+    "name": "Evening",
+    "start_hour": 14.0,
+    "end_hour": 22.0,
+    "is_working": True,
+}
+
+STATE = {"running_task": None, "next_task_id": 1}
+
+
+def now():
+    """Timestamps in the format FastAPI emits for aware datetimes."""
+    return datetime.now(UTC).isoformat()
+
+
+def task_read(text, start_time, stop_time=None, task_id="task_1"):
+    """Shaped like schemas.TaskRead."""
+    return {
+        "id": task_id,
+        "user_id": 1,
+        "label_id": None,
+        "gantt_task_id": None,
+        "text": text,
+        "start_time": start_time,
+        "stop_time": stop_time,
+        "includes_break": False,
+        "created_at": start_time,
+    }
+
+
+def dashboard(with_shift=True):
+    """Shaped like routers.pebble.PebbleDashboardRead."""
+    today = datetime.now(UTC).date()
+    current_shift = (
+        {
+            "team_number": 3,
+            "date": today.isoformat(),
+            "shift_day": today.isoformat(),
+            "shift_code": "M",
+            "shift": MORNING,
+            "is_currently_working": True,
+        }
+        if with_shift
+        else None
+    )
+    next_items = (
+        [
+            {
+                "team_number": 3,
+                "date": (today + timedelta(days=1)).isoformat(),
+                "shift_code": "E",
+                "shift": EVENING,
+            }
+        ]
+        if with_shift
+        else []
+    )
+    return {
+        "running_task": STATE["running_task"],
+        "current_status": {
+            "as_of": now(),
+            "current_shift": current_shift,
+            "currently_working_team": None,
+            "off_day_progress": None,
+        },
+        "next_shifts": {"as_of": now(), "items": next_items},
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    token = "wtpat_test"
+    log_path = Path("requests.log")
+    latency = 0.0
+    fail_with = None
+    with_shift = True
+
+    def log_message(self, *args):
+        """Silence the default stderr access log; we keep our own."""
+
+    def record(self, line):
+        stamped = f"{datetime.now(UTC).strftime('%H:%M:%S.%f')[:-3]} {line}"
+        with self.log_path.open("a") as fh:
+            fh.write(stamped + "\n")
+        print(stamped, flush=True)
+
+    def authorized(self):
+        return self.headers.get("Authorization") == f"Bearer {self.token}"
+
+    def respond(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def preconditions(self, label):
+        """Shared 401 / forced-failure handling. True means keep going."""
+        if not self.authorized():
+            self.record(f"{label} -> 401 (bad or missing bearer token)")
+            self.respond(401, {"detail": "invalid access token"})
+            return False
+        if self.latency:
+            self.record(f"{label} … holding {self.latency}s")
+            sleep(self.latency)
+        if self.fail_with:
+            self.record(f"{label} -> {self.fail_with} (forced)")
+            self.respond(self.fail_with, {"detail": "forced failure"})
+            return False
+        return True
+
+    def do_GET(self):
+        label = f"GET {self.path}"
+        if self.path != DASHBOARD_PATH:
+            self.record(f"{label} -> 404")
+            return self.respond(404, {"detail": "not found"})
+        if not self.preconditions(label):
+            return
+        running = STATE["running_task"]
+        self.record(f"{label} -> 200 ({'running' if running else 'not clocked in'})")
+        self.respond(200, dashboard(self.with_shift))
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+        if self.path == CLOCK_IN_PATH:
+            action = "clock-in"
+        elif self.path == CLOCK_OUT_PATH:
+            action = "clock-out"
+        else:
+            self.record(f"POST {self.path} -> 404")
+            return self.respond(404, {"detail": "not found"})
+
+        label = f"POST {action}"
+        if not self.preconditions(label):
+            return
+
+        if action == "clock-in":
+            if STATE["running_task"] is not None:
+                self.record(f"{label} -> 409 (a task is already running)")
+                return self.respond(409, {"detail": "A task is already running"})
+            task_id = f"task_{STATE['next_task_id']}"
+            STATE["next_task_id"] += 1
+            STATE["running_task"] = task_read("Working", now(), task_id=task_id)
+            self.record(f"{label} -> 201 {task_id}")
+            return self.respond(201, STATE["running_task"])
+
+        running = STATE["running_task"]
+        if running is None:
+            self.record(f"{label} -> 409 (no running task)")
+            return self.respond(409, {"detail": "No running task to clock out"})
+        stopped = {**running, "stop_time": now()}
+        STATE["running_task"] = None
+        self.record(f"{label} -> 200 {stopped['id']}")
+        self.respond(200, stopped)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mock Worktime Pebble API.")
+    parser.add_argument("port", nargs="?", type=int, default=8899)
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="bind address; pass the LAN address to reach it from a watch on the network",
+    )
+    parser.add_argument("--token", default=Handler.token, help="expected bearer token")
+    parser.add_argument("--log", default="requests.log", help="request log file")
+    parser.add_argument(
+        "--latency",
+        type=float,
+        default=0.0,
+        help="seconds to hold each response, for testing repeated button presses",
+    )
+    parser.add_argument(
+        "--fail-with",
+        type=int,
+        help="respond to everything with this status (401, 429, 503 …)",
+    )
+    parser.add_argument("--clocked-in", action="store_true", help="start with a running task")
+    parser.add_argument("--no-shift", action="store_true", help="report no configured shift")
+    args = parser.parse_args()
+
+    Handler.token = args.token
+    Handler.log_path = Path(args.log)
+    Handler.latency = args.latency
+    Handler.fail_with = args.fail_with
+    Handler.with_shift = not args.no_shift
+    Handler.log_path.write_text("")
+
+    if args.clocked_in:
+        started = (datetime.now(UTC) - timedelta(minutes=42)).isoformat()
+        STATE["running_task"] = task_read("Working", started)
+        STATE["next_task_id"] = 2
+
+    print(f"mock Worktime Pebble API on http://{args.host}:{args.port} (log: {args.log})")
+    ThreadingHTTPServer((args.host, args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/pebble/scripts/validate.mjs
+++ b/pebble/scripts/validate.mjs
@@ -10,6 +10,7 @@ const requiredFiles = [
   "src/embeddedjs/main.js",
   "src/embeddedjs/manifest.json",
   "src/pkjs/index.js",
+  "scripts/mock-server.py",
 ];
 
 for (const file of requiredFiles) {
@@ -43,15 +44,22 @@ const tokenServiceSource = readFileSync(
   resolve(repoRoot, "backend/app/services/access_token_service.py"),
   "utf8",
 );
+const mockSource = readFileSync(resolve(root, "scripts/mock-server.py"), "utf8");
+const routerSource = readFileSync(resolve(repoRoot, "backend/app/routers/pebble.py"), "utf8");
+
 if (!watchSource.includes("fetch(")) throw new Error("Watch code must use Alloy fetch()");
-if (!watchSource.includes("/api/pebble/dashboard")) {
-  throw new Error("Watch code must use the scoped Pebble dashboard");
-}
-for (const path of [
-  "/api/pebble/actions/clock-in",
-  "/api/pebble/actions/clock-out",
+// The watch, the mock backend used for emulator/hardware runs, and the router
+// must agree on every path; a silent drift there is invisible until a device test.
+for (const [path, routerPath] of [
+  ["/api/pebble/dashboard", '"/dashboard"'],
+  ["/api/pebble/actions/clock-in", '"/actions/clock-in"'],
+  ["/api/pebble/actions/clock-out", '"/actions/clock-out"'],
 ]) {
-  if (!watchSource.includes(path)) throw new Error(`Missing clock action: ${path}`);
+  if (!watchSource.includes(path)) throw new Error(`Watch code is missing ${path}`);
+  if (!mockSource.includes(path)) throw new Error(`Mock server is missing ${path}`);
+  if (!routerSource.includes(routerPath)) {
+    throw new Error(`Pebble router no longer declares ${routerPath}`);
+  }
 }
 if (!watchSource.includes("localStorage.setItem(SNAPSHOT_KEY") || !watchSource.includes("loadSnapshot(")) {
   throw new Error("Watch code must persist and restore the offline dashboard snapshot");

--- a/pebble/scripts/validate.mjs
+++ b/pebble/scripts/validate.mjs
@@ -11,6 +11,7 @@ const requiredFiles = [
   "src/embeddedjs/manifest.json",
   "src/pkjs/index.js",
   "scripts/mock-server.py",
+  "scripts/check-screenshot.py",
 ];
 
 for (const file of requiredFiles) {
@@ -69,6 +70,12 @@ if (!watchSource.includes("runExclusive(toggleClock)")) {
 }
 if (!phoneSource.includes("@moddable/pebbleproxy")) {
   throw new Error("Phone code must initialize the official Alloy network proxy");
+}
+if (/,\s*[)\]]/.test(phoneSource)) {
+  throw new Error("Trailing comma in src/pkjs/index.js: the SDK's PKJS bundler cannot parse it");
+}
+if (/Pebble\.sendAppMessage\s*\(/.test(phoneSource)) {
+  throw new Error("Use moddableProxy.sendAppMessage() so sends are queued behind proxy traffic");
 }
 if (!phoneSource.includes("/pebble-pair") || !pairingSource.includes("pebblejs://close")) {
   throw new Error("Phone and web code must use the authenticated Pebble pairing flow");

--- a/pebble/scripts/validate.mjs
+++ b/pebble/scripts/validate.mjs
@@ -53,6 +53,12 @@ for (const path of [
 ]) {
   if (!watchSource.includes(path)) throw new Error(`Missing clock action: ${path}`);
 }
+if (!watchSource.includes("localStorage.setItem(SNAPSHOT_KEY") || !watchSource.includes("loadSnapshot(")) {
+  throw new Error("Watch code must persist and restore the offline dashboard snapshot");
+}
+if (!watchSource.includes("runExclusive(toggleClock)")) {
+  throw new Error("Clock actions must go through the exclusive-action guard");
+}
 if (!phoneSource.includes("@moddable/pebbleproxy")) {
   throw new Error("Phone code must initialize the official Alloy network proxy");
 }

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -359,18 +359,22 @@ const message = new Message({
     const payload = this.read();
     const baseUrl = payload.get("API_BASE_URL");
     const token = payload.get("AUTH_TOKEN");
+    const nextBaseUrl = baseUrl ? baseUrl.replace(/\/$/, "") : apiBaseUrl;
+    const identityChanged =
+      nextBaseUrl !== apiBaseUrl || (token && token !== authToken);
+    if (identityChanged) {
+      // Either value can select a different account or deployment.
+      credentialGeneration += 1;
+      clearSnapshot();
+      dashboardIsLive = false;
+    }
     if (baseUrl) {
-      apiBaseUrl = baseUrl.replace(/\/$/, "");
+      apiBaseUrl = nextBaseUrl;
       localStorage.setItem("apiBaseUrl", apiBaseUrl);
     }
     if (token && token !== authToken) {
       authToken = token;
       localStorage.setItem("authToken", authToken);
-      // The credential may belong to a different account than the cached
-      // glance, and than any read still in flight.
-      credentialGeneration += 1;
-      clearSnapshot();
-      dashboardIsLive = false;
     }
     requestRefresh();
   },

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -87,7 +87,11 @@ function loadSnapshot() {
     clearSnapshot();
     return null;
   }
-  if (Math.floor(Date.now() / 1000) - snapshot.fetchedAt > SNAPSHOT_MAX_AGE_SECONDS) {
+  const age = Math.floor(Date.now() / 1000) - snapshot.fetchedAt;
+  // A negative age means the watch clock moved back since the read; that
+  // snapshot is as untrustworthy as an expired one, and its "as of" time would
+  // be in the future.
+  if (age < 0 || age > SNAPSHOT_MAX_AGE_SECONDS) {
     clearSnapshot();
     return null;
   }
@@ -203,6 +207,14 @@ let authToken = localStorage.getItem("authToken");
 // not been superseded by a mutation or a failure.
 let dashboardIsLive = false;
 let busy = false;
+// Bumped whenever the paired credential changes. A response authorized with
+// the previous token must not be displayed, cached, or used to pick a mutation
+// once it lands, since it describes a different account.
+let credentialGeneration = 0;
+// Set when a lifecycle refresh (reconnect, new credential) arrives while the
+// watch is busy. Dropping a button press is intended; dropping one of these
+// would leave the watch on state it knows is out of date.
+let refreshOwed = false;
 
 // Serializes every watch → server interaction: a second SELECT press while a
 // clock mutation is in flight is dropped instead of queued, so repeated
@@ -212,9 +224,19 @@ async function runExclusive(action) {
   busy = true;
   try {
     await action();
+    while (refreshOwed) {
+      refreshOwed = false;
+      await refreshStatus();
+    }
   } finally {
     busy = false;
   }
+}
+
+// A refresh that must happen even if it cannot happen now.
+function requestRefresh() {
+  if (busy) refreshOwed = true;
+  else runExclusive(refreshStatus);
 }
 
 function authorizationHeaders() {
@@ -269,14 +291,19 @@ async function refreshStatus() {
     showStale("Phone offline");
     return false;
   }
+  const generation = credentialGeneration;
   try {
     const dashboard = await apiRequest("GET", "/api/pebble/dashboard");
+    // Paired to a different account while this was in flight: this response
+    // belongs to the previous one. Discard it; a refresh is already owed.
+    if (generation !== credentialGeneration) return false;
     const snapshot = snapshotOf(dashboard);
     saveSnapshot(snapshot);
     dashboardIsLive = true;
     application.behavior.showSnapshot(snapshot, null);
     return true;
   } catch (error) {
+    if (generation !== credentialGeneration) return false;
     showStale(String(error.message || error));
     return false;
   }
@@ -293,6 +320,7 @@ async function toggleClock() {
     showStale("Phone offline");
     return;
   }
+  const generation = credentialGeneration;
   try {
     // Cached state is display-only: re-read the dashboard before deciding
     // between clock-in and clock-out so a stale task can never be replayed
@@ -301,6 +329,9 @@ async function toggleClock() {
       application.behavior.setHint("Checking…");
       if (!(await refreshStatus())) return;
     }
+    // Never send a mutation authorized with a new credential but decided from
+    // the previously paired account's state.
+    if (generation !== credentialGeneration) return;
     const runningTask = application.behavior.runningTask;
     application.behavior.data.STATUS.string = runningTask ? "Clocking out…" : "Clocking in…";
     // The server view is about to change; only the follow-up read is authoritative.
@@ -311,6 +342,7 @@ async function toggleClock() {
     );
     await refreshStatus();
   } catch (error) {
+    if (generation !== credentialGeneration) return;
     // 409 means the server state moved under us (clocked in or out elsewhere);
     // re-reading resolves it instead of retrying the mutation.
     if (error.status === 409) {
@@ -334,15 +366,17 @@ const message = new Message({
     if (token && token !== authToken) {
       authToken = token;
       localStorage.setItem("authToken", authToken);
-      // The credential may belong to a different account than the cached glance.
+      // The credential may belong to a different account than the cached
+      // glance, and than any read still in flight.
+      credentialGeneration += 1;
       clearSnapshot();
       dashboardIsLive = false;
     }
-    runExclusive(refreshStatus);
+    requestRefresh();
   },
 });
 
-watch.addEventListener("connected", () => runExclusive(refreshStatus));
+watch.addEventListener("connected", requestRefresh);
 
 new Button({
   types: ["up", "select"],

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -5,13 +5,93 @@ import Button from "pebble/button";
 import Message from "pebble/message";
 
 const DEFAULT_API_BASE_URL = "https://worktime.tjor.im";
+// Last successful dashboard, kept so the watch still shows shift and task
+// information while the phone is out of range. Display-only: clock actions
+// never act on it (see toggleClock).
+const SNAPSHOT_KEY = "lastDashboard";
+const SNAPSHOT_VERSION = 1;
+// Beyond this the cached glance is more misleading than useful (an elapsed
+// timer that ran overnight is worse than no timer at all).
+const SNAPSHOT_MAX_AGE_SECONDS = 12 * 60 * 60;
+const CLOCK_HINT = "SELECT: clock in/out";
+
+const pad = (value) => (value < 10 ? `0${value}` : String(value));
 
 function formatElapsed(totalSeconds) {
-  const pad = (value) => (value < 10 ? `0${value}` : String(value));
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
   return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+function formatClock(epochSeconds) {
+  const date = new Date(epochSeconds * 1000);
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function shiftLine(dashboard) {
+  const current = dashboard?.current_status?.current_shift;
+  const next = dashboard?.next_shifts?.items?.[0];
+  if (current?.shift) return `Today: ${current.shift.name || current.shift.code}`;
+  if (next?.shift) return `Next: ${next.shift.name || next.shift.code} ${next.date}`;
+  return "No shift configured";
+}
+
+function runningTaskOf(dashboard) {
+  const task = dashboard?.running_task;
+  if (!task || task.stop_time) return null;
+  return { text: task.text || "Working", start_time: task.start_time };
+}
+
+function snapshotOf(dashboard) {
+  return {
+    version: SNAPSHOT_VERSION,
+    fetchedAt: Math.floor(Date.now() / 1000),
+    shift: shiftLine(dashboard),
+    task: runningTaskOf(dashboard),
+  };
+}
+
+function saveSnapshot(snapshot) {
+  try {
+    localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot));
+  } catch (error) {
+    // A full or unavailable store only costs the offline glance.
+  }
+}
+
+function clearSnapshot() {
+  try {
+    localStorage.removeItem(SNAPSHOT_KEY);
+  } catch (error) {
+    // Nothing to do: the stale snapshot is display-only.
+  }
+}
+
+function loadSnapshot() {
+  let stored;
+  try {
+    stored = localStorage.getItem(SNAPSHOT_KEY);
+  } catch (error) {
+    return null;
+  }
+  if (!stored) return null;
+  let snapshot;
+  try {
+    snapshot = JSON.parse(stored);
+  } catch (error) {
+    clearSnapshot();
+    return null;
+  }
+  if (!snapshot || snapshot.version !== SNAPSHOT_VERSION || !snapshot.fetchedAt) {
+    clearSnapshot();
+    return null;
+  }
+  if (Math.floor(Date.now() / 1000) - snapshot.fetchedAt > SNAPSHOT_MAX_AGE_SECONDS) {
+    clearSnapshot();
+    return null;
+  }
+  return snapshot;
 }
 
 const WorktimeApplication = Application.template(($) => ({
@@ -45,12 +125,13 @@ const WorktimeApplication = Application.template(($) => ({
       string: "",
     }),
     Label($, {
+      anchor: "HINT",
       left: 4,
       right: 4,
       bottom: 12,
       height: 20,
       style: new Style({ font: "16px Gothic", color: "gray" }),
-      string: "SELECT: clock in/out",
+      string: CLOCK_HINT,
     }),
   ],
   Behavior: class extends Behavior {
@@ -62,40 +143,46 @@ const WorktimeApplication = Application.template(($) => ({
 
     onDisplaying(application) {
       application.start();
-      refreshStatus();
+      // Paint the cached glance first so a cold start out of range shows
+      // something better than "Loading…" while the fetch is attempted.
+      const snapshot = loadSnapshot();
+      if (snapshot) this.showSnapshot(snapshot, "Last known");
+      runExclusive(refreshStatus);
+    }
+
+    setHint(hint) {
+      this.data.HINT.string = hint;
     }
 
     showTask(task) {
-      this.runningTask = task && !task.stop_time ? task : null;
-      this.data.STATUS.string = this.runningTask
-        ? this.runningTask.text || "Working"
-        : "Not clocked in";
-      if (!this.runningTask) {
+      this.runningTask = task;
+      this.data.STATUS.string = task ? task.text || "Working" : "Not clocked in";
+      if (!task) {
         this.data.TIMER.string = "";
         this.lastTick = -1;
+        return;
       }
+      this.lastTick = -1;
+      this.onTimeChanged();
     }
 
-    showShift(dashboard) {
-      const current = dashboard?.current_status?.current_shift;
-      const next = dashboard?.next_shifts?.items?.[0];
-      if (current?.shift) {
-        this.data.SHIFT.string = `Today: ${current.shift.name || current.shift.code}`;
-      } else if (next?.shift) {
-        this.data.SHIFT.string = `Next: ${next.shift.name || next.shift.code} ${next.date}`;
-      } else {
-        this.data.SHIFT.string = "No shift configured";
-      }
-    }
-
-    showShiftError() {
-      this.data.SHIFT.string = "Shift unavailable";
+    // `staleReason` is null for a live dashboard, otherwise the reason the
+    // watch is showing cached values (offline, server error, …).
+    showSnapshot(snapshot, staleReason) {
+      this.data.SHIFT.string = snapshot.shift || "Shift unavailable";
+      this.showTask(snapshot.task);
+      this.setHint(
+        staleReason ? `${staleReason} · ${formatClock(snapshot.fetchedAt)}` : CLOCK_HINT,
+      );
     }
 
     showError(message) {
       this.runningTask = null;
+      this.data.SHIFT.string = "Shift unavailable";
       this.data.STATUS.string = message;
       this.data.TIMER.string = "";
+      this.lastTick = -1;
+      this.setHint(CLOCK_HINT);
     }
 
     onTimeChanged() {
@@ -112,13 +199,35 @@ const WorktimeApplication = Application.template(($) => ({
 const application = new WorktimeApplication(null, {});
 let apiBaseUrl = localStorage.getItem("apiBaseUrl") || DEFAULT_API_BASE_URL;
 let authToken = localStorage.getItem("authToken");
-let pending = false;
+// True only while the rendered task state came from a dashboard read that has
+// not been superseded by a mutation or a failure.
+let dashboardIsLive = false;
+let busy = false;
+
+// Serializes every watch → server interaction: a second SELECT press while a
+// clock mutation is in flight is dropped instead of queued, so repeated
+// presses cannot submit overlapping mutations.
+async function runExclusive(action) {
+  if (busy) return;
+  busy = true;
+  try {
+    await action();
+  } finally {
+    busy = false;
+  }
+}
 
 function authorizationHeaders() {
   return {
     Authorization: `Bearer ${authToken}`,
     "Content-Type": "application/json",
   };
+}
+
+function apiError(message, status) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
 }
 
 async function apiRequest(method, path, body) {
@@ -128,52 +237,87 @@ async function apiRequest(method, path, body) {
     body: body ? JSON.stringify(body) : undefined,
   });
   if (response.status === 401 || response.status === 403) {
-    throw new Error("Sign-in needed");
+    throw apiError("Sign-in needed", response.status);
+  }
+  if (response.status === 409) {
+    throw apiError("Out of sync", response.status);
   }
   if (response.status === 429 || response.status >= 500) {
-    throw new Error(`Try again later (${response.status})`);
+    throw apiError(`Try again later (${response.status})`, response.status);
   }
-  if (!response.ok) throw new Error(`Error ${response.status}`);
+  if (!response.ok) throw apiError(`Error ${response.status}`, response.status);
   return response.status === 204 ? null : response.json();
 }
 
+// Renders the cached glance labeled with why it is stale, or the bare reason
+// when there is nothing cached. Never marks the dashboard live.
+function showStale(reason) {
+  dashboardIsLive = false;
+  const snapshot = loadSnapshot();
+  if (snapshot) application.behavior.showSnapshot(snapshot, reason);
+  else application.behavior.showError(reason);
+}
+
+// Resolves true when the rendered state came from a fresh server read.
 async function refreshStatus() {
   if (!authToken) {
+    dashboardIsLive = false;
     application.behavior.showError("Not configured");
-    return;
+    return false;
   }
   if (!watch.connected.pebblekit) {
-    application.behavior.showError("Phone offline");
-    return;
+    showStale("Phone offline");
+    return false;
   }
   try {
     const dashboard = await apiRequest("GET", "/api/pebble/dashboard");
-    application.behavior.showTask(dashboard.running_task);
-    application.behavior.showShift(dashboard);
+    const snapshot = snapshotOf(dashboard);
+    saveSnapshot(snapshot);
+    dashboardIsLive = true;
+    application.behavior.showSnapshot(snapshot, null);
+    return true;
   } catch (error) {
-    application.behavior.showError(String(error.message || error));
-    application.behavior.showShiftError();
+    showStale(String(error.message || error));
+    return false;
   }
 }
 
 async function toggleClock() {
-  if (pending || !authToken) return;
-  pending = true;
-  const runningTask = application.behavior.runningTask;
-  application.behavior.data.STATUS.string = runningTask
-    ? "Clocking out…"
-    : "Clocking in…";
+  if (!authToken) {
+    application.behavior.showError("Not configured");
+    return;
+  }
+  // Clocking is online-only: without the phone link there is no way to reach
+  // the server, and queueing the action would replay it on reconnect.
+  if (!watch.connected.pebblekit) {
+    showStale("Phone offline");
+    return;
+  }
   try {
-    if (runningTask) {
-      await apiRequest("POST", "/api/pebble/actions/clock-out");
-    } else {
-      await apiRequest("POST", "/api/pebble/actions/clock-in");
+    // Cached state is display-only: re-read the dashboard before deciding
+    // between clock-in and clock-out so a stale task can never be replayed
+    // into a mutation. The read also fails closed while offline.
+    if (!dashboardIsLive) {
+      application.behavior.setHint("Checking…");
+      if (!(await refreshStatus())) return;
     }
+    const runningTask = application.behavior.runningTask;
+    application.behavior.data.STATUS.string = runningTask ? "Clocking out…" : "Clocking in…";
+    // The server view is about to change; only the follow-up read is authoritative.
+    dashboardIsLive = false;
+    await apiRequest(
+      "POST",
+      runningTask ? "/api/pebble/actions/clock-out" : "/api/pebble/actions/clock-in",
+    );
     await refreshStatus();
   } catch (error) {
-    application.behavior.showError(String(error.message || error));
-  } finally {
-    pending = false;
+    // 409 means the server state moved under us (clocked in or out elsewhere);
+    // re-reading resolves it instead of retrying the mutation.
+    if (error.status === 409) {
+      await refreshStatus();
+      return;
+    }
+    showStale(String(error.message || error));
   }
 }
 
@@ -187,21 +331,24 @@ const message = new Message({
       apiBaseUrl = baseUrl.replace(/\/$/, "");
       localStorage.setItem("apiBaseUrl", apiBaseUrl);
     }
-    if (token) {
+    if (token && token !== authToken) {
       authToken = token;
       localStorage.setItem("authToken", authToken);
+      // The credential may belong to a different account than the cached glance.
+      clearSnapshot();
+      dashboardIsLive = false;
     }
-    refreshStatus();
+    runExclusive(refreshStatus);
   },
 });
 
-watch.addEventListener("connected", refreshStatus);
+watch.addEventListener("connected", () => runExclusive(refreshStatus));
 
 new Button({
   types: ["up", "select"],
   onPush(down, type) {
     if (!down) return;
-    if (type === "up") refreshStatus();
-    else if (type === "select") toggleClock();
+    if (type === "up") runExclusive(refreshStatus);
+    else if (type === "select") runExclusive(toggleClock);
   },
 });

--- a/pebble/src/pkjs/index.js
+++ b/pebble/src/pkjs/index.js
@@ -20,17 +20,19 @@ Pebble.addEventListener("webviewclosed", function (event) {
   try {
     const result = JSON.parse(decodeURIComponent(event.response));
     if (!result.accessToken) return;
-    Pebble.sendAppMessage(
+    // Share the proxy's queue with watch-side fetch traffic. Sending directly
+    // through Pebble can exceed PKJS's small in-flight AppMessage budget.
+    moddableProxy.sendAppMessage(
       {
         API_BASE_URL: "https://worktime.tjor.im",
-        AUTH_TOKEN: result.accessToken,
+        AUTH_TOKEN: result.accessToken
       },
       function () {
         console.log("Worktime: pairing token relayed to watch");
       },
       function (error) {
         console.log(`Worktime: failed to relay pairing token: ${JSON.stringify(error)}`);
-      },
+      }
     );
   } catch (error) {
     console.log(`Worktime: failed to parse pairing response: ${error}`);

--- a/pebble/tests/harness.mjs
+++ b/pebble/tests/harness.mjs
@@ -9,6 +9,8 @@ import { createContext, runInContext } from "node:vm";
 
 const MAIN_PATH = resolve(import.meta.dirname, "../src/embeddedjs/main.js");
 
+const pause = (ms) => new Promise((done) => setTimeout(done, ms));
+
 // The watch bundle imports Alloy modules by bare specifier; the stubs below
 // stand in for them, so the import statements are dropped before evaluation.
 function stripImports(source) {
@@ -18,6 +20,7 @@ function stripImports(source) {
 export function createHarness({ connected = true, storage = {} } = {}) {
   const store = new Map(Object.entries(storage));
   const requests = [];
+  const inFlight = new Set();
   const listeners = new Map();
   const hooks = {};
   let respond = () => ({ status: 200, body: {} });
@@ -61,14 +64,21 @@ export function createHarness({ connected = true, storage = {} } = {}) {
       connected: { pebblekit: connected },
       addEventListener: (type, handler) => listeners.set(type, handler),
     },
-    fetch: async (url, options = {}) => {
+    fetch: (url, options = {}) => {
       requests.push({ url, method: options.method, headers: options.headers });
-      const { status, body } = respond(url, options);
-      return {
-        status,
-        ok: status >= 200 && status < 300,
-        json: async () => body,
-      };
+      const work = (async () => {
+        // Awaited so a responder can proxy to a real server (see live.test.mjs).
+        const { status, body } = await respond(url, options);
+        return {
+          status,
+          ok: status >= 200 && status < 300,
+          json: async () => body,
+        };
+      })();
+      inFlight.add(work);
+      const forget = () => inFlight.delete(work);
+      work.then(forget, forget);
+      return work;
     },
     Button: class Button {
       constructor(dict) {
@@ -89,10 +99,22 @@ export function createHarness({ connected = true, storage = {} } = {}) {
     filename: "main.js",
   });
 
-  // Alloy resolves and dispatches on its own event loop; here every stubbed
-  // response is already settled, so draining the microtask queue is enough.
-  const settle = async () => {
-    for (let i = 0; i < 50; i += 1) await Promise.resolve();
+  // Alloy resolves and dispatches on its own event loop. Wait for the app to
+  // go quiet: no request outstanding, and nothing new started after a full
+  // turn. The deadline only guards a responder that never answers.
+  const settle = async (timeoutMs = 2000) => {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (inFlight.size) {
+        await Promise.race([Promise.allSettled([...inFlight]), pause(5)]);
+      }
+      for (let i = 0; i < 20; i += 1) await Promise.resolve();
+      if (!inFlight.size) {
+        await pause(0);
+        if (!inFlight.size) return;
+      }
+      if (Date.now() > deadline) return;
+    }
   };
 
   return {

--- a/pebble/tests/harness.mjs
+++ b/pebble/tests/harness.mjs
@@ -151,6 +151,11 @@ export function createHarness({ connected = true, storage = {} } = {}) {
       listeners.get("connected")?.();
       await settle();
     },
+    // Fires a watch event without waiting for the app to go quiet, so a test
+    // can deliver it while an earlier request is still in flight.
+    emit(type) {
+      listeners.get(type)?.();
+    },
     async settle() {
       await settle();
     },

--- a/pebble/tests/harness.mjs
+++ b/pebble/tests/harness.mjs
@@ -1,0 +1,157 @@
+// Runs src/embeddedjs/main.js against stubbed Alloy globals.
+//
+// This exercises the watch app's *logic* — caching, staleness, and the
+// serialization of clock actions — not the Alloy APIs themselves, which still
+// need a device or emulator (see pebble/README.md).
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createContext, runInContext } from "node:vm";
+
+const MAIN_PATH = resolve(import.meta.dirname, "../src/embeddedjs/main.js");
+
+// The watch bundle imports Alloy modules by bare specifier; the stubs below
+// stand in for them, so the import statements are dropped before evaluation.
+function stripImports(source) {
+  return source.replace(/^import .*?;$/gm, "");
+}
+
+export function createHarness({ connected = true, storage = {} } = {}) {
+  const store = new Map(Object.entries(storage));
+  const requests = [];
+  const listeners = new Map();
+  const hooks = {};
+  let respond = () => ({ status: 200, body: {} });
+
+  class Behavior {}
+
+  function Label(data, dict) {
+    const label = { string: dict.string ?? "" };
+    if (dict.anchor) data[dict.anchor] = label;
+    return label;
+  }
+
+  const Application = {
+    template(build) {
+      return class FakeApplication {
+        constructor(_parent, data) {
+          this.data = data;
+          const spec = build(data);
+          this.behavior = new spec.Behavior();
+          this.behavior.onCreate(this, data);
+          hooks.application = this;
+        }
+        start() {}
+      };
+    },
+  };
+
+  const context = createContext({
+    Application,
+    Behavior,
+    Label,
+    Skin: class Skin {},
+    Style: class Style {},
+    console,
+    localStorage: {
+      getItem: (key) => (store.has(key) ? store.get(key) : null),
+      setItem: (key, value) => store.set(key, String(value)),
+      removeItem: (key) => store.delete(key),
+    },
+    watch: {
+      connected: { pebblekit: connected },
+      addEventListener: (type, handler) => listeners.set(type, handler),
+    },
+    fetch: async (url, options = {}) => {
+      requests.push({ url, method: options.method, headers: options.headers });
+      const { status, body } = respond(url, options);
+      return {
+        status,
+        ok: status >= 200 && status < 300,
+        json: async () => body,
+      };
+    },
+    Button: class Button {
+      constructor(dict) {
+        hooks.onPush = dict.onPush.bind(this);
+      }
+    },
+    // Alloy calls onReadable with the Message as `this`; the payload arrives
+    // through its read().
+    Message: class Message {
+      constructor(dict) {
+        this.onReadable = dict.onReadable;
+        hooks.message = this;
+      }
+    },
+  });
+
+  runInContext(stripImports(readFileSync(MAIN_PATH, "utf8")), context, {
+    filename: "main.js",
+  });
+
+  // Alloy resolves and dispatches on its own event loop; here every stubbed
+  // response is already settled, so draining the microtask queue is enough.
+  const settle = async () => {
+    for (let i = 0; i < 50; i += 1) await Promise.resolve();
+  };
+
+  return {
+    requests,
+    get labels() {
+      return hooks.application.data;
+    },
+    get stored() {
+      return Object.fromEntries(store);
+    },
+    setConnected(value) {
+      context.watch.connected.pebblekit = value;
+    },
+    // respond(url, options) -> { status, body }
+    setResponder(handler) {
+      respond = handler;
+    },
+    async display() {
+      hooks.application.behavior.onDisplaying(hooks.application);
+      await settle();
+    },
+    async press(type) {
+      hooks.onPush(true, type);
+      await settle();
+    },
+    async configure(payload) {
+      const map = new Map(Object.entries(payload));
+      hooks.message.read = () => map;
+      hooks.message.onReadable();
+      await settle();
+    },
+    async reconnect() {
+      context.watch.connected.pebblekit = true;
+      listeners.get("connected")?.();
+      await settle();
+    },
+    async settle() {
+      await settle();
+    },
+  };
+}
+
+export const DASHBOARD_PATH = "/api/pebble/dashboard";
+export const CLOCK_IN_PATH = "/api/pebble/actions/clock-in";
+export const CLOCK_OUT_PATH = "/api/pebble/actions/clock-out";
+
+export function dashboardBody({ task = null, shift = null } = {}) {
+  return {
+    running_task: task,
+    current_status: shift ? { current_shift: { shift } } : { current_shift: null },
+    next_shifts: { items: [] },
+  };
+}
+
+export function snapshot({ task = null, shift = "Today: Morning", ageSeconds = 0 } = {}) {
+  return JSON.stringify({
+    version: 1,
+    fetchedAt: Math.floor(Date.now() / 1000) - ageSeconds,
+    shift,
+    task,
+  });
+}

--- a/pebble/tests/live.test.mjs
+++ b/pebble/tests/live.test.mjs
@@ -15,7 +15,15 @@ import { createHarness } from "./harness.mjs";
 
 const SERVER = resolve(import.meta.dirname, "../scripts/mock-server.py");
 const TOKEN = "wtpat_test";
-const hasPython = spawnSync("python3", ["--version"]).status === 0;
+const python = [
+  process.env.PYTHON,
+  "python3",
+  resolve(import.meta.dirname, "../../backend/.venv/Scripts/python.exe"),
+  "python",
+]
+  .filter(Boolean)
+  .find((candidate) => spawnSync(candidate, ["--version"]).status === 0);
+const hasPython = Boolean(python);
 
 let server;
 let port;
@@ -54,7 +62,7 @@ before(async () => {
   if (!hasPython) return;
   workdir = mkdtempSync(join(tmpdir(), "pebble-live-"));
   port = await freePort();
-  server = spawn("python3", [SERVER, String(port), "--log", join(workdir, "requests.log")], {
+  server = spawn(python, [SERVER, String(port), "--log", join(workdir, "requests.log")], {
     stdio: "ignore",
   });
   for (let attempt = 0; attempt < 50; attempt += 1) {

--- a/pebble/tests/live.test.mjs
+++ b/pebble/tests/live.test.mjs
@@ -1,0 +1,172 @@
+// End-to-end check of the watch app against scripts/mock-server.py over real
+// HTTP: the app's own request/parse/render path, the mock's status codes, and
+// the payload shapes from backend/app/routers/pebble.py.
+//
+// Skipped when python3 is unavailable. This still stubs Piu and AppMessage —
+// only a device or the emulator covers those (see ../EMULATOR.md).
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, before, beforeEach, test } from "node:test";
+import { createHarness } from "./harness.mjs";
+
+const SERVER = resolve(import.meta.dirname, "../scripts/mock-server.py");
+const TOKEN = "wtpat_test";
+const hasPython = spawnSync("python3", ["--version"]).status === 0;
+
+let server;
+let port;
+let workdir;
+
+// Ask the OS for a free port rather than guessing one, so a busy port on a CI
+// runner cannot fail the suite.
+function freePort() {
+  return new Promise((done, fail) => {
+    const probe = createServer();
+    probe.on("error", fail);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port: chosen } = probe.address();
+      probe.close(() => done(chosen));
+    });
+  });
+}
+
+// The harness stubs fetch; this responder forwards to the mock server so the
+// app's real URLs, headers, and JSON parsing are exercised.
+async function proxy(url, options) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : {} };
+}
+
+function harnessFor() {
+  const harness = createHarness({
+    storage: { authToken: TOKEN, apiBaseUrl: `http://127.0.0.1:${port}` },
+  });
+  harness.setResponder(proxy);
+  return harness;
+}
+
+before(async () => {
+  if (!hasPython) return;
+  workdir = mkdtempSync(join(tmpdir(), "pebble-live-"));
+  port = await freePort();
+  server = spawn("python3", [SERVER, String(port), "--log", join(workdir, "requests.log")], {
+    stdio: "ignore",
+  });
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await fetch(`http://127.0.0.1:${port}/api/pebble/dashboard`);
+      return;
+    } catch {
+      await new Promise((done) => setTimeout(done, 100));
+    }
+  }
+  throw new Error("mock server did not start");
+});
+
+// Leave no running task behind, so each test starts from a known server state.
+beforeEach(async () => {
+  if (!hasPython) return;
+  await fetch(`http://127.0.0.1:${port}/api/pebble/actions/clock-out`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  }); // 409 when nothing is running, which is the state we want anyway
+});
+
+after(() => {
+  server?.kill();
+  if (workdir) rmSync(workdir, { recursive: true, force: true });
+});
+
+test("renders a dashboard served by the mock backend", { skip: !hasPython }, async () => {
+  const harness = harnessFor();
+
+  await harness.display();
+
+  assert.equal(harness.labels.SHIFT.string, "Today: Morning");
+  assert.equal(harness.labels.STATUS.string, "Not clocked in");
+  assert.equal(harness.labels.HINT.string, "SELECT: clock in/out");
+});
+
+test("clocks in and out against the mock backend", { skip: !hasPython }, async () => {
+  const harness = harnessFor();
+  await harness.display();
+
+  await harness.press("select");
+  assert.equal(harness.labels.STATUS.string, "Working");
+  // start_time is the aware-datetime format FastAPI emits; a parse failure
+  // here would show up as an empty or nonsensical timer on a real watch.
+  assert.match(harness.labels.TIMER.string, /^00:00:\d\d$/);
+
+  await harness.press("select");
+  assert.equal(harness.labels.STATUS.string, "Not clocked in");
+  assert.equal(harness.labels.TIMER.string, "");
+});
+
+test("a stale cache does not replay a mutation", { skip: !hasPython }, async () => {
+  // Clock in on one "watch", then bring up a second one whose cache still says
+  // a task is running after the first clocked out.
+  const first = harnessFor();
+  await first.display();
+  await first.press("select");
+  assert.equal(first.labels.STATUS.string, "Working");
+
+  const second = createHarness({
+    connected: false,
+    storage: {
+      authToken: TOKEN,
+      apiBaseUrl: `http://127.0.0.1:${port}`,
+      lastDashboard: JSON.stringify({
+        version: 1,
+        fetchedAt: Math.floor(Date.now() / 1000),
+        shift: "Today: Morning",
+        task: { text: "Working", start_time: new Date().toISOString() },
+      }),
+    },
+  });
+  second.setResponder(proxy);
+  await second.display();
+  assert.equal(second.labels.STATUS.string, "Working");
+
+  await first.press("select");
+  assert.equal(first.labels.STATUS.string, "Not clocked in");
+
+  // The second watch still shows the cached running task; pressing SELECT must
+  // clock in (from the re-read) rather than replay a clock-out.
+  second.setConnected(true);
+  await second.press("select");
+  assert.equal(second.labels.STATUS.string, "Working");
+  assert.deepEqual(
+    second.requests.map((request) => new URL(request.url).pathname),
+    [
+      "/api/pebble/dashboard",
+      "/api/pebble/actions/clock-in",
+      "/api/pebble/dashboard",
+    ],
+  );
+});
+
+test("a real 409 resolves by re-reading, not by retrying", { skip: !hasPython }, async () => {
+  // This watch has a live read saying nothing is running…
+  const watchApp = harnessFor();
+  await watchApp.display();
+  assert.equal(watchApp.labels.STATUS.string, "Not clocked in");
+
+  // …but the user clocks in from the web app before pressing SELECT.
+  const elsewhere = harnessFor();
+  await elsewhere.display();
+  await elsewhere.press("select");
+
+  watchApp.requests.length = 0;
+  await watchApp.press("select");
+
+  assert.deepEqual(
+    watchApp.requests.map((request) => new URL(request.url).pathname),
+    ["/api/pebble/actions/clock-in", "/api/pebble/dashboard"],
+  );
+  assert.equal(watchApp.labels.STATUS.string, "Working");
+});

--- a/pebble/tests/offline.test.mjs
+++ b/pebble/tests/offline.test.mjs
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  CLOCK_IN_PATH,
+  CLOCK_OUT_PATH,
+  DASHBOARD_PATH,
+  createHarness,
+  dashboardBody,
+  snapshot,
+} from "./harness.mjs";
+
+const TOKEN = { authToken: "wtpat_test", apiBaseUrl: "https://example.test" };
+const RUNNING = { text: "Working", start_time: new Date(Date.now() - 60_000).toISOString() };
+
+function paths(harness) {
+  return harness.requests.map((request) => new URL(request.url).pathname);
+}
+
+function ok(body) {
+  return () => ({ status: 200, body });
+}
+
+test("a live dashboard renders shift, task, and the clock hint", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  harness.setResponder(
+    ok(dashboardBody({ task: RUNNING, shift: { name: "Morning", code: "M" } })),
+  );
+
+  await harness.display();
+
+  assert.equal(harness.labels.SHIFT.string, "Today: Morning");
+  assert.equal(harness.labels.STATUS.string, "Working");
+  assert.match(harness.labels.TIMER.string, /^00:0[01]:\d\d$/);
+  assert.equal(harness.labels.HINT.string, "SELECT: clock in/out");
+});
+
+test("a successful read is persisted for the next cold start", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  harness.setResponder(
+    ok(dashboardBody({ task: RUNNING, shift: { name: "Morning", code: "M" } })),
+  );
+
+  await harness.display();
+
+  const cached = JSON.parse(harness.stored.lastDashboard);
+  assert.equal(cached.shift, "Today: Morning");
+  assert.equal(cached.task.text, "Working");
+  assert.equal(cached.task.start_time, RUNNING.start_time);
+});
+
+test("an offline cold start shows the cached glance with its timestamp", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: { ...TOKEN, lastDashboard: snapshot({ task: RUNNING }) },
+  });
+
+  await harness.display();
+
+  assert.equal(harness.labels.SHIFT.string, "Today: Morning");
+  assert.equal(harness.labels.STATUS.string, "Working");
+  assert.match(harness.labels.HINT.string, /^Phone offline · \d\d:\d\d$/);
+  assert.deepEqual(paths(harness), []);
+});
+
+test("an offline cold start without a cache reports the disconnect", async () => {
+  const harness = createHarness({ connected: false, storage: TOKEN });
+
+  await harness.display();
+
+  assert.equal(harness.labels.STATUS.string, "Phone offline");
+  assert.equal(harness.labels.TIMER.string, "");
+});
+
+test("a cache older than 12 hours is discarded rather than displayed", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: {
+      ...TOKEN,
+      lastDashboard: snapshot({ task: RUNNING, ageSeconds: 13 * 60 * 60 }),
+    },
+  });
+
+  await harness.display();
+
+  assert.equal(harness.labels.STATUS.string, "Phone offline");
+  assert.equal(harness.labels.TIMER.string, "");
+  assert.equal(harness.stored.lastDashboard, undefined);
+});
+
+test("SELECT while offline never reaches the server", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: { ...TOKEN, lastDashboard: snapshot({ task: RUNNING }) },
+  });
+
+  await harness.display();
+  await harness.press("select");
+
+  assert.deepEqual(paths(harness), []);
+  assert.match(harness.labels.HINT.string, /^Phone offline · /);
+});
+
+test("SELECT on cached state re-reads before choosing the mutation", async () => {
+  // The cache says a task is running; the server says it already stopped, so
+  // the press must clock in rather than replay a clock-out.
+  const harness = createHarness({
+    connected: false,
+    storage: { ...TOKEN, lastDashboard: snapshot({ task: RUNNING }) },
+  });
+  await harness.display();
+  assert.equal(harness.labels.STATUS.string, "Working");
+
+  harness.setConnected(true);
+  harness.setResponder((url) =>
+    url.endsWith(DASHBOARD_PATH)
+      ? { status: 200, body: dashboardBody() }
+      : { status: 201, body: {} },
+  );
+  await harness.press("select");
+
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH, CLOCK_IN_PATH, DASHBOARD_PATH]);
+});
+
+test("reconnecting does not replay a clock action", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  harness.setResponder((url) =>
+    url.endsWith(DASHBOARD_PATH)
+      ? { status: 200, body: dashboardBody() }
+      : { status: 201, body: {} },
+  );
+  await harness.display();
+  await harness.press("select");
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH, CLOCK_IN_PATH, DASHBOARD_PATH]);
+
+  harness.setConnected(false);
+  await harness.settle();
+  harness.requests.length = 0;
+  harness.setResponder(ok(dashboardBody({ task: RUNNING })));
+  await harness.reconnect();
+
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH]);
+});
+
+test("repeated SELECT presses submit a single mutation", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  let releaseClockIn;
+  harness.setResponder((url) => {
+    if (url.endsWith(DASHBOARD_PATH)) return { status: 200, body: dashboardBody() };
+    return {
+      status: 201,
+      body: new Promise((resolvePromise) => {
+        releaseClockIn = () => resolvePromise({});
+      }),
+    };
+  });
+  await harness.display();
+
+  await harness.press("select");
+  await harness.press("select");
+  await harness.press("select");
+
+  assert.deepEqual(
+    paths(harness).filter((path) => path === CLOCK_IN_PATH),
+    [CLOCK_IN_PATH],
+  );
+  releaseClockIn();
+  await harness.settle();
+});
+
+test("clocking out uses the running task from the live read", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  harness.setResponder((url) =>
+    url.endsWith(DASHBOARD_PATH)
+      ? { status: 200, body: dashboardBody({ task: RUNNING }) }
+      : { status: 200, body: {} },
+  );
+  await harness.display();
+
+  await harness.press("select");
+
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH, CLOCK_OUT_PATH, DASHBOARD_PATH]);
+});
+
+test("a conflicting mutation re-reads instead of retrying", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  harness.setResponder((url) =>
+    url.endsWith(DASHBOARD_PATH)
+      ? { status: 200, body: dashboardBody({ task: RUNNING }) }
+      : { status: 409, body: {} },
+  );
+  await harness.display();
+
+  await harness.press("select");
+
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH, CLOCK_OUT_PATH, DASHBOARD_PATH]);
+  assert.equal(harness.labels.STATUS.string, "Working");
+});
+
+test("authentication failures prompt reconfiguration", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  harness.setResponder(() => ({ status: 401, body: {} }));
+
+  await harness.display();
+
+  assert.equal(harness.labels.STATUS.string, "Sign-in needed");
+});
+
+test("retryable failures fall back to the cached glance", async () => {
+  const harness = createHarness({
+    storage: { ...TOKEN, lastDashboard: snapshot({ task: RUNNING }) },
+  });
+  harness.setResponder(() => ({ status: 503, body: {} }));
+
+  await harness.display();
+
+  assert.equal(harness.labels.STATUS.string, "Working");
+  assert.match(harness.labels.HINT.string, /^Try again later \(503\) · \d\d:\d\d$/);
+});
+
+test("UP refreshes the dashboard", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  harness.setResponder(ok(dashboardBody()));
+  await harness.display();
+  harness.requests.length = 0;
+
+  await harness.press("up");
+
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH]);
+});
+
+test("an unconfigured watch asks for pairing", async () => {
+  const harness = createHarness();
+
+  await harness.display();
+  await harness.press("select");
+
+  assert.equal(harness.labels.STATUS.string, "Not configured");
+  assert.deepEqual(paths(harness), []);
+});
+
+test("a new pairing credential clears the cached glance", async () => {
+  const harness = createHarness({
+    storage: { ...TOKEN, lastDashboard: snapshot({ task: RUNNING }) },
+  });
+  harness.setResponder(ok(dashboardBody()));
+
+  await harness.configure({
+    API_BASE_URL: "https://other.test/",
+    AUTH_TOKEN: "wtpat_other",
+  });
+
+  assert.equal(harness.stored.authToken, "wtpat_other");
+  assert.equal(harness.stored.apiBaseUrl, "https://other.test");
+  assert.equal(harness.labels.STATUS.string, "Not clocked in");
+  assert.equal(harness.requests[0].url, "https://other.test/api/pebble/dashboard");
+  assert.equal(harness.requests[0].headers.Authorization, "Bearer wtpat_other");
+});

--- a/pebble/tests/offline.test.mjs
+++ b/pebble/tests/offline.test.mjs
@@ -357,3 +357,19 @@ test("a new pairing credential clears the cached glance", async () => {
   assert.equal(harness.requests[0].url, "https://other.test/api/pebble/dashboard");
   assert.equal(harness.requests[0].headers.Authorization, "Bearer wtpat_other");
 });
+
+test("a changed server clears a snapshot from the previous deployment", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: {
+      ...TOKEN,
+      lastDashboard: snapshot({ task: RUNNING }),
+    },
+  });
+  await harness.display();
+
+  await harness.configure({ API_BASE_URL: "https://other.test/" });
+
+  assert.equal(harness.stored.lastDashboard, undefined);
+  assert.equal(harness.labels.STATUS.string, "Phone offline");
+});

--- a/pebble/tests/offline.test.mjs
+++ b/pebble/tests/offline.test.mjs
@@ -238,6 +238,108 @@ test("an unconfigured watch asks for pairing", async () => {
   assert.deepEqual(paths(harness), []);
 });
 
+// A held response leaves the app mid-request: fetch has resolved, so the
+// harness stops waiting, but the app is still awaiting the body.
+function heldResponder(resolveWith) {
+  let release;
+  const responder = () => ({
+    status: 200,
+    body: new Promise((resolve) => {
+      release = () => resolve(resolveWith);
+    }),
+  });
+  return [responder, () => release()];
+}
+
+test("a snapshot stamped in the future is discarded", async () => {
+  const harness = createHarness({
+    connected: false,
+    // The watch clock moved back after the read.
+    storage: { ...TOKEN, lastDashboard: snapshot({ task: RUNNING, ageSeconds: -600 }) },
+  });
+
+  await harness.display();
+
+  assert.equal(harness.labels.STATUS.string, "Phone offline");
+  assert.equal(harness.stored.lastDashboard, undefined);
+});
+
+test("a reconnect during another request is serviced, not dropped", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  const [held, release] = heldResponder(dashboardBody());
+  harness.setResponder(held);
+
+  await harness.display(); // the read's body is still held, so the app is busy
+  harness.emit("connected"); // dropped by the in-flight guard…
+  release();
+  await harness.settle();
+
+  // …and made good once the first request finishes.
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH, DASHBOARD_PATH]);
+});
+
+test("a credential change mid-read does not adopt the old account's state", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  const [held, release] = heldResponder(
+    dashboardBody({ task: RUNNING, shift: { name: "Morning", code: "M" } }),
+  );
+  harness.setResponder(held);
+  await harness.display(); // read in flight, authorized with the old token
+
+  await harness.configure({ AUTH_TOKEN: "wtpat_other" });
+  // The newly paired account has no running task.
+  harness.setResponder(ok(dashboardBody()));
+  release(); // the old account's response lands after the swap
+  await harness.settle();
+
+  assert.equal(harness.labels.STATUS.string, "Not clocked in");
+  assert.equal(JSON.parse(harness.stored.lastDashboard).task, null);
+  assert.equal(harness.requests.at(-1).headers.Authorization, "Bearer wtpat_other");
+});
+
+test("an old account's response is never cached under a new credential", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  const [held, release] = heldResponder(
+    dashboardBody({ task: RUNNING, shift: { name: "Morning", code: "M" } }),
+  );
+  harness.setResponder(held);
+  await harness.display();
+
+  await harness.configure({ AUTH_TOKEN: "wtpat_other" });
+  // The refresh owed to the new credential fails, so anything the old-token
+  // response managed to cache would be rendered in its place.
+  harness.setResponder(() => ({ status: 503, body: {} }));
+  release();
+  await harness.settle();
+
+  assert.equal(harness.labels.STATUS.string, "Try again later (503)");
+  assert.equal(harness.stored.lastDashboard, undefined);
+});
+
+test("a mutation after a credential change uses the new account's state", async () => {
+  const harness = createHarness({ storage: TOKEN });
+  const [held, release] = heldResponder(
+    dashboardBody({ task: RUNNING, shift: { name: "Morning", code: "M" } }),
+  );
+  harness.setResponder(held);
+  await harness.display();
+
+  await harness.configure({ AUTH_TOKEN: "wtpat_other" });
+  harness.setResponder((url) =>
+    url.endsWith(DASHBOARD_PATH)
+      ? { status: 200, body: dashboardBody() }
+      : { status: 201, body: {} },
+  );
+  release();
+  await harness.settle();
+  harness.requests.length = 0;
+
+  await harness.press("select");
+
+  // The old account was clocked in; the new one is not, so this must clock in.
+  assert.deepEqual(paths(harness), [CLOCK_IN_PATH, DASHBOARD_PATH]);
+});
+
 test("a new pairing credential clears the cached glance", async () => {
   const harness = createHarness({
     storage: { ...TOKEN, lastDashboard: snapshot({ task: RUNNING }) },


### PR DESCRIPTION
## Summary

Stacked on `agent/align-pebble-pairing` (the authenticated `/pebble-pair` webview), this PR is the offline-behavior decision from #1025 plus the tooling to test the watchapp without a watch.

### Offline behavior

#1025 asked to either add a last-dashboard cache or explicitly accept online-only. This implements the cache, with clocking kept strictly online-only:

- The watch persists the last successful dashboard read (shift line, running task label and start time, read time) and renders it while disconnected or after a failed read, with the bottom line showing the reason and read time, e.g. `Phone offline · 08:12`. Previously the whole screen was replaced by `Phone offline`.
- Snapshots older than 12 hours — or stamped in the future, after the watch clock moves back — are discarded rather than shown.

Replay safety — the cache is display-only and never decides a mutation:

- SELECT while the phone link is down does nothing; there is no offline queue.
- When the rendered state came from the cache or a failed read, SELECT re-reads `/api/pebble/dashboard` first and acts only on that result, so a stale task cannot be replayed into a clock-in/clock-out.
- A mutation marks state non-authoritative until the follow-up read lands, so reconnecting never repeats a request that already succeeded.
- `409` re-reads the dashboard instead of retrying the mutation.
- A single in-flight guard serializes all watch → server work, so repeated SELECT presses drop rather than queue.

Account isolation across pairing (from review, 9a5ffe4): responses carry the credential generation they were authorized under and are discarded if it changed while they were in flight, so a read authorized with the previous account's token is never cached, rendered, or used to pick a mutation. Lifecycle refreshes (reconnect, new credential) that arrive while the watch is busy are owed and serviced afterwards rather than dropped — dropping a repeated *button press* stays deliberate.

### Emulator runbook and mock backend

Ported from the sibling Daynest companion — its routes, auth scheme, payload shapes, and button semantics all differ, so this is an adaptation, not a copy. Provenance is stated in the doc.

- `EMULATOR.md` — Emery QEMU setup, how to drive the app, and its hard limit: watch-side `fetch()` never completes under QEMU, because the Alloy HTTP client waits on a PebbleOS comm session pypkjs never establishes. For Worktime that rules out the dashboard load, clock actions, the offline cache (never written without a successful read), and the replay guards.
- `scripts/mock-server.py` — mirrors `backend/app/routers/pebble.py`, including 201 on clock-in and 409 on a double clock-in or an empty clock-out, and logs timestamped requests so replay claims can be checked against what the server received rather than what the watch displayed. `--latency` holds responses so repeated presses can be tested on hardware; `--fail-with` forces the retryable and reconfiguration states.

## Not done: hardware validation

The rest of #1025 — `pebble build`, install on a Pebble Time 2, and the on-device smoke tests — is **not** done here: this environment has no Pebble SDK, emulator, or watch. `README.md` replaces the old blanket "not build-/device-tested" warning with a checklist split into what the emulator can cover and what needs hardware, and the issue stays open.

## Testing

- `pebble/tests/` — 25 `node:test` cases running `src/embeddedjs/main.js` against stubbed Alloy globals (`tests/harness.mjs`). 21 use stubbed responses; 4 (`live.test.mjs`) drive the app over real HTTP against the mock server, covering the cache-replay and 409 paths end to end. CI runs all 25 with 0 skipped.
- Mock payloads validate against the real `PebbleDashboardRead` and `TaskRead` Pydantic models; its status codes were checked against the router by hand.
- Mutation-checked — each guard has a test that fails when it is reverted: the pre-mutation re-read, the in-flight guard, the 409 recovery, the credential generation check, the owed lifecycle refresh, and the snapshot age bounds. The credential one is pinned by the case the owed refresh cannot mask (that refresh failing, leaving the poisoned cache to be rendered), since a test asserting only the final state passes without the fix.
- `scripts/validate.mjs` now also checks that the watch, the mock, and the router agree on all three paths.
- Nothing here exercises Piu, AppMessage, or the phone proxy — those need the emulator or a device.

No web-app UI changes, so no screenshots (the pairing states screenshot is in the base branch, `docs/screenshots/pebble-pairing-states.png`).

Also fixes the `Pebble CI` path filter, which still pointed at the deleted `frontend/public/pebble-config.html` instead of the files `validate.mjs` actually reads.

Refs #1025, #1005, #996