### PR TITLE
Add request logging, version reporting, and friendly port-conflict errors to hday-helper

### DIFF
--- a/hday-helper/README.md
+++ b/hday-helper/README.md
@@ -60,7 +60,7 @@ SHARE_DIR=Z:\worktime
 Returns the server status, the helper's own version, and whether the share directory is accessible.
 
 ```json
-{ "status": "ok", "version": "2026.8.1", "share": "accessible", "share_dir": "Z:\\worktime" }
+{ "status": "ok", "version": "2026.8.2", "share": "accessible", "share_dir": "Z:\\worktime" }
 ```
 
 HTTP 200 when accessible, 503 when the share directory cannot be reached.

--- a/hday-helper/README.md
+++ b/hday-helper/README.md
@@ -6,10 +6,12 @@ required on the target machine.
 
 ## What it does
 
-- Exposes the same `/hday/:username` and `/team/:teamId` API shapes as the Python backend
+- Exposes `/hday/:username` and `/team/:teamId` HTTP endpoints for `.hday` file and team-config access
 - Reads `.hday` files from the share root; reads team config (`.conf`, `.people`) from `{SHARE_DIR}/config/`
 - Reads from / writes to a configurable directory (local path or UNC/mapped-drive path)
 - No database, no OIDC, no authentication — pure file I/O over HTTP
+- Logs each request (method, path, status, timing) to the console — the only diagnostic
+  output when running as a standalone EXE
 
 ## Quick start
 
@@ -55,10 +57,10 @@ SHARE_DIR=Z:\worktime
 
 ### `GET /health`
 
-Returns the server status and whether the share directory is accessible.
+Returns the server status, the helper's own version, and whether the share directory is accessible.
 
 ```json
-{ "status": "ok", "share": "accessible", "share_dir": "Z:\\worktime" }
+{ "status": "ok", "version": "2026.8.1", "share": "accessible", "share_dir": "Z:\\worktime" }
 ```
 
 HTTP 200 when accessible, 503 when the share directory cannot be reached.

--- a/hday-helper/src/main.ts
+++ b/hday-helper/src/main.ts
@@ -15,9 +15,9 @@
  * | HOST           | 127.0.0.1             | Bind address                        |
  * | CORS_ORIGINS   | http://localhost:5173 | Comma-separated allowed origins     |
  *
- * ## API (mirrors backend/app/routers/hday.py + team.py)
+ * ## API
  *
- * GET  /health              — health + share-directory status
+ * GET  /health              — health, own version, and share-directory status
  * GET  /hday/:username      — read a user's .hday file (always includes parsed events)
  * PUT  /hday/:username      — create or update a user's .hday file
  * GET  /team/:teamId        — read team config + member list
@@ -44,11 +44,16 @@ import { basename, join, resolve, sep } from "path";
 import { parseHday } from "../../frontend/src/lib/hday/parser";
 import { toLine } from "../../frontend/src/lib/hday/serializer";
 import type { HdayEvent } from "../../frontend/src/lib/hday/types";
+// `with { type: "text" }` embeds the file's contents as a string constant at bundle
+// time (verified to survive `bun build --compile` too), so the compiled EXE reports
+// the version of the source tree it was built from, not whatever's on the host disk.
+import VERSION_FILE from "../../VERSION" with { type: "text" };
 
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
 
+const HELPER_VERSION = VERSION_FILE.trim();
 const SHARE_DIR = resolve(process.env.SHARE_DIR ?? "./hday_files");
 const PORT = parseInt(process.env.PORT || "8080", 10) || 8080;
 const HOST = process.env.HOST || "127.0.0.1";
@@ -429,7 +434,12 @@ async function handleRequest(req: Request): Promise<Response> {
   if (req.method === "GET" && pathname === "/health") {
     const shareOk = isShareAccessible();
     return jsonResponse(
-      { status: "ok", share: shareOk ? "accessible" : "inaccessible", share_dir: SHARE_DIR },
+      {
+        status: "ok",
+        version: HELPER_VERSION,
+        share: shareOk ? "accessible" : "inaccessible",
+        share_dir: SHARE_DIR,
+      },
       shareOk ? 200 : 503,
       corsHeaders,
     );
@@ -648,6 +658,26 @@ async function handleRequest(req: Request): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
+// Request logging — the only diagnostic output available to someone running
+// this as a standalone EXE with no other way to see what it's doing.
+// ---------------------------------------------------------------------------
+
+async function loggedHandleRequest(req: Request): Promise<Response> {
+  const start = performance.now();
+  const { pathname } = new URL(req.url);
+  try {
+    const response = await handleRequest(req);
+    const ms = (performance.now() - start).toFixed(1);
+    console.log(`${req.method} ${pathname} -> ${response.status} (${ms}ms)`);
+    return response;
+  } catch (err) {
+    const ms = (performance.now() - start).toFixed(1);
+    console.error(`${req.method} ${pathname} -> unhandled error (${ms}ms):`, err);
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Bootstrap
 // ---------------------------------------------------------------------------
 
@@ -661,15 +691,29 @@ if (!existsSync(SHARE_DIR)) {
   }
 }
 
-Bun.serve({
-  hostname: HOST,
-  port: PORT,
-  fetch: handleRequest,
-});
+try {
+  Bun.serve({
+    hostname: HOST,
+    port: PORT,
+    fetch: loggedHandleRequest,
+  });
+} catch (err) {
+  if (err instanceof Error && "code" in err && err.code === "EADDRINUSE") {
+    console.error(
+      `\nCould not start: port ${PORT} is already in use on ${HOST}.\n` +
+        `Either stop whatever else is using it, or set PORT to a different value ` +
+        `(e.g. PORT=8081) in your .env file next to the executable.\n`,
+    );
+  } else {
+    console.error("\nCould not start the .hday helper:", err, "\n");
+  }
+  process.exit(1);
+}
 
 console.log("============================================================");
 console.log("Worktime .hday Helper");
 console.log("============================================================");
+console.log(`Version:   ${HELPER_VERSION}`);
 console.log(`Host:      ${HOST}`);
 console.log(`Port:      ${PORT}`);
 console.log(`Share dir: ${SHARE_DIR}`);

--- a/hday-helper/src/main.ts
+++ b/hday-helper/src/main.ts
@@ -673,7 +673,16 @@ async function loggedHandleRequest(req: Request): Promise<Response> {
   } catch (err) {
     const ms = (performance.now() - start).toFixed(1);
     console.error(`${req.method} ${pathname} -> unhandled error (${ms}ms):`, err);
-    throw err;
+    // Every known error path in handleRequest already returns a CORS-headered
+    // response — this only catches genuine bugs. Respond ourselves (with CORS
+    // headers) rather than letting it fall through to Bun's default handling,
+    // which would omit them and surface to the browser as an opaque "CORS
+    // error" that hides the real problem.
+    return jsonResponse(
+      { detail: "Internal server error" },
+      500,
+      getCorsHeaders(req.headers.get("Origin")),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the `hday-helper` review discussed alongside #1043/#1048/#1049. Addresses the three "lower priority, UX-flavored" gaps from that review, plus one small addition — relevant since this ships as a standalone .exe for less technical, self-hosting users:

- **No runtime logging.** A user with a misbehaving helper had nothing to look at but raw HTTP responses. `GET /health` and every other request now logs `METHOD path -> status (Xms)` to the console; unhandled errors are logged too.
- **No version reporting.** `/health` now includes a `version` field, so a stale helper build can eventually be detected against a newer app. Embeds the repo-root `VERSION` file at bundle time via Bun's `with { type: "text" }` import attribute — verified this survives `bun build --compile`, so the compiled EXE reports the version of the source tree it was actually built from, not whatever happens to be on the host disk.
- **No friendly port-conflict handling.** `Bun.serve()` throwing `EADDRINUSE` used to crash with a raw stack trace. Now prints a plain-language message pointing at the `PORT` env var and exits cleanly (code 1).
- **Unhandled exceptions could produce CORS-less error responses.** Every known error path already returned CORS headers, but a genuine bug (unexpected throw) fell through to Bun's default error handling, which omits them — surfacing to the browser as an opaque "CORS error" masking the real 500. The request wrapper now responds itself (with CORS headers) on that path instead of rethrowing.

Also touched two doc lines while in the neighborhood: the "mirrors the Python backend" comparison in the file header and README was going stale regardless of merge order (see #1049), so reworded to describe the API directly instead of by comparison.

Deliberately *not* included — bigger, independently-reviewable chunks better suited to their own PRs: a test suite (currently zero automated coverage of the path-traversal defense and conflict logic), and enforcing the 10MB PUT limit as a true stream cap rather than a declared `Content-Length` check.

## Test plan

- [x] `bun run hday-helper/src/main.ts` locally — confirmed `/health` returns `version`, confirmed request logging output, confirmed a second instance on the same port prints the friendly message and exits 1 instead of crashing, confirmed CORS headers are present on responses
- [x] `bun build hday-helper/src/main.ts --compile --outfile ...` (same command as `.github/workflows/hday-helper-ci.yml`) — confirmed the compiled EXE also reports the correct version and behaves identically to `bun run`