### PR TITLE
Enforce hday-helper PUT size limit on actual bytes, not declared Content-Length

### DIFF
--- a/hday-helper/src/main.ts
+++ b/hday-helper/src/main.ts
@@ -436,7 +436,12 @@ async function readBodyTextWithLimit(req: Request, maxBytes: number): Promise<st
   if (!req.body) return "";
 
   const reader = req.body.getReader();
-  const chunks: Uint8Array[] = [];
+  // Decode incrementally (stream: true carries partial multi-byte UTF-8
+  // sequences across chunk boundaries) instead of collecting raw chunks and
+  // concatenating them into a second full-size buffer before decoding —
+  // avoids holding two complete copies of a near-limit body in memory at once.
+  const decoder = new TextDecoder("utf-8");
+  const parts: string[] = [];
   let total = 0;
 
   while (true) {
@@ -447,16 +452,11 @@ async function readBodyTextWithLimit(req: Request, maxBytes: number): Promise<st
       await reader.cancel();
       throw new PayloadTooLargeError();
     }
-    chunks.push(value);
+    parts.push(decoder.decode(value, { stream: true }));
   }
+  parts.push(decoder.decode());
 
-  const combined = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder("utf-8").decode(combined);
+  return parts.join("");
 }
 
 // ---------------------------------------------------------------------------

--- a/hday-helper/src/main.ts
+++ b/hday-helper/src/main.ts
@@ -61,6 +61,7 @@ const CORS_ORIGINS = (process.env.CORS_ORIGINS ?? "http://localhost:5173")
   .split(",")
   .map((s) => s.trim())
   .filter(Boolean);
+const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024; // 10 MiB
 
 // ---------------------------------------------------------------------------
 // Per-user write mutex — serializes concurrent writes to the same .hday file
@@ -109,6 +110,13 @@ class TeamNotFoundError extends Error {
   constructor(detail: string) {
     super(detail);
     this.name = "TeamNotFoundError";
+  }
+}
+
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super("Request body exceeds the maximum allowed size");
+    this.name = "PayloadTooLargeError";
   }
 }
 
@@ -416,6 +424,42 @@ function jsonResponse(
 }
 
 // ---------------------------------------------------------------------------
+// Request body helpers
+// ---------------------------------------------------------------------------
+
+// Reads the request body as UTF-8 text, aborting once more than `maxBytes` have
+// actually been received. Content-Length is client-supplied and not trustworthy
+// on its own — a client that omits it or lies about it can otherwise stream an
+// unbounded amount of data into memory via req.json()/req.text(). This caps the
+// real byte count regardless of what the header claims.
+async function readBodyTextWithLimit(req: Request, maxBytes: number): Promise<string> {
+  if (!req.body) return "";
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new PayloadTooLargeError();
+    }
+    chunks.push(value);
+  }
+
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8").decode(combined);
+}
+
+// ---------------------------------------------------------------------------
 // Request handler
 // ---------------------------------------------------------------------------
 
@@ -497,14 +541,27 @@ async function handleRequest(req: Request): Promise<Response> {
 
     // PUT /hday/:username
     if (req.method === "PUT") {
-      const contentLength = parseInt(req.headers.get("content-length") ?? "0", 10);
-      if (Number.isNaN(contentLength) || contentLength > 10 * 1024 * 1024) {
+      // Fast-path rejection when the client declares an oversized body up front.
+      // readBodyTextWithLimit() below is the authoritative cap regardless — this
+      // just avoids reading anything at all from an honestly-labeled huge request.
+      const declaredLength = parseInt(req.headers.get("content-length") ?? "0", 10);
+      if (!Number.isNaN(declaredLength) && declaredLength > MAX_REQUEST_BODY_BYTES) {
         return jsonResponse({ detail: "Payload too large" }, 413, corsHeaders);
+      }
+
+      let bodyText: string;
+      try {
+        bodyText = await readBodyTextWithLimit(req, MAX_REQUEST_BODY_BYTES);
+      } catch (err) {
+        if (err instanceof PayloadTooLargeError) {
+          return jsonResponse({ detail: "Payload too large" }, 413, corsHeaders);
+        }
+        return jsonResponse({ detail: "Invalid request body" }, 400, corsHeaders);
       }
 
       let body: { raw?: string; events?: HdayEvent[]; etag?: string | null };
       try {
-        body = (await req.json()) as { raw?: string; events?: HdayEvent[]; etag?: string | null };
+        body = JSON.parse(bodyText) as { raw?: string; events?: HdayEvent[]; etag?: string | null };
       } catch {
         return jsonResponse({ detail: "Invalid JSON body" }, 400, corsHeaders);
       }


### PR DESCRIPTION
## Summary

Follow-up to #1050 (stacked on top of it — bases on `claude/hday-helper-improvements`). Fixes one of the two "worth doing" items deferred there: the `PUT /hday/:username` 10MB size limit only checked the client-supplied `Content-Length` header, not actual bytes read.

A client that omits `Content-Length` (e.g. chunked transfer encoding) or lies about it could stream an unbounded body into memory via `req.json()`, since nothing capped the bytes actually consumed. `readBodyTextWithLimit()` now reads the request body stream chunk by chunk, aborting and cancelling the stream once real bytes exceed the cap, then `JSON.parse()`s the resulting text. The `Content-Length` check is kept as a cheap fast-path rejection for honestly-labeled oversized requests, but the stream reader is now the authoritative enforcement.

## Test plan

- [x] `bun build hday-helper/src/main.ts --compile --outfile ...` — builds cleanly
- [x] Small valid PUT still succeeds (200)
- [x] **The actual gap this closes:** a chunked PUT with no `Content-Length` header carrying an 11MB body — which the old header-only check let straight through untouched — is now rejected with 413 before any file is written. Verified no partial/oversized file landed on disk.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnmfGfyaravNqN45tFKmkJ)_