### PR TITLE
Add managed integration clients and audit trail

### DIFF
--- a/backend/app/audit/db.py
+++ b/backend/app/audit/db.py
@@ -1,0 +1,124 @@
+"""Transactional, durable mutation audit trail (issue #1054).
+
+This is the authoritative audit record. Unlike ``app.audit.logger`` (from
+#984 — a fire-and-forget, rotated file write outside the mutation's
+transaction), entries here are staged onto the *same* SQLAlchemy session as
+the mutation they describe and committed atomically with it: either both
+persist or neither does. ``app.audit.logger`` keeps running unchanged as
+secondary, best-effort operational telemetry (e.g. for tailing/grepping on
+the host) — it is no longer treated as the source of truth for "did this
+mutation happen and who did it".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import AuditEntry
+
+# Bounded reads: mirrors champagnefestival's DEFAULT_AUDIT_LIMIT/MAX_AUDIT_LIMIT
+# so a caller can never pull an unbounded audit trail into memory/context.
+DEFAULT_AUDIT_LIMIT = 100
+MAX_AUDIT_LIMIT = 1000
+
+
+class AuditAuthorizationError(Exception):
+    """Raised when a caller requests another user's audit trail without admin scope."""
+
+
+@dataclass(frozen=True)
+class AuditActor:
+    """Identity of the caller performing a mutation, for the audit trail.
+
+    ``user_id`` is the Worktime user the mutation is attributed to (nullable
+    only for the theoretical case of a system-initiated write with no human
+    or credential behind it — no current call site needs that). ``label`` is
+    a human-readable identity (username, or ``integration:<client name>`` for
+    managed integration-client calls) safe to display without a join.
+    ``auth_source`` matches ``WorktimeMcpContext.auth_type`` / REST
+    ``AuthType`` values (e.g. ``keycloak_user``, ``keycloak_service``,
+    ``integration_client``, ``delegated``).
+    """
+
+    user_id: int | None
+    label: str
+    auth_source: str
+    subject: str | None = None
+
+
+async def write_audit_entry(
+    db: AsyncSession,
+    *,
+    actor: AuditActor,
+    action: str,
+    resource_type: str,
+    resource_id: str,
+    request_id: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Stage an audit entry on *db*.
+
+    Does not commit — the caller commits as part of the same transaction as
+    the mutation this entry describes. This mirrors champagnefestival's
+    ``write_audit_entry`` contract: audit staging is always the caller's
+    responsibility to commit, never a side transaction.
+    """
+    db.add(
+        AuditEntry(
+            actor_user_id=actor.user_id,
+            actor_label=actor.label,
+            subject=actor.subject,
+            auth_source=actor.auth_source,
+            action=action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            request_id=request_id,
+            details=details or {},
+        )
+    )
+
+
+async def list_audit_entries(
+    db: AsyncSession,
+    *,
+    requesting_user_id: int,
+    is_admin: bool,
+    target_user_id: int | None = None,
+    limit: int = DEFAULT_AUDIT_LIMIT,
+    before_id: int | None = None,
+) -> list[AuditEntry]:
+    """Return bounded, stably-ordered audit entries with ownership enforcement.
+
+    - A non-admin caller may only read their own trail: ``target_user_id`` is
+      forced to ``requesting_user_id`` regardless of what was requested.
+    - An admin caller may read any user's trail (``target_user_id`` given) or
+      the full team-wide trail (``target_user_id`` omitted).
+    - ``limit`` is clamped between 1 and ``MAX_AUDIT_LIMIT``.
+    - Results are ordered ``(created_at DESC, id DESC)`` — a strictly
+      decreasing key — and ``before_id`` (an exclusive keyset cursor on
+      ``id``) gives stable pagination that can't skip or repeat rows even
+      when many entries share a ``created_at`` timestamp.
+    """
+    if limit < 1 or limit > MAX_AUDIT_LIMIT:
+        raise ValueError(f"limit must be between 1 and {MAX_AUDIT_LIMIT}, got: {limit}")
+
+    if is_admin:
+        effective_target = target_user_id
+    else:
+        if target_user_id is not None and target_user_id != requesting_user_id:
+            raise AuditAuthorizationError("admin scope required to read another user's audit trail")
+        effective_target = requesting_user_id
+
+    statement = select(AuditEntry)
+    if effective_target is not None:
+        statement = statement.where(AuditEntry.actor_user_id == effective_target)
+    if before_id is not None:
+        statement = statement.where(AuditEntry.id < before_id)
+
+    statement = statement.order_by(AuditEntry.created_at.desc(), AuditEntry.id.desc()).limit(limit)
+    result = await db.execute(statement)
+    return list(result.scalars().all())

--- a/backend/app/audit/db.py
+++ b/backend/app/audit/db.py
@@ -39,9 +39,9 @@ class AuditActor:
     or credential behind it — no current call site needs that). ``label`` is
     a human-readable identity (username, or ``integration:<client name>`` for
     managed integration-client calls) safe to display without a join.
-    ``auth_source`` matches ``WorktimeMcpContext.auth_type`` / REST
-    ``AuthType`` values (e.g. ``keycloak_user``, ``keycloak_service``,
-    ``integration_client``, ``delegated``).
+    ``auth_source`` is the persisted authentication source (e.g. ``oidc``,
+    ``keycloak_user``, ``keycloak_service``, ``integration_client``,
+    ``delegated`` — see ``AuthType``/``WorktimeMcpContext.auth_type``).
     """
 
     user_id: int | None
@@ -97,11 +97,12 @@ async def list_audit_entries(
       forced to ``requesting_user_id`` regardless of what was requested.
     - An admin caller may read any user's trail (``target_user_id`` given) or
       the full team-wide trail (``target_user_id`` omitted).
-    - ``limit`` is clamped between 1 and ``MAX_AUDIT_LIMIT``.
+    - ``limit`` must be between 1 and ``MAX_AUDIT_LIMIT`` (inclusive);
+      out-of-range values raise ``ValueError``.
     - Results are ordered ``(created_at DESC, id DESC)`` — a strictly
       decreasing key — and ``before_id`` (an exclusive keyset cursor on
-      ``id``) gives stable pagination that can't skip or repeat rows even
-      when many entries share a ``created_at`` timestamp.
+      ``(created_at, id)``) gives stable pagination that can't skip or repeat
+      rows even when many entries share a ``created_at`` timestamp.
     """
     if limit < 1 or limit > MAX_AUDIT_LIMIT:
         raise ValueError(f"limit must be between 1 and {MAX_AUDIT_LIMIT}, got: {limit}")
@@ -117,7 +118,13 @@ async def list_audit_entries(
     if effective_target is not None:
         statement = statement.where(AuditEntry.actor_user_id == effective_target)
     if before_id is not None:
-        statement = statement.where(AuditEntry.id < before_id)
+        # Use full (created_at, id) keyset cursor for stable pagination
+        cursor = await db.get(AuditEntry, before_id)
+        if cursor is not None:
+            statement = statement.where(
+                (AuditEntry.created_at < cursor.created_at)
+                | ((AuditEntry.created_at == cursor.created_at) & (AuditEntry.id < cursor.id))
+            )
 
     statement = statement.order_by(AuditEntry.created_at.desc(), AuditEntry.id.desc()).limit(limit)
     result = await db.execute(statement)

--- a/backend/app/audit/logger.py
+++ b/backend/app/audit/logger.py
@@ -59,9 +59,7 @@ def _get_audit_logger(log_dir: Path, log_file: Path) -> logging.Logger | None:
             return None
 
         try:
-            handler = RotatingFileHandler(
-                log_file, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT, encoding="utf-8"
-            )
+            handler = RotatingFileHandler(log_file, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT, encoding="utf-8")
         except (PermissionError, OSError) as e:
             logger.error(f"Failed to open audit log file: {e}")
             return None

--- a/backend/app/cache/store.py
+++ b/backend/app/cache/store.py
@@ -112,7 +112,7 @@ _cache: FileCache | None = None
 
 def get_cache() -> FileCache:
     """Get the global FileCache singleton instance.
-    
+
     Returns:
         The FileCache singleton instance
     """

--- a/backend/app/config/cors.py
+++ b/backend/app/config/cors.py
@@ -11,16 +11,16 @@ logger = logging.getLogger(__name__)
 
 def get_cors_origins(cors_env: str, environment: str) -> list[str]:
     """Parse and validate CORS origins with production safety checks.
-    
+
     Args:
         cors_env: CORS_ORIGINS environment variable value
         environment: Current environment mode (development/production)
-    
+
     Returns:
         List of allowed origins. Returns empty list if wildcard is attempted
         in production (forcing explicit origin configuration for security).
         Falls back to http://localhost:5173 if parsing fails.
-    
+
     Production Safety:
         - Wildcard (*) is rejected in production/prod environments
         - Logs warning when wildcard is blocked
@@ -28,7 +28,7 @@ def get_cors_origins(cors_env: str, environment: str) -> list[str]:
     """
     cors_value = cors_env.strip()
     env_lower = environment.lower()
-    
+
     # Production safety check for wildcard
     if cors_value == "*":
         if env_lower in ("production", "prod"):
@@ -39,15 +39,13 @@ def get_cors_origins(cors_env: str, environment: str) -> list[str]:
             return []
         logger.info("CORS: Allowing all origins (*) in development mode")
         return ["*"]
-    
+
     # Parse comma-separated origins
     origins = [origin.strip() for origin in cors_value.split(",") if origin.strip()]
-    
+
     # Fallback to localhost if no valid origins
     if not origins:
-        logger.warning(
-            "No valid CORS origins parsed. Falling back to http://localhost:5173"
-        )
+        logger.warning("No valid CORS origins parsed. Falling back to http://localhost:5173")
         return ["http://localhost:5173"]
-    
+
     return origins

--- a/backend/app/config/oidc_config.py
+++ b/backend/app/config/oidc_config.py
@@ -151,6 +151,7 @@ def start_periodic_jwks_refresh() -> asyncio.Task[None]:
 # Token validation
 # ---------------------------------------------------------------------------
 
+
 class OIDCTokenError(Exception):
     """Raised when a JWT cannot be validated."""
 
@@ -158,6 +159,7 @@ class OIDCTokenError(Exception):
 def _find_signing_key(jwks_dict: dict[str, Any], kid: str | None) -> Any | None:
     """Return the JWKS key matching kid, or any key when kid is absent."""
     from jwt import PyJWKSet
+
     jwks_set = PyJWKSet.from_dict(jwks_dict)
     return next(
         (k for k in jwks_set.keys if kid is None or k.key_id == kid),
@@ -218,6 +220,7 @@ async def decode_token(token: str) -> dict[str, Any]:
 # Local user provisioning
 # ---------------------------------------------------------------------------
 
+
 def _derive_username_and_display_name(claims: dict[str, Any], subject: str) -> tuple[str, str]:
     """Derive a local username and display name from OIDC token claims."""
     # Prefer preferred_username → email local part → sub prefix (explicit fallbacks)
@@ -228,11 +231,7 @@ def _derive_username_and_display_name(claims: dict[str, Any], subject: str) -> t
     if not username:
         username = f"user-{subject[:8]}"
 
-    display_name = (
-        (claims.get("name") or "").strip()
-        or (claims.get("display_name") or "").strip()
-        or username
-    )
+    display_name = (claims.get("name") or "").strip() or (claims.get("display_name") or "").strip() or username
 
     return username, display_name
 
@@ -257,10 +256,12 @@ async def _find_available_username(db_session, base_username: str, subject: str)
         attempt += 1
         # Progressively use more of the subject string as a disambiguation suffix.
         # Once the full subject is exhausted, append a numeric counter too.
-        suffix = subject[:min(8 + attempt, len(subject))]
+        suffix = subject[: min(8 + attempt, len(subject))]
         candidate = f"{base_username}-{suffix}" if len(suffix) < len(subject) else f"{base_username}-{suffix}-{attempt}"
 
-    raise RuntimeError(f"Could not find available username for {base_username!r} after {_MAX_USERNAME_ATTEMPTS} attempts")
+    raise RuntimeError(
+        f"Could not find available username for {base_username!r} after {_MAX_USERNAME_ATTEMPTS} attempts"
+    )
 
 
 async def get_or_create_local_user(subject: str, claims: dict[str, Any], db_session: Any):

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -73,6 +73,18 @@ class Settings(BaseSettings):
     # Generate a suitable value with: python -c "import secrets; print(secrets.token_hex(32))"
     METRICS_HMAC_SECRET: str = ""
 
+    # HMAC secret used to hash managed integration-client keys (app.services
+    # .integration_client_service) before they're stored in the database. The
+    # raw key is server-generated with high entropy (secrets.token_urlsafe),
+    # not a user password, so HMAC-SHA256 with a server-side secret is
+    # correct here: it adds defense-in-depth against a stolen database dump
+    # (without the secret, a leaked key_hash can't be replayed even though
+    # brute-forcing the raw key is already infeasible at this entropy).
+    # Falls back to a fixed local-dev-only value when unset; production must
+    # set a real secret — see validate_production_integration_key_hash_secret.
+    # Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
+    INTEGRATION_KEY_HASH_SECRET: str = ""
+
     # Sentry error tracking.
     # Leave SENTRY_DSN empty (the default) to disable Sentry entirely.
     # When set, sentry-sdk[fastapi] must be installed: uv add sentry-sdk[fastapi]
@@ -176,6 +188,29 @@ class Settings(BaseSettings):
         if self.DEV_AUTH_BYPASS_TOKEN and self.ENVIRONMENT != "development":
             raise ValueError("DEV_AUTH_BYPASS_TOKEN must not be set outside ENVIRONMENT=development.")
         return self
+
+    @model_validator(mode="after")
+    def validate_production_integration_key_hash_secret(self) -> "Settings":
+        """Refuse to start in production without a real integration-key hash secret.
+
+        The unset default is safe only for local dev (single-operator,
+        low-value threat model); production must set an explicit secret so a
+        database dump alone can't be used to forge/replay integration-client
+        keys, matching the pattern already established for TRUSTED_HOSTS and
+        DEV_AUTH_BYPASS_TOKEN above.
+        """
+        if self.ENVIRONMENT == "production" and not self.INTEGRATION_KEY_HASH_SECRET.strip():
+            raise ValueError("INTEGRATION_KEY_HASH_SECRET must be set to a real secret in production.")
+        return self
+
+    def resolved_integration_key_hash_secret(self) -> str:
+        """Resolve the HMAC secret for hashing integration-client keys.
+
+        Falls back to a fixed local-dev-only value when unset. Production
+        cannot reach this fallback: validate_production_integration_key_hash_secret
+        refuses to start without an explicit value first.
+        """
+        return self.INTEGRATION_KEY_HASH_SECRET or "worktime-dev-integration-key-hash-secret"
 
     def get_cors_origins_list(self) -> list[str]:
         """Parse CORS_ORIGINS into a list of allowed origins.

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -21,13 +21,8 @@ class Settings(BaseSettings):
     In production, override via environment variables.
     """
 
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        case_sensitive=False,
-        extra="allow"
-    )
-    
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="allow")
+
     # CORS configuration
     CORS_ORIGINS: str = "http://localhost:5173"
 
@@ -38,11 +33,11 @@ class Settings(BaseSettings):
 
     # Environment mode
     ENVIRONMENT: str = "development"
-    
+
     # Server configuration
     HOST: str = "0.0.0.0"
     PORT: int = 8000
-    
+
     # Cache configuration
     CACHE_TTL: int = 10
     CACHE_ENABLED: bool = True
@@ -139,18 +134,16 @@ class Settings(BaseSettings):
         if not v or not v.strip():
             raise ValueError("CORS_ORIGINS cannot be empty")
         return v
-    
+
     @field_validator("ENVIRONMENT")
     @classmethod
     def validate_environment(cls, v: str) -> str:
         """Validate environment mode."""
         v = v.lower()
         if v not in ("development", "production"):
-            raise ValueError(
-                f"ENVIRONMENT must be 'development' or 'production', got: {v}"
-            )
+            raise ValueError(f"ENVIRONMENT must be 'development' or 'production', got: {v}")
         return v
-    
+
     @field_validator("CACHE_TTL")
     @classmethod
     def validate_cache_ttl(cls, v: int) -> int:
@@ -210,17 +203,17 @@ class Settings(BaseSettings):
         cannot reach this fallback: validate_production_integration_key_hash_secret
         refuses to start without an explicit value first.
         """
-        return self.INTEGRATION_KEY_HASH_SECRET or "worktime-dev-integration-key-hash-secret"
+        return self.INTEGRATION_KEY_HASH_SECRET.strip() or "worktime-dev-integration-key-hash-secret"
 
     def get_cors_origins_list(self) -> list[str]:
         """Parse CORS_ORIGINS into a list of allowed origins.
-        
+
         Returns:
             List of allowed origins. Returns empty list if wildcard is attempted
             in production (forcing explicit origin configuration for security).
         """
         cors_env = self.CORS_ORIGINS.strip()
-        
+
         # Handle wildcard
         if cors_env == "*":
             # Only allow wildcard in non-production
@@ -232,11 +225,11 @@ class Settings(BaseSettings):
                 return []
             logger.info("CORS: Allowing all origins (*) in development mode")
             return ["*"]
-        
+
         # Parse comma-separated origins
         origins = [origin.strip() for origin in cors_env.split(",") if origin.strip()]
         return origins
-    
+
     def _parse_trusted_hosts(self) -> list[str]:
         """Parse the raw TRUSTED_HOSTS value into real hostnames.
 
@@ -279,9 +272,7 @@ class Settings(BaseSettings):
             try:
                 return Path(self.DB_PASSWORD_FILE).read_text(encoding="utf-8").strip()
             except OSError as e:
-                raise ValueError(
-                    f"Could not read DB_PASSWORD_FILE at {self.DB_PASSWORD_FILE}: {e}"
-                ) from e
+                raise ValueError(f"Could not read DB_PASSWORD_FILE at {self.DB_PASSWORD_FILE}: {e}") from e
         return self.DB_PASSWORD
 
     def resolved_database_url(self) -> str:
@@ -316,9 +307,7 @@ class Settings(BaseSettings):
         # Log CORS configuration
         cors_origins = self.get_cors_origins_list()
         if not cors_origins:
-            logger.error(
-                "⚠️  No CORS origins configured - all cross-origin requests will be blocked!"
-            )
+            logger.error("⚠️  No CORS origins configured - all cross-origin requests will be blocked!")
         else:
             logger.info(f"CORS Origins:    {', '.join(cors_origins)}")
 
@@ -345,7 +334,9 @@ class Settings(BaseSettings):
         if self.DATABASE_ENABLED and not self.DATABASE_URL:
             logger.info(f"  DB Host:       {self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME} (user: {self.DB_USER})")
         logger.info(f"OIDC Issuer:     {self.OIDC_ISSUER_URL}")
-        sentry_status = f"enabled (traces_sample_rate={self.SENTRY_TRACES_SAMPLE_RATE})" if self.SENTRY_DSN else "disabled"
+        sentry_status = (
+            f"enabled (traces_sample_rate={self.SENTRY_TRACES_SAMPLE_RATE})" if self.SENTRY_DSN else "disabled"
+        )
         logger.info(f"Sentry:          {sentry_status}")
         logger.info("=" * 60)
 

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -79,6 +79,7 @@ class Settings(BaseSettings):
     # set a real secret — see validate_production_integration_key_hash_secret.
     # Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
     INTEGRATION_KEY_HASH_SECRET: str = ""
+    INTEGRATION_KEY_HASH_SECRET_PREVIOUS: str = ""
 
     # Sentry error tracking.
     # Leave SENTRY_DSN empty (the default) to disable Sentry entirely.

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -202,6 +202,11 @@ class Settings(BaseSettings):
         Falls back to a fixed local-dev-only value when unset. Production
         cannot reach this fallback: validate_production_integration_key_hash_secret
         refuses to start without an explicit value first.
+
+        Deployment note: changing the effective secret (via env or fallback)
+        invalidates all previously stored ``integration_clients.key_hash`` values;
+        existing clients will fail to authenticate until rotated. Rotate all
+        integration clients when rotating this secret.
         """
         return self.INTEGRATION_KEY_HASH_SECRET.strip() or "worktime-dev-integration-key-hash-secret"
 

--- a/backend/app/database/init.py
+++ b/backend/app/database/init.py
@@ -1,4 +1,5 @@
 """Database initialization utilities."""
+
 import logging
 import os
 from pathlib import Path

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 )
 from sqlalchemy import false as sa_false
 from sqlalchemy import text as sql_text
+from sqlalchemy import true as sa_true
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -368,4 +369,91 @@ class CachedHoliday(Base):
             name="uq_cached_holiday",
             postgresql_nulls_not_distinct=True,
         ),
+    )
+
+
+class IntegrationClient(Base):
+    """Managed, database-backed credential for automation/integration callers (e.g. MCP).
+
+    Replaces the long-lived static-token map previously parsed once from
+    ``WORKTIME_MCP_INTEGRATION_KEYS`` at process startup. Each row is a
+    revocable, rotatable, rate-limited credential bound to one Worktime user.
+    Only the HMAC hash of the raw key is stored (see
+    ``app.services.integration_client_service.hash_integration_key``); the raw
+    value is returned once at creation/rotation time and cannot be recovered.
+
+    ``scopes`` follows the same shape as ``AccessToken.scopes``. The
+    well-known ``worktime:mcp`` scope grants ordinary personal-write MCP
+    access matching the caller's bound user; ``worktime:admin`` must be
+    granted explicitly (never implied) for team-wide/admin-tier access — this
+    preserves Worktime's existing ``is_admin`` semantics as a deliberate
+    grant rather than a default.
+    """
+
+    __tablename__ = "integration_clients"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    key_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
+    key_preview: Mapped[str] = mapped_column(String(8), nullable=False)
+    scopes: Mapped[list[str]] = mapped_column(
+        JSON,
+        nullable=False,
+        default=lambda: ["worktime:mcp"],
+        server_default='["worktime:mcp"]',
+    )
+    rate_limit_per_minute: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=120, server_default="120"
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa_true())
+    created_at: Mapped[dt_datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), default=_utc_now
+    )
+    last_used_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index("ix_integration_clients_user_id_created_at", "user_id", "created_at"),
+    )
+
+
+class AuditEntry(Base):
+    """Transactional, durable record of a mutation performed via REST or MCP.
+
+    Written by ``app.audit.db.write_audit_entry`` into the *same* database
+    transaction as the mutation it describes (staged via ``session.add`` and
+    committed by the caller), so a mutation can never commit without leaving
+    an audit trail, and a failed mutation never leaves an orphaned entry.
+    This is the authoritative audit record; the rotated file logger in
+    ``app.audit.logger`` (from #984) remains as secondary, best-effort
+    operational telemetry only.
+    """
+
+    __tablename__ = "audit_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    actor_user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    actor_label: Mapped[str] = mapped_column(String, nullable=False)
+    subject: Mapped[str | None] = mapped_column(String, nullable=True)
+    auth_source: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    resource_type: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    resource_id: Mapped[str] = mapped_column(String, nullable=False)
+    request_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    details: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[dt_datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), default=_utc_now, index=True
+    )
+
+    __table_args__ = (
+        # Stable-pagination read order: (created_at DESC, id DESC). Ties on
+        # created_at (same-millisecond entries) still resolve deterministically
+        # via the autoincrement id, so keyset pagination never skips or repeats
+        # a row across pages.
+        Index("ix_audit_entries_created_at_id", "created_at", "id"),
     )

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -50,9 +50,7 @@ class User(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     username: Mapped[str] = mapped_column(String, index=True, unique=True)
-    oidc_subject: Mapped[str | None] = mapped_column(
-        String, unique=True, index=True, nullable=True
-    )
+    oidc_subject: Mapped[str | None] = mapped_column(String, unique=True, index=True, nullable=True)
     display_name: Mapped[str] = mapped_column(String)
     settings: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
     created_at: Mapped[dt_datetime] = mapped_column(
@@ -78,9 +76,7 @@ class Label(ClientTimestampMixin, Base):
     updated_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=_utc_now, default=_utc_now, index=True
     )
-    deleted_at: Mapped[dt_datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
+    deleted_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
     __table_args__ = (
         Index(
@@ -101,9 +97,7 @@ class TimeTrackingTask(ClientTimestampMixin, Base):
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
-    label_id: Mapped[str | None] = mapped_column(
-        String, ForeignKey("labels.id"), nullable=True, index=True
-    )
+    label_id: Mapped[str | None] = mapped_column(String, ForeignKey("labels.id"), nullable=True, index=True)
     gantt_task_id: Mapped[str | None] = mapped_column(
         String, ForeignKey("gantt_tasks.id", ondelete="SET NULL"), nullable=True, index=True
     )
@@ -119,9 +113,7 @@ class TimeTrackingTask(ClientTimestampMixin, Base):
     updated_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=_utc_now, default=_utc_now, index=True
     )
-    deleted_at: Mapped[dt_datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
+    deleted_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
     __table_args__ = (
         Index("ix_time_tracking_tasks_user_id_updated_at", "user_id", "updated_at"),
@@ -136,9 +128,7 @@ class TimeTrackingTemplate(ClientTimestampMixin, Base):
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
-    label_id: Mapped[str | None] = mapped_column(
-        String, ForeignKey("labels.id"), nullable=True, index=True
-    )
+    label_id: Mapped[str | None] = mapped_column(String, ForeignKey("labels.id"), nullable=True, index=True)
     text: Mapped[str] = mapped_column(String)
     start_time: Mapped[dt_time] = mapped_column(Time)
     stop_time: Mapped[dt_time] = mapped_column(Time)
@@ -148,13 +138,9 @@ class TimeTrackingTemplate(ClientTimestampMixin, Base):
     updated_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=_utc_now, default=_utc_now, index=True
     )
-    deleted_at: Mapped[dt_datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
+    deleted_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
-    __table_args__ = (
-        Index("ix_time_tracking_templates_user_id_updated_at", "user_id", "updated_at"),
-    )
+    __table_args__ = (Index("ix_time_tracking_templates_user_id_updated_at", "user_id", "updated_at"),)
 
 
 class WorkLocation(ClientTimestampMixin, Base):
@@ -173,9 +159,7 @@ class WorkLocation(ClientTimestampMixin, Base):
     updated_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=_utc_now, default=_utc_now, index=True
     )
-    deleted_at: Mapped[dt_datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
+    deleted_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
     __table_args__ = (
         Index(
@@ -195,12 +179,8 @@ class GanttTask(ClientTimestampMixin, Base):
     __tablename__ = "gantt_tasks"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True
-    )
-    label_id: Mapped[str | None] = mapped_column(
-        String, ForeignKey("labels.id"), nullable=True, index=True
-    )
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    label_id: Mapped[str | None] = mapped_column(String, ForeignKey("labels.id"), nullable=True, index=True)
     name: Mapped[str] = mapped_column(String)
     start_date: Mapped[dt_date] = mapped_column(Date)
     end_date: Mapped[dt_date] = mapped_column(Date)
@@ -213,9 +193,7 @@ class GanttTask(ClientTimestampMixin, Base):
     updated_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=_utc_now, default=_utc_now, index=True
     )
-    deleted_at: Mapped[dt_datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
+    deleted_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
     __table_args__ = (Index("ix_gantt_tasks_user_id_updated_at", "user_id", "updated_at"),)
 
@@ -230,9 +208,7 @@ class UserPreferences(ClientTimestampMixin, Base):
 
     __tablename__ = "user_preferences"
 
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
-    )
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
     data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
     created_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), default=_utc_now
@@ -270,9 +246,7 @@ class TimeOffEntry(ClientTimestampMixin, Base):
     updated_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=_utc_now, default=_utc_now, index=True
     )
-    deleted_at: Mapped[dt_datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
+    deleted_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
     __table_args__ = (
         Index(
@@ -312,9 +286,7 @@ class AccessToken(Base):
     __tablename__ = "access_tokens"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True
-    )
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True)
     name: Mapped[str] = mapped_column(String)
     token_hash: Mapped[str] = mapped_column(String, unique=True, index=True)
     token_preview: Mapped[str] = mapped_column(String)
@@ -405,9 +377,7 @@ class IntegrationClient(Base):
         default=lambda: ["worktime:mcp"],
         server_default='["worktime:mcp"]',
     )
-    rate_limit_per_minute: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=120, server_default="120"
-    )
+    rate_limit_per_minute: Mapped[int] = mapped_column(Integer, nullable=False, default=120, server_default="120")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa_true())
     created_at: Mapped[dt_datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), default=_utc_now
@@ -415,9 +385,7 @@ class IntegrationClient(Base):
     last_used_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    __table_args__ = (
-        Index("ix_integration_clients_user_id_created_at", "user_id", "created_at"),
-    )
+    __table_args__ = (Index("ix_integration_clients_user_id_created_at", "user_id", "created_at"),)
 
 
 class AuditEntry(Base):
@@ -447,7 +415,7 @@ class AuditEntry(Base):
     request_id: Mapped[str | None] = mapped_column(String, nullable=True)
     details: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
     created_at: Mapped[dt_datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), default=_utc_now, index=True
+        DateTime(timezone=True), server_default=func.now(), default=_utc_now
     )
 
     __table_args__ = (

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -384,6 +384,8 @@ class IntegrationClient(Base):
     )
     last_used_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rate_limit_window_started_at: Mapped[dt_datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rate_limit_window_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
 
     __table_args__ = (Index("ix_integration_clients_user_id_created_at", "user_id", "created_at"),)
 

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -369,7 +369,7 @@ class IntegrationClient(Base):
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String(120), nullable=False)
-    key_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
+    key_hash: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
     key_preview: Mapped[str] = mapped_column(String(8), nullable=False)
     scopes: Mapped[list[str]] = mapped_column(
         JSON,
@@ -408,9 +408,9 @@ class AuditEntry(Base):
     )
     actor_label: Mapped[str] = mapped_column(String, nullable=False)
     subject: Mapped[str | None] = mapped_column(String, nullable=True)
-    auth_source: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    action: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    resource_type: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    auth_source: Mapped[str] = mapped_column(String, nullable=False)
+    action: Mapped[str] = mapped_column(String, nullable=False)
+    resource_type: Mapped[str] = mapped_column(String, nullable=False)
     resource_id: Mapped[str] = mapped_column(String, nullable=False)
     request_id: Mapped[str | None] = mapped_column(String, nullable=True)
     details: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,10 +39,12 @@ logger = logging.getLogger(__name__)
 
 _worktime_mcp_base_url = os.environ.get("WORKTIME_MCP_BASE_URL", "")
 if _worktime_mcp_base_url:
+    from .mcp_server import MCP_TOOL_CAPABILITIES as _MCP_TOOL_CAPABILITIES
     from .mcp_server import create_mcp_server as _create_mcp_server
     _mcp = _create_mcp_server()
     _mcp_app = _mcp.http_app(path="/")
 else:
+    from .mcp_server import MCP_TOOL_CAPABILITIES as _MCP_TOOL_CAPABILITIES
     _mcp = None
     _mcp_app = None
 
@@ -191,6 +193,7 @@ app.include_router(holidays_router, prefix="/api")
 if settings.DATABASE_ENABLED:
     from .routers.access_tokens import router as access_tokens_router
     from .routers.account_router import router as account_router
+    from .routers.audit import router as audit_router
     from .routers.db_gantt import router as db_gantt_router
     from .routers.db_preferences import router as db_preferences_router
     from .routers.db_sync import router as db_sync_router
@@ -198,12 +201,15 @@ if settings.DATABASE_ENABLED:
     from .routers.db_time_tracking import router as db_time_tracking_router
     from .routers.db_users import router as db_users_router
     from .routers.db_work_locations import router as db_work_locations_router
+    from .routers.integration_clients import router as integration_clients_router
     from .routers.pebble import router as pebble_router
     from .routers.read_models import router as read_models_router
     from .routers.registration import router as registration_router
 
     app.include_router(account_router, prefix="/api")
     app.include_router(access_tokens_router, prefix="/api")
+    app.include_router(integration_clients_router, prefix="/api")
+    app.include_router(audit_router, prefix="/api")
     app.include_router(registration_router, prefix="/api")
     app.include_router(db_users_router, prefix="/api")
     app.include_router(db_time_tracking_router, prefix="/api")
@@ -221,6 +227,33 @@ else:
 if _mcp_app is not None:
     app.mount("/mcp", _mcp_app)
     logger.info("✓ MCP server mounted at /mcp")
+
+
+@app.get("/api/mcp/capabilities", tags=["Info"])
+async def mcp_capabilities() -> dict[str, object]:
+    """Authoritative MCP capability manifest (issue #1054).
+
+    Sourced directly from ``app.mcp_server.MCP_TOOL_CAPABILITIES`` — the same
+    dict ``create_mcp_server()`` iterates to register tools — so this
+    response cannot drift from what's actually registered on the running
+    server. ``tools`` is empty when the MCP server isn't mounted
+    (``WORKTIME_MCP_BASE_URL`` unset).
+    """
+    enabled = _mcp_app is not None
+    return {
+        "enabled": enabled,
+        "mount_path": "/mcp",
+        "tools": [
+            {
+                "name": name,
+                "side_effect": capability.effect.value,
+                "required_tier": capability.required_tier,
+            }
+            for name, capability in _MCP_TOOL_CAPABILITIES.items()
+        ]
+        if enabled
+        else [],
+    }
 
 
 @app.get("/", response_class=PlainTextResponse, tags=["Info"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,20 +31,19 @@ from .utils.sse_manager import sync_event_manager
 from .version import APP_VERSION
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 _worktime_mcp_base_url = os.environ.get("WORKTIME_MCP_BASE_URL", "")
 if _worktime_mcp_base_url:
     from .mcp_server import MCP_TOOL_CAPABILITIES as _MCP_TOOL_CAPABILITIES
     from .mcp_server import create_mcp_server as _create_mcp_server
+
     _mcp = _create_mcp_server()
     _mcp_app = _mcp.http_app(path="/")
 else:
     from .mcp_server import MCP_TOOL_CAPABILITIES as _MCP_TOOL_CAPABILITIES
+
     _mcp = None
     _mcp_app = None
 
@@ -62,8 +61,7 @@ if settings.SENTRY_DSN:
         logger.info("✓ Sentry error tracking initialized")
     except ImportError:
         logger.warning(
-            "⚠️  SENTRY_DSN is configured but sentry-sdk is not installed. "
-            "Install it with: uv add sentry-sdk[fastapi]"
+            "⚠️  SENTRY_DSN is configured but sentry-sdk is not installed. Install it with: uv add sentry-sdk[fastapi]"
         )
 
 
@@ -74,7 +72,7 @@ async def lifespan(app: FastAPI):
     logger.info("=" * 60)
     logger.info("Worktime Backend API - Starting up")
     logger.info("=" * 60)
-    
+
     # Log configuration
     settings.log_configuration()
 
@@ -124,7 +122,7 @@ app = FastAPI(
     title="Worktime Backend API",
     description="API server for Worktime shift tracker and time-off management",
     version=APP_VERSION,
-    lifespan=_lifespan
+    lifespan=_lifespan,
 )
 
 # Configure CORS middleware with production safety
@@ -146,6 +144,7 @@ _cors_kwargs: dict[str, Any] = {
     "expose_headers": ["X-Request-ID", "X-Total-Ms"],
 }
 if _mcp_app is not None:
+
     class _MCPAwareCORSMiddleware:
         def __init__(self, app, **kwargs) -> None:
             self._app = app
@@ -259,7 +258,7 @@ async def mcp_capabilities() -> dict[str, object]:
 @app.get("/", response_class=PlainTextResponse, tags=["Info"])
 async def root():
     """Root endpoint with basic API information.
-    
+
     Returns:
         Plain text message with API title and version.
     """
@@ -268,11 +267,11 @@ async def root():
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     uvicorn.run(
         "app.main:app",
         host=settings.HOST,
         port=settings.PORT,
         reload=settings.ENVIRONMENT == "development",
-        log_level="info"
+        log_level="info",
     )

--- a/backend/app/mcp/__init__.py
+++ b/backend/app/mcp/__init__.py
@@ -1,0 +1,10 @@
+"""Domain modules for the Worktime FastMCP server.
+
+``app.mcp_server`` is the thin assembler (imports, auth-provider building,
+``WorktimeMcpContext``/error types re-exported from ``app.mcp.context``,
+tool registration). Each module here holds the actual tool logic for one
+domain, as plain async functions the assembler's ``WorktimeMcpBackend``
+methods delegate to — mirroring champagnefestival's ``app/mcp/`` package
+shape while keeping Worktime's own async-service-reuse and
+``_map_domain_errors`` patterns.
+"""

--- a/backend/app/mcp/context.py
+++ b/backend/app/mcp/context.py
@@ -1,0 +1,91 @@
+"""Shared MCP call context: principal type, error types, and cross-cutting helpers.
+
+Kept separate from ``app.mcp_server`` (the assembler) so the domain modules
+in this package can import it without a circular dependency on the
+assembler, which in turn imports the domain modules.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Concatenate
+
+from app.audit.db import AuditActor
+from app.services.db_service import ConflictError, NotFoundError, ValidationError
+
+if TYPE_CHECKING:
+    from app.mcp_server import WorktimeMcpBackend
+
+
+class McpAuthError(RuntimeError):
+    """Raised when MCP authentication context is missing or invalid."""
+
+
+class McpPermissionError(RuntimeError):
+    """Raised when MCP caller is authenticated but not authorized."""
+
+
+class McpRateLimitError(RuntimeError):
+    """Raised when an integration-client caller exceeds its configured rate limit.
+
+    MCP tool calls are JSON-RPC, not HTTP, so there's no 429 status code to
+    return — raising here surfaces a clear, actionable error message to the
+    calling model/client instead, which is the closest MCP equivalent.
+    """
+
+
+@dataclass(frozen=True)
+class WorktimeMcpContext:
+    user_id: int
+    username: str
+    display_name: str
+    is_admin: bool
+    subject: str | None
+    claims: dict[str, Any]
+    scopes: list[str]
+    auth_type: str
+
+
+def actor_from_context(context: WorktimeMcpContext) -> AuditActor:
+    """Build the transactional-audit actor identity for an authenticated MCP call.
+
+    For integration-client calls, the label is the managed client's own name
+    (never raw key material — the client only ever sees a hash) so the audit
+    trail reads as e.g. ``integration:home-assistant`` rather than an opaque
+    user id.
+    """
+    label = context.username
+    if context.auth_type == "integration_client":
+        client_name = context.claims.get("worktime_integration_client_name")
+        client_id = context.claims.get("worktime_integration_client_id")
+        label = f"integration:{client_name or client_id}"
+    return AuditActor(
+        user_id=context.user_id,
+        label=label,
+        auth_source=context.auth_type,
+        subject=context.subject,
+    )
+
+
+def map_domain_errors[**P, R](
+    func: Callable[Concatenate[WorktimeMcpBackend, P], Awaitable[R]],
+) -> Callable[Concatenate[WorktimeMcpBackend, P], Awaitable[R]]:
+    """Translate db_service domain exceptions into ValueError for MCP callers.
+
+    Without this, only delete_label mapped ConflictError to ValueError —
+    every other write tool let ConflictError / NotFoundError / ValidationError
+    (e.g. "only one running task is allowed per user") propagate raw, so the
+    calling model saw an opaque failure instead of the actionable message the
+    exception already carries. Apply to every write tool method.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self: WorktimeMcpBackend, *args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return await func(self, *args, **kwargs)
+        except (ConflictError, NotFoundError, ValidationError) as exc:
+            raise ValueError(str(exc)) from exc
+
+    return wrapper

--- a/backend/app/mcp/formatting.py
+++ b/backend/app/mcp/formatting.py
@@ -1,0 +1,15 @@
+"""Shared response-formatting helpers for MCP domain modules."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+
+def to_iso_date(value: date) -> str:
+    return value.isoformat()
+
+
+def to_iso_datetime(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()

--- a/backend/app/mcp/gantt.py
+++ b/backend/app/mcp/gantt.py
@@ -50,7 +50,7 @@ async def get_gantt_tasks(
         # Bounded, paginated retrieval with DB-side active_on filtering and count
         tasks, total_tasks = await list_gantt_tasks(
             db, user_id=context.user_id, active_on=active_on, limit=MAX_GANTT_TASKS_RETURNED
-        )
+        )  # type: ignore[assignment]
         payload_tasks = [
             GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json") for task in tasks
         ]

--- a/backend/app/mcp/gantt.py
+++ b/backend/app/mcp/gantt.py
@@ -50,7 +50,7 @@ async def get_gantt_tasks(
         # Bounded, paginated retrieval with DB-side active_on filtering and count
         tasks, total_tasks = await list_gantt_tasks(
             db, user_id=context.user_id, active_on=active_on, limit=MAX_GANTT_TASKS_RETURNED
-        )  # type: ignore[assignment]
+        )
         payload_tasks = [
             GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json") for task in tasks
         ]

--- a/backend/app/mcp/gantt.py
+++ b/backend/app/mcp/gantt.py
@@ -40,18 +40,21 @@ async def get_gantt_tasks(
     if task_id:
         task = await get_gantt_task(db, context.user_id, task_id)
         payload_tasks = [GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")]
+        total_tasks = 1
+        if active_on is not None:
+            payload_tasks = [
+                task for task in payload_tasks if task["start_date"] <= to_iso_date(active_on) <= task["end_date"]
+            ]
+            total_tasks = len(payload_tasks)
     else:
-        tasks = await list_gantt_tasks(db, user_id=context.user_id)
+        # Bounded, paginated retrieval with DB-side active_on filtering and count
+        tasks, total_tasks = await list_gantt_tasks(
+            db, user_id=context.user_id, active_on=active_on, limit=MAX_GANTT_TASKS_RETURNED
+        )
         payload_tasks = [
             GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json") for task in tasks
         ]
 
-    if active_on is not None:
-        payload_tasks = [
-            task for task in payload_tasks if task["start_date"] <= to_iso_date(active_on) <= task["end_date"]
-        ]
-
-    total_tasks = len(payload_tasks)
     truncated = total_tasks > MAX_GANTT_TASKS_RETURNED
     payload_tasks = payload_tasks[:MAX_GANTT_TASKS_RETURNED]
 
@@ -92,7 +95,7 @@ async def create_gantt_task(
     audit.append(
         target=f"user:{context.user_id}:gantt:{task.id}",
         action="create_gantt_task",
-        details=f"name={name!r} via MCP",
+        details="via MCP",
     )
     return GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 

--- a/backend/app/mcp/gantt.py
+++ b/backend/app/mcp/gantt.py
@@ -1,0 +1,168 @@
+"""Gantt domain: personal Gantt board reads and write tools."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import logger as audit
+from app.mcp.context import WorktimeMcpContext, actor_from_context
+from app.mcp.formatting import to_iso_date
+from app.schemas import GanttTaskCreate, GanttTaskRead, GanttTaskUpdate
+from app.services.db_service import (
+    create_gantt_task as create_gantt_task_service,
+)
+from app.services.db_service import (
+    delete_gantt_task as delete_gantt_task_service,
+)
+from app.services.db_service import (
+    get_gantt_task,
+    list_gantt_tasks,
+)
+from app.services.db_service import (
+    update_gantt_task as update_gantt_task_service,
+)
+
+# Hard cap on items returned by get_gantt_tasks. Personal Gantt boards are
+# typically small (a handful of projects), so this is a defense-in-depth
+# bound rather than an expected everyday limit.
+MAX_GANTT_TASKS_RETURNED = 200
+
+
+async def get_gantt_tasks(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    active_on: date | None = None,
+    task_id: str | None = None,
+) -> dict[str, Any]:
+    if task_id:
+        task = await get_gantt_task(db, context.user_id, task_id)
+        payload_tasks = [GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")]
+    else:
+        tasks = await list_gantt_tasks(db, user_id=context.user_id)
+        payload_tasks = [
+            GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json") for task in tasks
+        ]
+
+    if active_on is not None:
+        payload_tasks = [
+            task for task in payload_tasks if task["start_date"] <= to_iso_date(active_on) <= task["end_date"]
+        ]
+
+    total_tasks = len(payload_tasks)
+    truncated = total_tasks > MAX_GANTT_TASKS_RETURNED
+    payload_tasks = payload_tasks[:MAX_GANTT_TASKS_RETURNED]
+
+    return {
+        "user_id": context.user_id,
+        "active_on": to_iso_date(active_on) if active_on is not None else None,
+        "total_tasks": total_tasks,
+        "truncated": truncated,
+        "tasks": payload_tasks,
+    }
+
+
+async def create_gantt_task(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    name: str,
+    start_date: date,
+    end_date: date,
+    progress: int = 0,
+    dependencies: str | None = None,
+    notes: str | None = None,
+    label_id: str | None = None,
+) -> dict[str, Any]:
+    """Create a personal Gantt task.
+
+    Side effects: inserts a new GanttTask row. Returns the created task.
+    """
+    payload = GanttTaskCreate(
+        name=name,
+        start_date=start_date,
+        end_date=end_date,
+        progress=progress,
+        dependencies=dependencies,
+        notes=notes,
+        label_id=label_id,
+    )
+    task = await create_gantt_task_service(db, context.user_id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:gantt:{task.id}",
+        action="create_gantt_task",
+        details=f"name={name!r} via MCP",
+    )
+    return GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+
+
+async def update_gantt_task(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    task_id: str,
+    name: str | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    progress: int | None = None,
+    dependencies: str | None = None,
+    notes: str | None = None,
+    label_id: str | None = None,
+    clear_label_id: bool = False,
+) -> dict[str, Any]:
+    """Update a personal Gantt task.
+
+    Omit any parameter to leave it unchanged. Set clear_label_id=True to
+    unlink its label; this takes precedence over label_id when true.
+
+    Side effects: updates the specified GanttTask row. The task must belong
+    to the authenticated user. Returns the updated task.
+    """
+    # Verify ownership before updating
+    await get_gantt_task(db, context.user_id, task_id)
+    update_data: dict[str, Any] = {}
+    if name is not None:
+        update_data["name"] = name
+    if clear_label_id:
+        update_data["label_id"] = None
+    elif label_id is not None:
+        update_data["label_id"] = label_id
+    if start_date is not None:
+        update_data["start_date"] = start_date
+    if end_date is not None:
+        update_data["end_date"] = end_date
+    if progress is not None:
+        update_data["progress"] = progress
+    if dependencies is not None:
+        update_data["dependencies"] = None if dependencies == "" else dependencies
+    if notes is not None:
+        update_data["notes"] = None if notes == "" else notes
+
+    payload = GanttTaskUpdate(**update_data)
+    task = await update_gantt_task_service(db, context.user_id, task_id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:gantt:{task_id}",
+        action="update_gantt_task",
+        details="via MCP",
+    )
+    return GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+
+
+async def delete_gantt_task(context: WorktimeMcpContext, db: AsyncSession, task_id: str) -> dict[str, Any]:
+    """Delete a personal Gantt task.
+
+    Side effects: soft-deletes the GanttTask row (sets deleted_at so the
+    deletion propagates through the sync layer to other devices; the row is
+    not removed) and unlinks any time-tracking tasks that referenced it. The
+    task must belong to the authenticated user. Returns a confirmation
+    payload.
+    """
+    # Verify ownership before deleting
+    await get_gantt_task(db, context.user_id, task_id)
+    await delete_gantt_task_service(db, context.user_id, task_id, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:gantt:{task_id}",
+        action="delete_gantt_task",
+        details="via MCP",
+    )
+    return {"deleted": True, "task_id": task_id, "user_id": context.user_id}

--- a/backend/app/mcp/identity.py
+++ b/backend/app/mcp/identity.py
@@ -1,0 +1,36 @@
+"""Identity domain: whoami / capability self-description."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp.context import WorktimeMcpContext
+
+
+async def whoami(context: WorktimeMcpContext) -> dict[str, Any]:
+    """Describe the authenticated caller, including managed integration-client identity.
+
+    When the caller authenticated via a managed integration client (issue
+    #1054), the response includes that client's id/name/scopes so the caller
+    can confirm what it's authorized for — never raw key material, which the
+    server never has access to after creation/rotation (only the HMAC hash is
+    stored).
+    """
+    integration_client: dict[str, Any] | None = None
+    if context.auth_type == "integration_client":
+        integration_client = {
+            "id": context.claims.get("worktime_integration_client_id"),
+            "name": context.claims.get("worktime_integration_client_name"),
+            "scopes": context.claims.get("worktime_integration_client_scopes"),
+        }
+
+    return {
+        "user_id": context.user_id,
+        "username": context.username,
+        "display_name": context.display_name,
+        "is_admin": context.is_admin,
+        "subject": context.subject,
+        "auth_type": context.auth_type,
+        "scopes": context.scopes,
+        "integration_client": integration_client,
+    }

--- a/backend/app/mcp/schedule.py
+++ b/backend/app/mcp/schedule.py
@@ -1,0 +1,152 @@
+"""Schedule domain: current status, next shift, team status, sync status."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp.context import WorktimeMcpContext
+from app.mcp.formatting import to_iso_date, to_iso_datetime
+from app.routers.auth import AuthenticatedPrincipal
+from app.schemas import TaskRead, TimeOffEntryRead, WorkLocationRead
+from app.services.db_service import get_running_task, list_time_off_entries, list_work_locations
+from app.services.read_models_service import (
+    build_dashboard_read_model,
+    compute_next_shifts_for_team,
+    get_schedule_type_for_user,
+)
+from app.services.sync_service import get_sync_status as get_sync_status_service
+
+
+async def get_current_status(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any]:
+    today = datetime.now(UTC).date()
+    now_utc = datetime.now(UTC)
+
+    running_task = await get_running_task(db, context.user_id)
+    running_task_payload = (
+        TaskRead.model_validate(running_task, from_attributes=True).model_dump(mode="json")
+        if running_task is not None
+        else None
+    )
+    running_seconds = None
+    if running_task is not None:
+        start = running_task.start_time
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=UTC)
+        running_seconds = max(0, int((now_utc - start.astimezone(UTC)).total_seconds()))
+
+    work_location = None
+    today_locations = await list_work_locations(db, user_id=context.user_id, start_date=today, end_date=today)
+    if today_locations:
+        work_location = WorkLocationRead.model_validate(today_locations[-1], from_attributes=True).model_dump(
+            mode="json"
+        )
+
+    time_off_entries = await list_time_off_entries(db, user_id=context.user_id, start_date=today, end_date=today)
+    active_time_off = [
+        TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
+        for entry in time_off_entries
+    ]
+
+    return {
+        "date": to_iso_date(today),
+        "user": {
+            "user_id": context.user_id,
+            "username": context.username,
+            "display_name": context.display_name,
+        },
+        "running_task": running_task_payload,
+        "running_task_seconds": running_seconds,
+        "work_location": work_location,
+        "active_time_off": active_time_off,
+    }
+
+
+async def get_next_shift(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any]:
+    principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
+    dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
+    as_of = dashboard.next_shifts.as_of
+    items = dashboard.next_shifts.items
+    if not items:
+        return {"as_of": to_iso_datetime(as_of), "next_shift": None}
+    item = items[0]
+    return {
+        "as_of": to_iso_datetime(as_of),
+        "next_shift": {
+            "team_number": item.team_number,
+            "date": to_iso_date(item.date),
+            "shift_code": item.shift_code,
+            "shift": item.shift.model_dump(mode="json"),
+        },
+    }
+
+
+async def get_team_status(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any]:
+    principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
+    dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
+    return {
+        "as_of": to_iso_datetime(dashboard.team_status.as_of),
+        "schedule_type": dashboard.work_context.schedule_type,
+        "items": [
+            {
+                "team_number": item.team_number,
+                "date": to_iso_date(item.date),
+                "shift_day": to_iso_date(item.shift_day),
+                "shift_code": item.shift_code,
+                "shift": item.shift.model_dump(mode="json"),
+                "is_currently_working": item.is_currently_working,
+            }
+            for item in dashboard.team_status.items
+        ],
+    }
+
+
+async def get_next_shifts_for_team(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    team_number: int,
+    limit: int = 5,
+) -> dict[str, Any]:
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+    limit = min(limit, 50)
+    # Only the schedule type is needed here, so use the lightweight lookup
+    # instead of build_dashboard_read_model(), which would also fetch the
+    # user row, list time-off entries, and compute a team_status entry for
+    # every team in the schedule.
+    as_of = datetime.now(UTC)
+    schedule_type = await get_schedule_type_for_user(db, context.user_id)
+    if schedule_type is None:
+        return {
+            "as_of": to_iso_datetime(as_of),
+            "schedule_type": None,
+            "team_number": team_number,
+            "items": [],
+        }
+    items = compute_next_shifts_for_team(
+        schedule_type,
+        team_number,
+        as_of=as_of,
+        limit=limit,
+    )
+    return {
+        "as_of": to_iso_datetime(as_of),
+        "schedule_type": schedule_type,
+        "team_number": team_number,
+        "items": [
+            {
+                "team_number": item.team_number,
+                "date": to_iso_date(item.date),
+                "shift_code": item.shift_code,
+                "shift": item.shift.model_dump(mode="json"),
+            }
+            for item in items
+        ],
+    }
+
+
+async def get_sync_status(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any]:
+    payload = await get_sync_status_service(db, context.user_id)
+    return payload.model_dump(mode="json")

--- a/backend/app/mcp/time_off.py
+++ b/backend/app/mcp/time_off.py
@@ -84,7 +84,7 @@ async def create_time_off_event(
     audit.append(
         target=f"user:{context.user_id}:time_off:{entry.entry_id}",
         action=action,
-        details=f"entry_type={entry_type!r} entry_kind={entry_kind!r} via MCP",
+        details="via MCP",
     )
     return TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
 

--- a/backend/app/mcp/time_off.py
+++ b/backend/app/mcp/time_off.py
@@ -1,0 +1,155 @@
+"""Time-off domain: summary and personal write tools."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import logger as audit
+from app.mcp.context import WorktimeMcpContext, actor_from_context
+from app.schemas import EntryFlag, EntryKind, EntryType, TimeOffEntryCreate, TimeOffEntryRead, TimeOffEntryUpdate
+from app.services.db_service import (
+    create_or_update_time_off_entry,
+    delete_time_off_entry,
+    get_time_off_entry,
+    list_time_off_entries,
+    update_time_off_entry,
+)
+
+
+async def get_time_off_summary(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> dict[str, Any]:
+    start = start_date or datetime.now(UTC).date()
+    end = end_date or start
+    entries = await list_time_off_entries(db, user_id=context.user_id, start_date=start, end_date=end)
+    payload_entries = [
+        TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json") for entry in entries
+    ]
+
+    by_type = Counter(entry["entry_type"] for entry in payload_entries)
+    by_kind = Counter(entry["entry_kind"] for entry in payload_entries)
+
+    return {
+        "user_id": context.user_id,
+        "start_date": start.isoformat(),
+        "end_date": end.isoformat(),
+        "total_entries": len(payload_entries),
+        "counts_by_type": dict(by_type),
+        "counts_by_kind": dict(by_kind),
+        "entries": payload_entries,
+    }
+
+
+async def create_time_off_event(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    entry_kind: EntryKind,
+    entry_type: EntryType,
+    entry_flag: EntryFlag = "full_day",
+    date: date | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    weekday: int | None = None,
+    note: str | None = None,
+    entry_id: str | None = None,
+) -> dict[str, Any]:
+    """Create (or upsert) a personal time-off event.
+
+    Side effects: inserts or updates a TimeOffEntry row. If entry_id is
+    provided the call is idempotent — re-sending the same payload restores a
+    previously deleted entry. Returns the created or updated entry.
+    """
+    payload = TimeOffEntryCreate(
+        entry_id=entry_id,
+        entry_kind=entry_kind,
+        entry_type=entry_type,
+        entry_flag=entry_flag,
+        date=date,
+        start_date=start_date,
+        end_date=end_date,
+        weekday=weekday,
+        note=note,
+    )
+    entry, created = await create_or_update_time_off_entry(
+        db, context.user_id, payload, actor=actor_from_context(context)
+    )
+    action = "create_time_off_event" if created else "upsert_time_off_event"
+    audit.append(
+        target=f"user:{context.user_id}:time_off:{entry.entry_id}",
+        action=action,
+        details=f"entry_type={entry_type!r} entry_kind={entry_kind!r} via MCP",
+    )
+    return TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
+
+
+async def update_time_off_event(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    entry_id: str,
+    entry_kind: EntryKind | None = None,
+    entry_type: EntryType | None = None,
+    entry_flag: EntryFlag | None = None,
+    date: date | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    weekday: int | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Update an existing personal time-off event.
+
+    Side effects: updates the specified TimeOffEntry row. The entry must
+    belong to the authenticated user. Returns the updated entry.
+    """
+    # Verify ownership before updating
+    await get_time_off_entry(db, context.user_id, entry_id)
+    update_data: dict[str, Any] = {}
+    if entry_kind is not None:
+        update_data["entry_kind"] = entry_kind
+    if entry_type is not None:
+        update_data["entry_type"] = entry_type
+    if entry_flag is not None:
+        update_data["entry_flag"] = entry_flag
+    if date is not None:
+        update_data["date"] = date
+    if start_date is not None:
+        update_data["start_date"] = start_date
+    if end_date is not None:
+        update_data["end_date"] = end_date
+    if weekday is not None:
+        update_data["weekday"] = weekday
+    if note is not None:
+        update_data["note"] = None if note == "" else note
+
+    payload = TimeOffEntryUpdate(**update_data)
+    entry = await update_time_off_entry(db, context.user_id, entry_id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:time_off:{entry_id}",
+        action="update_time_off_event",
+        details="via MCP",
+    )
+    return TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
+
+
+async def delete_time_off_event(context: WorktimeMcpContext, db: AsyncSession, entry_id: str) -> dict[str, Any]:
+    """Soft-delete a personal time-off event.
+
+    Side effects: sets deleted_at on the TimeOffEntry row so the deletion
+    propagates through the sync layer. The entry must belong to the
+    authenticated user. Returns a confirmation payload.
+    """
+    # Verify ownership before deleting
+    await get_time_off_entry(db, context.user_id, entry_id)
+    await delete_time_off_entry(db, context.user_id, entry_id, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:time_off:{entry_id}",
+        action="delete_time_off_event",
+        details="via MCP",
+    )
+    return {"deleted": True, "entry_id": entry_id, "user_id": context.user_id}

--- a/backend/app/mcp/time_tracking.py
+++ b/backend/app/mcp/time_tracking.py
@@ -61,9 +61,7 @@ async def get_time_tracking_summary(
 
     running = await get_running_task(db, context.user_id)
     running_payload = (
-        TaskRead.model_validate(running, from_attributes=True).model_dump(mode="json")
-        if running is not None
-        else None
+        TaskRead.model_validate(running, from_attributes=True).model_dump(mode="json") if running is not None else None
     )
 
     return {
@@ -81,12 +79,7 @@ async def get_time_tracking_summary(
 async def list_labels(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any]:
     """List the authenticated user's active time-tracking labels."""
     labels = await list_labels_for_user(db, context.user_id)
-    return {
-        "labels": [
-            {"id": label.id, "name": label.name, "color": label.color}
-            for label in labels
-        ]
-    }
+    return {"labels": [{"id": label.id, "name": label.name, "color": label.color} for label in labels]}
 
 
 async def delete_label_tool(context: WorktimeMcpContext, db: AsyncSession, label_id: str) -> dict[str, Any]:

--- a/backend/app/mcp/time_tracking.py
+++ b/backend/app/mcp/time_tracking.py
@@ -129,7 +129,7 @@ async def start_time_entry(
     audit.append(
         target=f"user:{context.user_id}:task:{task.id}",
         action="start_time_entry",
-        details=f"text={text!r} via MCP",
+        details="via MCP",
     )
     return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
@@ -185,7 +185,7 @@ async def create_time_tracking_task(
     audit.append(
         target=f"user:{context.user_id}:task:{task.id}",
         action="create_time_tracking_task",
-        details=f"text={text!r} via MCP",
+        details="via MCP",
     )
     return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 

--- a/backend/app/mcp/time_tracking.py
+++ b/backend/app/mcp/time_tracking.py
@@ -1,0 +1,259 @@
+"""Time-tracking domain: summary, labels, and personal task write tools."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import logger as audit
+from app.mcp.context import WorktimeMcpContext, actor_from_context
+from app.mcp.formatting import to_iso_datetime
+from app.schemas import TaskCreate, TaskRead, TaskUpdate
+from app.services.db_service import (
+    NotFoundError,
+    create_task,
+    delete_label,
+    delete_task,
+    get_running_task,
+    get_task,
+    list_labels_for_user,
+    list_tasks,
+    update_task,
+)
+
+# Default lookback window for get_time_tracking_summary when the caller omits
+# both start_at and end_at — bounds the response to a reasonable size instead
+# of returning the user's entire tracked-task history into the model's
+# context on every unfiltered call.
+DEFAULT_SUMMARY_WINDOW = timedelta(days=30)
+
+
+async def get_time_tracking_summary(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Summarize time-tracking tasks for the authenticated user.
+
+    When both start_at and end_at are omitted, defaults to the trailing
+    30 days rather than the user's entire history, so a plain call stays
+    bounded. Pass explicit dates for a wider or narrower range.
+    """
+    now_utc = datetime.now(UTC)
+    default_range_applied = start_at is None and end_at is None
+    effective_end = end_at or now_utc
+    effective_start = start_at or (effective_end - DEFAULT_SUMMARY_WINDOW)
+
+    tasks = await list_tasks(db, user_id=context.user_id, start_date=effective_start, end_date=effective_end)
+    payload_tasks = [TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json") for task in tasks]
+    total_seconds = 0
+    for task in tasks:
+        start = task.start_time
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=UTC)
+        stop = task.stop_time or now_utc
+        if stop.tzinfo is None:
+            stop = stop.replace(tzinfo=UTC)
+        total_seconds += max(0, int((stop.astimezone(UTC) - start.astimezone(UTC)).total_seconds()))
+
+    running = await get_running_task(db, context.user_id)
+    running_payload = (
+        TaskRead.model_validate(running, from_attributes=True).model_dump(mode="json")
+        if running is not None
+        else None
+    )
+
+    return {
+        "user_id": context.user_id,
+        "start_at": to_iso_datetime(effective_start),
+        "end_at": to_iso_datetime(effective_end),
+        "default_range_applied": default_range_applied,
+        "task_count": len(payload_tasks),
+        "tracked_seconds": total_seconds,
+        "running_task": running_payload,
+        "tasks": payload_tasks,
+    }
+
+
+async def list_labels(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any]:
+    """List the authenticated user's active time-tracking labels."""
+    labels = await list_labels_for_user(db, context.user_id)
+    return {
+        "labels": [
+            {"id": label.id, "name": label.name, "color": label.color}
+            for label in labels
+        ]
+    }
+
+
+async def delete_label_tool(context: WorktimeMcpContext, db: AsyncSession, label_id: str) -> dict[str, Any]:
+    """Delete a time-tracking label owned by the authenticated user.
+
+    Raises an error if the label is currently referenced by any tasks or
+    templates. Returns a confirmation payload on success.
+    """
+    await delete_label(db, context.user_id, label_id, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:label:{label_id}",
+        action="delete_label",
+        details="via MCP",
+    )
+    return {"deleted": True, "label_id": label_id, "user_id": context.user_id}
+
+
+async def start_time_entry(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    text: str,
+    start_time: datetime | None = None,
+    label_id: str | None = None,
+) -> dict[str, Any]:
+    """Start a new running time entry for the authenticated user.
+
+    Side effects: creates a new TimeTrackingTask row with no stop_time. Only
+    one running task per user is allowed; the call will fail if one already
+    exists. Returns the created task resource.
+    """
+    effective_start = start_time or datetime.now(UTC)
+    payload = TaskCreate(
+        text=text,
+        label_id=label_id,
+        start_time=effective_start,
+        stop_time=None,
+        includes_break=False,
+    )
+    task = await create_task(db, context.user_id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:task:{task.id}",
+        action="start_time_entry",
+        details=f"text={text!r} via MCP",
+    )
+    return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+
+
+async def stop_time_entry(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    stop_time: datetime | None = None,
+) -> dict[str, Any]:
+    """Stop the currently running time entry for the authenticated user.
+
+    Side effects: sets stop_time on the active (open) task. Returns the
+    updated task resource, or raises NotFoundError when no running task
+    exists.
+    """
+    running = await get_running_task(db, context.user_id)
+    if running is None:
+        raise NotFoundError("no running task found")
+    effective_stop = stop_time or datetime.now(UTC)
+    payload = TaskUpdate(stop_time=effective_stop)
+    task = await update_task(db, context.user_id, running.id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:task:{task.id}",
+        action="stop_time_entry",
+        details=f"stop_time={to_iso_datetime(effective_stop)!r} via MCP",
+    )
+    return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+
+
+async def create_time_tracking_task(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    text: str,
+    start_time: datetime,
+    stop_time: datetime | None = None,
+    includes_break: bool = False,
+    label_id: str | None = None,
+) -> dict[str, Any]:
+    """Create a time-tracking task for the authenticated user.
+
+    Side effects: inserts a new TimeTrackingTask row. When stop_time is
+    omitted the task is left open (running); only one open task is allowed
+    per user. Returns the created task resource.
+    """
+    payload = TaskCreate(
+        text=text,
+        label_id=label_id,
+        start_time=start_time,
+        stop_time=stop_time,
+        includes_break=includes_break,
+    )
+    task = await create_task(db, context.user_id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:task:{task.id}",
+        action="create_time_tracking_task",
+        details=f"text={text!r} via MCP",
+    )
+    return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+
+
+async def update_time_tracking_task(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    task_id: str,
+    text: str | None = None,
+    start_time: datetime | None = None,
+    stop_time: datetime | None = None,
+    includes_break: bool | None = None,
+    label_id: str | None = None,
+    clear_stop_time: bool = False,
+    clear_label_id: bool = False,
+) -> dict[str, Any]:
+    """Update a time-tracking task owned by the authenticated user.
+
+    Omit any parameter to leave it unchanged. Set clear_stop_time=True to
+    reopen the task (make it running again) instead of passing a stop_time;
+    set clear_label_id=True to unlink its label. Both take precedence over
+    the corresponding value parameter when true.
+
+    Side effects: updates the specified TimeTrackingTask row. Authorization
+    is enforced — the task must belong to the caller. Reopening a task
+    (clear_stop_time=True) fails if another task is already running. Returns
+    the updated task resource.
+    """
+    # Verify ownership before updating
+    await get_task(db, context.user_id, task_id)
+    update_data: dict[str, Any] = {}
+    if text is not None:
+        update_data["text"] = text
+    if clear_label_id:
+        update_data["label_id"] = None
+    elif label_id is not None:
+        update_data["label_id"] = label_id
+    if start_time is not None:
+        update_data["start_time"] = start_time
+    if clear_stop_time:
+        update_data["stop_time"] = None
+    elif stop_time is not None:
+        update_data["stop_time"] = stop_time
+    if includes_break is not None:
+        update_data["includes_break"] = includes_break
+
+    payload = TaskUpdate(**update_data)
+    task = await update_task(db, context.user_id, task_id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:task:{task_id}",
+        action="update_time_tracking_task",
+        details="via MCP",
+    )
+    return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+
+
+async def delete_time_tracking_task(context: WorktimeMcpContext, db: AsyncSession, task_id: str) -> dict[str, Any]:
+    """Delete a time-tracking task owned by the authenticated user.
+
+    Side effects: soft-deletes the TimeTrackingTask row (sets deleted_at so
+    the deletion propagates through the sync layer to other devices; the row
+    is not removed). The task must belong to the caller. Returns a
+    confirmation payload.
+    """
+    await delete_task(db, context.user_id, task_id, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:task:{task_id}",
+        action="delete_time_tracking_task",
+        details="via MCP",
+    )
+    return {"deleted": True, "task_id": task_id, "user_id": context.user_id}

--- a/backend/app/mcp/work_location.py
+++ b/backend/app/mcp/work_location.py
@@ -1,0 +1,77 @@
+"""Work-location domain: per-day country summary and personal write tools."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import logger as audit
+from app.mcp.context import WorktimeMcpContext, actor_from_context
+from app.schemas import WorkLocationCreate, WorkLocationRead
+from app.services.db_service import create_or_update_work_location, delete_work_location, list_work_locations
+
+
+async def get_work_location_summary(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> dict[str, Any]:
+    start = start_date or datetime.now(UTC).date()
+    end = end_date or start
+    locations = await list_work_locations(db, user_id=context.user_id, start_date=start, end_date=end)
+    payload_locations = [
+        WorkLocationRead.model_validate(location, from_attributes=True).model_dump(mode="json")
+        for location in locations
+    ]
+    by_country = Counter(location["country_code"] for location in payload_locations)
+
+    return {
+        "user_id": context.user_id,
+        "start_date": start.isoformat(),
+        "end_date": end.isoformat(),
+        "total_days": len(payload_locations),
+        "counts_by_country": dict(by_country),
+        "locations": payload_locations,
+    }
+
+
+async def set_work_location(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    value_date: date,
+    country_code: str,
+    label: str | None = None,
+) -> dict[str, Any]:
+    """Set (create or replace) the work location for a given date.
+
+    Side effects: upserts a WorkLocation row for (user_id, date). Returns the
+    created or updated work-location resource.
+    """
+    payload = WorkLocationCreate(date=value_date, country_code=country_code, label=label)
+    location = await create_or_update_work_location(db, context.user_id, payload, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:work_location:{value_date.isoformat()}",
+        action="set_work_location",
+        details=f"country_code={country_code!r} via MCP",
+    )
+    return WorkLocationRead.model_validate(location, from_attributes=True).model_dump(mode="json")
+
+
+async def delete_work_location_tool(context: WorktimeMcpContext, db: AsyncSession, value_date: date) -> dict[str, Any]:
+    """Delete the work location entry for a given date.
+
+    Side effects: soft-deletes the WorkLocation row for (user_id, date) (sets
+    deleted_at so the deletion propagates through the sync layer to other
+    devices; the row is not removed). Returns a confirmation payload.
+    """
+    await delete_work_location(db, context.user_id, value_date, actor=actor_from_context(context))
+    audit.append(
+        target=f"user:{context.user_id}:work_location:{value_date.isoformat()}",
+        action="delete_work_location",
+        details="via MCP",
+    )
+    return {"deleted": True, "date": value_date.isoformat(), "user_id": context.user_id}

--- a/backend/app/mcp/work_location.py
+++ b/backend/app/mcp/work_location.py
@@ -56,7 +56,7 @@ async def set_work_location(
     audit.append(
         target=f"user:{context.user_id}:work_location:{value_date.isoformat()}",
         action="set_work_location",
-        details=f"country_code={country_code!r} via MCP",
+        details="via MCP",
     )
     return WorkLocationRead.model_validate(location, from_attributes=True).model_dump(mode="json")
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -12,6 +12,7 @@ delegate to — mirroring champagnefestival's ``app/mcp/`` package shape.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -25,6 +26,7 @@ from fastmcp.server.auth import AccessToken, MultiAuth
 from fastmcp.server.auth.auth import TokenVerifier
 from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
 from fastmcp.server.dependencies import get_access_token
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import settings
@@ -42,6 +44,8 @@ from app.mcp.context import (
 from app.schemas import EntryFlag, EntryKind, EntryType
 from app.services import integration_client_service
 from app.services.db_service import get_user
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "McpAuthError",
@@ -144,7 +148,10 @@ class DbIntegrationClientVerifier(TokenVerifier):
             client = await integration_client_service.get_active_integration_client_by_key(session, token)
             if client is None:
                 return None
-            await integration_client_service.record_integration_client_usage(session, client)
+            try:
+                await integration_client_service.record_integration_client_usage(session, client)
+            except SQLAlchemyError:
+                logger.warning("Failed to record integration client usage", exc_info=True)
 
         return AccessToken(
             token=token,
@@ -240,11 +247,12 @@ class WorktimeMcpBackend:
         if auth_type == "integration_client":
             client_id = claims.get("worktime_integration_client_id")
             rate_limit = claims.get("worktime_integration_client_rate_limit_per_minute")
-            if isinstance(client_id, int) and isinstance(rate_limit, int):
-                try:
-                    integration_client_service.enforce_integration_client_rate_limit(client_id, rate_limit)
-                except integration_client_service.RateLimitExceededError as exc:
-                    raise McpRateLimitError(str(exc)) from exc
+            if not isinstance(client_id, int) or not isinstance(rate_limit, int):
+                raise McpAuthError("Invalid integration client rate-limit claims")
+            try:
+                integration_client_service.enforce_integration_client_rate_limit(client_id, rate_limit)
+            except integration_client_service.RateLimitExceededError as exc:
+                raise McpRateLimitError(str(exc)) from exc
 
         user = await get_user(db, user_id)
         realm_access = claims.get("realm_access")
@@ -440,15 +448,15 @@ class WorktimeMcpBackend:
             return await time_off.create_time_off_event(
                 context,
                 db,
-                entry_kind,
-                entry_type,
-                entry_flag,
-                date,
-                start_date,
-                end_date,
-                weekday,
-                note,
-                entry_id,
+                entry_kind=entry_kind,
+                entry_type=entry_type,
+                entry_flag=entry_flag,
+                date=date,
+                start_date=start_date,
+                end_date=end_date,
+                weekday=weekday,
+                note=note,
+                entry_id=entry_id,
             )
 
     @_map_domain_errors
@@ -468,15 +476,15 @@ class WorktimeMcpBackend:
             return await time_off.update_time_off_event(
                 context,
                 db,
-                entry_id,
-                entry_kind,
-                entry_type,
-                entry_flag,
-                date,
-                start_date,
-                end_date,
-                weekday,
-                note,
+                entry_id=entry_id,
+                entry_kind=entry_kind,
+                entry_type=entry_type,
+                entry_flag=entry_flag,
+                date=date,
+                start_date=start_date,
+                end_date=end_date,
+                weekday=weekday,
+                note=note,
             )
 
     @_map_domain_errors
@@ -529,15 +537,15 @@ class WorktimeMcpBackend:
             return await gantt.update_gantt_task(
                 context,
                 db,
-                task_id,
-                name,
-                start_date,
-                end_date,
-                progress,
-                dependencies,
-                notes,
-                label_id,
-                clear_label_id,
+                task_id=task_id,
+                name=name,
+                start_date=start_date,
+                end_date=end_date,
+                progress=progress,
+                dependencies=dependencies,
+                notes=notes,
+                label_id=label_id,
+                clear_label_id=clear_label_id,
             )
 
     @_map_domain_errors
@@ -608,11 +616,12 @@ def create_mcp_server(
     session_factory: async_sessionmaker[AsyncSession] | None = None,
 ) -> FastMCP:
     """Create and configure the Worktime FastMCP server."""
-    backend = WorktimeMcpBackend(session_factory or get_session_factory())
+    factory = session_factory or get_session_factory()
+    backend = WorktimeMcpBackend(factory)
     server = FastMCP(
         "worktime",
         instructions="Worktime assistant tools — read and personal write access",
-        auth=_build_auth_provider(),
+        auth=_build_auth_provider(factory),
     )
 
     for tool_name in MCP_TOOL_CAPABILITIES:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -184,12 +184,17 @@ def _build_auth_provider(
         audience=audience,
     )
 
-    verifiers: list[TokenVerifier] = [
-        DbIntegrationClientVerifier(session_factory or get_session_factory())
-    ]
+    verifiers: list[TokenVerifier] = [DbIntegrationClientVerifier(session_factory or get_session_factory())]
 
     integration_keys = _parse_integration_key_mapping(os.environ.get("WORKTIME_MCP_INTEGRATION_KEYS", ""))
     if integration_keys:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "WORKTIME_MCP_INTEGRATION_KEYS is deprecated and will be removed in the next "
+            "release — migrate to managed integration clients (POST /api/integration-clients) "
+            "before the overlap period ends. See docs/integrations/LOCAL_MCP_SERVER.md."
+        )
         verifiers.append(IntegrationKeyVerifier(integration_keys))
 
     return MultiAuth(server=keycloak, verifiers=verifiers)
@@ -211,10 +216,7 @@ class WorktimeMcpBackend:
         subject = claims.get("sub")
         auth_type = str(claims.get("auth_type") or "oidc")
         preferred_username = claims.get("preferred_username")
-        is_service_account = (
-            isinstance(preferred_username, str)
-            and preferred_username.startswith("service-account-")
-        )
+        is_service_account = isinstance(preferred_username, str) and preferred_username.startswith("service-account-")
 
         if raw_user_id is not None:
             try:
@@ -247,9 +249,7 @@ class WorktimeMcpBackend:
         user = await get_user(db, user_id)
         realm_access = claims.get("realm_access")
         roles = realm_access.get("roles", []) if isinstance(realm_access, dict) else []
-        is_admin = bool(claims.get("worktime_is_admin")) or (
-            isinstance(roles, list) and "admin" in roles
-        )
+        is_admin = bool(claims.get("worktime_is_admin")) or (isinstance(roles, list) and "admin" in roles)
 
         return WorktimeMcpContext(
             user_id=user.id,

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -1,16 +1,24 @@
-"""FastMCP server exposing Worktime tools (read and personal write)."""
+"""FastMCP server exposing Worktime tools (read and personal write).
+
+This module is the thin assembler: imports, the ``WorktimeMcpContext``
+principal (re-exported from ``app.mcp.context``), auth-provider building
+(Keycloak + managed integration clients), and tool registration
+(``create_mcp_server``). Actual tool logic lives in the domain modules under
+``app.mcp`` (identity, schedule, time_tracking, work_location, time_off,
+gantt) as plain async functions this module's ``WorktimeMcpBackend`` methods
+delegate to — mirroring champagnefestival's ``app/mcp/`` package shape.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import functools
 import os
-from collections import Counter
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, timedelta
-from typing import Any, Concatenate
+from datetime import date, datetime
+from enum import StrEnum
+from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import AccessToken, MultiAuth
@@ -19,83 +27,44 @@ from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
 from fastmcp.server.dependencies import get_access_token
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.audit import logger as audit
 from app.config import settings
 from app.database.engine import get_session_factory
-from app.routers.auth import AuthenticatedPrincipal
-from app.schemas import (
-    EntryFlag,
-    EntryKind,
-    EntryType,
-    GanttTaskCreate,
-    GanttTaskRead,
-    GanttTaskUpdate,
-    TaskCreate,
-    TaskRead,
-    TaskUpdate,
-    TimeOffEntryCreate,
-    TimeOffEntryRead,
-    TimeOffEntryUpdate,
-    WorkLocationCreate,
-    WorkLocationRead,
+from app.mcp import gantt, identity, schedule, time_off, time_tracking, work_location
+from app.mcp.context import (
+    McpAuthError,
+    McpPermissionError,
+    McpRateLimitError,
+    WorktimeMcpContext,
 )
-from app.services.db_service import (
-    ConflictError,
-    NotFoundError,
-    ValidationError,
-    create_gantt_task,
-    create_or_update_time_off_entry,
-    create_or_update_work_location,
-    create_task,
-    delete_gantt_task,
-    delete_label,
-    delete_task,
-    delete_time_off_entry,
-    delete_work_location,
-    get_gantt_task,
-    get_running_task,
-    get_task,
-    get_time_off_entry,
-    get_user,
-    list_gantt_tasks,
-    list_labels_for_user,
-    list_tasks,
-    list_time_off_entries,
-    list_work_locations,
-    update_gantt_task,
-    update_task,
-    update_time_off_entry,
+from app.mcp.context import (
+    map_domain_errors as _map_domain_errors,
 )
-from app.services.read_models_service import (
-    build_dashboard_read_model,
-    compute_next_shifts_for_team,
-    get_schedule_type_for_user,
-)
-from app.services.sync_service import get_sync_status
+from app.schemas import EntryFlag, EntryKind, EntryType
+from app.services import integration_client_service
+from app.services.db_service import get_user
 
-
-class McpAuthError(RuntimeError):
-    """Raised when MCP authentication context is missing or invalid."""
-
-
-class McpPermissionError(RuntimeError):
-    """Raised when MCP caller is authenticated but not authorized."""
-
-
-@dataclass(frozen=True)
-class WorktimeMcpContext:
-    user_id: int
-    username: str
-    display_name: str
-    is_admin: bool
-    subject: str | None
-    claims: dict[str, Any]
-    scopes: list[str]
-    auth_type: str
+__all__ = [
+    "McpAuthError",
+    "McpPermissionError",
+    "McpRateLimitError",
+    "WorktimeMcpContext",
+    "WorktimeMcpBackend",
+    "create_mcp_server",
+]
 
 
 class IntegrationKeyVerifier(TokenVerifier):
-    """Accept static integration keys mapped to local users."""
+    """Accept legacy static integration keys mapped to local users.
+
+    Deprecated (issue #1054): superseded by ``DbIntegrationClientVerifier``,
+    which looks up revocable, rotatable, rate-limited credentials in the
+    database instead of a fixed in-memory map parsed once at startup. This
+    verifier keeps running, alongside the new one, only while
+    ``WORKTIME_MCP_INTEGRATION_KEYS`` is set, for a documented migration
+    overlap period — see docs/integrations/LOCAL_MCP_SERVER.md for the
+    end-of-support plan. New integrations should provision a managed
+    integration client instead of a static key.
+    """
 
     def __init__(self, key_mapping: dict[str, tuple[int, bool]]) -> None:
         self._key_mapping = key_mapping
@@ -128,15 +97,14 @@ def _parse_integration_key_mapping(value: str) -> dict[str, tuple[int, bool]]:
       token=user_id:user
     Multiple entries are comma-separated.
 
-    These are long-lived static bearer tokens with no built-in expiry — an
-    intentional trade-off for self-hosted, operator-controlled integrations
-    (they bypass the OIDC login flow entirely). To rotate a key: add a new
-    token=user_id entry alongside the old one, update the calling
-    integration to use it, then remove the old entry and restart the
-    process (the mapping is parsed once at startup, in _build_auth_provider).
-    There is no revocation mechanism short of removing the entry and
-    restarting, so treat these tokens like any other long-lived credential —
-    store them in a secret manager, not in version control.
+    Deprecated (issue #1054): this static, long-lived credential store has no
+    rotation or revocation short of removing the entry and restarting the
+    process. Prefer a managed integration client (``/api/integration-clients``,
+    ``app.services.integration_client_service``), which is DB-backed,
+    per-client rate-limited, and can be revoked or rotated without a
+    restart. WORKTIME_MCP_INTEGRATION_KEYS keeps working for now — see
+    docs/integrations/LOCAL_MCP_SERVER.md for the migration/overlap plan —
+    but new integrations should not adopt it.
     """
     mapping: dict[str, tuple[int, bool]] = {}
     for item in (part.strip() for part in value.split(",") if part.strip()):
@@ -155,8 +123,56 @@ def _parse_integration_key_mapping(value: str) -> dict[str, tuple[int, bool]]:
     return mapping
 
 
-def _build_auth_provider() -> KeycloakAuthProvider | MultiAuth:
-    """Build FastMCP auth provider with Keycloak plus optional integration keys."""
+class DbIntegrationClientVerifier(TokenVerifier):
+    """Verify managed, database-backed integration-client keys (issue #1054).
+
+    Looks the presented key's HMAC hash up in ``integration_clients`` instead
+    of a static in-memory map, so credentials can be created, rotated, and
+    revoked at runtime without a process restart. Inactive/revoked/unknown
+    keys verify as ``None`` (auth failure), matching ``TokenVerifier``'s
+    contract. Records best-effort ``last_used_at`` telemetry on success.
+    """
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not token.startswith(integration_client_service.KEY_PREFIX):
+            return None
+
+        async with self._session_factory() as session:
+            client = await integration_client_service.get_active_integration_client_by_key(session, token)
+            if client is None:
+                return None
+            await integration_client_service.record_integration_client_usage(session, client)
+
+        return AccessToken(
+            token=token,
+            client_id=f"integration-client-{client.id}",
+            scopes=list(client.scopes),
+            claims={
+                "worktime_user_id": client.user_id,
+                "worktime_is_admin": integration_client_service.ADMIN_SCOPE in client.scopes,
+                "sub": f"integration-client:{client.id}",
+                "auth_type": "integration_client",
+                "worktime_integration_client_id": client.id,
+                "worktime_integration_client_name": client.name,
+                "worktime_integration_client_scopes": list(client.scopes),
+                "worktime_integration_client_rate_limit_per_minute": client.rate_limit_per_minute,
+            },
+        )
+
+
+def _build_auth_provider(
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
+) -> KeycloakAuthProvider | MultiAuth:
+    """Build FastMCP auth provider: Keycloak + managed integration clients (+ legacy static keys).
+
+    The DB-backed ``DbIntegrationClientVerifier`` runs unconditionally
+    alongside Keycloak. The legacy ``IntegrationKeyVerifier`` is added on top,
+    for the documented migration/overlap period, only when
+    ``WORKTIME_MCP_INTEGRATION_KEYS`` is set — see docs/integrations/LOCAL_MCP_SERVER.md.
+    """
     base_url = os.environ.get("WORKTIME_MCP_BASE_URL", "http://localhost:8000/mcp")
     realm_url = os.environ.get("WORKTIME_MCP_KEYCLOAK_REALM_URL", settings.OIDC_ISSUER_URL)
     audience = settings.OIDC_AUDIENCE or None
@@ -168,55 +184,15 @@ def _build_auth_provider() -> KeycloakAuthProvider | MultiAuth:
         audience=audience,
     )
 
+    verifiers: list[TokenVerifier] = [
+        DbIntegrationClientVerifier(session_factory or get_session_factory())
+    ]
+
     integration_keys = _parse_integration_key_mapping(os.environ.get("WORKTIME_MCP_INTEGRATION_KEYS", ""))
-    if not integration_keys:
-        return keycloak
+    if integration_keys:
+        verifiers.append(IntegrationKeyVerifier(integration_keys))
 
-    return MultiAuth(server=keycloak, verifiers=[IntegrationKeyVerifier(integration_keys)])
-
-
-def _to_iso_date(value: date) -> str:
-    return value.isoformat()
-
-
-def _to_iso_datetime(value: datetime) -> str:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=UTC)
-    return value.astimezone(UTC).isoformat()
-
-
-# Default lookback window for get_time_tracking_summary when the caller omits
-# both start_at and end_at — bounds the response to a reasonable size instead
-# of returning the user's entire tracked-task history into the model's
-# context on every unfiltered call.
-_DEFAULT_SUMMARY_WINDOW = timedelta(days=30)
-
-# Hard cap on items returned by get_gantt_tasks. Personal Gantt boards are
-# typically small (a handful of projects), so this is a defense-in-depth
-# bound rather than an expected everyday limit.
-_MAX_GANTT_TASKS_RETURNED = 200
-
-
-def _map_domain_errors[**P, R](
-    func: Callable[Concatenate[WorktimeMcpBackend, P], Awaitable[R]],
-) -> Callable[Concatenate[WorktimeMcpBackend, P], Awaitable[R]]:
-    """Translate db_service domain exceptions into ValueError for MCP callers.
-
-    Without this, only delete_label mapped ConflictError to ValueError —
-    every other write tool let ConflictError / NotFoundError / ValidationError
-    (e.g. "only one running task is allowed per user") propagate raw, so the
-    calling model saw an opaque failure instead of the actionable message the
-    exception already carries. Apply to every write tool method.
-    """
-
-    @functools.wraps(func)
-    async def wrapper(self: WorktimeMcpBackend, *args: P.args, **kwargs: P.kwargs) -> R:
-        try:
-            return await func(self, *args, **kwargs)
-        except (ConflictError, NotFoundError, ValidationError) as exc:
-            raise ValueError(str(exc)) from exc
-
-    return wrapper
+    return MultiAuth(server=keycloak, verifiers=verifiers)
 
 
 class WorktimeMcpBackend:
@@ -259,6 +235,15 @@ class WorktimeMcpBackend:
                 else "Missing token subject"
             )
 
+        if auth_type == "integration_client":
+            client_id = claims.get("worktime_integration_client_id")
+            rate_limit = claims.get("worktime_integration_client_rate_limit_per_minute")
+            if isinstance(client_id, int) and isinstance(rate_limit, int):
+                try:
+                    integration_client_service.enforce_integration_client_rate_limit(client_id, rate_limit)
+                except integration_client_service.RateLimitExceededError as exc:
+                    raise McpRateLimitError(str(exc)) from exc
+
         user = await get_user(db, user_id)
         realm_access = claims.get("realm_access")
         roles = realm_access.get("roles", []) if isinstance(realm_access, dict) else []
@@ -286,323 +271,58 @@ class WorktimeMcpBackend:
         finally:
             await db.close()
 
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
     async def whoami(self) -> dict[str, Any]:
         async with self._tool_context() as (context, _db):
-            return {
-                "user_id": context.user_id,
-                "username": context.username,
-                "display_name": context.display_name,
-                "is_admin": context.is_admin,
-                "subject": context.subject,
-                "auth_type": context.auth_type,
-                "scopes": context.scopes,
-            }
+            return await identity.whoami(context)
+
+    # ------------------------------------------------------------------
+    # Schedule (read-only)
+    # ------------------------------------------------------------------
 
     async def get_current_status(self) -> dict[str, Any]:
-        today = datetime.now(UTC).date()
-        now_utc = datetime.now(UTC)
         async with self._tool_context() as (context, db):
-            running_task = await get_running_task(db, context.user_id)
-            running_task_payload = (
-                TaskRead.model_validate(running_task, from_attributes=True).model_dump(mode="json")
-                if running_task is not None
-                else None
-            )
-            running_seconds = None
-            if running_task is not None:
-                start = running_task.start_time
-                if start.tzinfo is None:
-                    start = start.replace(tzinfo=UTC)
-                running_seconds = max(0, int((now_utc - start.astimezone(UTC)).total_seconds()))
-
-            work_location = None
-            today_locations = await list_work_locations(db, user_id=context.user_id, start_date=today, end_date=today)
-            if today_locations:
-                work_location = WorkLocationRead.model_validate(
-                    today_locations[-1], from_attributes=True
-                ).model_dump(mode="json")
-
-            time_off_entries = await list_time_off_entries(
-                db, user_id=context.user_id, start_date=today, end_date=today
-            )
-            active_time_off = [
-                TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
-                for entry in time_off_entries
-            ]
-
-            return {
-                "date": _to_iso_date(today),
-                "user": {
-                    "user_id": context.user_id,
-                    "username": context.username,
-                    "display_name": context.display_name,
-                },
-                "running_task": running_task_payload,
-                "running_task_seconds": running_seconds,
-                "work_location": work_location,
-                "active_time_off": active_time_off,
-            }
+            return await schedule.get_current_status(context, db)
 
     async def get_next_shift(self) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
-            dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
-            as_of = dashboard.next_shifts.as_of
-            items = dashboard.next_shifts.items
-            if not items:
-                return {"as_of": _to_iso_datetime(as_of), "next_shift": None}
-            item = items[0]
-            return {
-                "as_of": _to_iso_datetime(as_of),
-                "next_shift": {
-                    "team_number": item.team_number,
-                    "date": _to_iso_date(item.date),
-                    "shift_code": item.shift_code,
-                    "shift": item.shift.model_dump(mode="json"),
-                },
-            }
+            return await schedule.get_next_shift(context, db)
 
     async def get_team_status(self) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            principal = AuthenticatedPrincipal(user_id=context.user_id, is_admin=context.is_admin)
-            dashboard = await build_dashboard_read_model(session=db, principal=principal, next_shift_limit=1)
-            return {
-                "as_of": _to_iso_datetime(dashboard.team_status.as_of),
-                "schedule_type": dashboard.work_context.schedule_type,
-                "items": [
-                    {
-                        "team_number": item.team_number,
-                        "date": _to_iso_date(item.date),
-                        "shift_day": _to_iso_date(item.shift_day),
-                        "shift_code": item.shift_code,
-                        "shift": item.shift.model_dump(mode="json"),
-                        "is_currently_working": item.is_currently_working,
-                    }
-                    for item in dashboard.team_status.items
-                ],
-            }
+            return await schedule.get_team_status(context, db)
 
-    async def get_next_shifts_for_team(
-        self,
-        team_number: int,
-        limit: int = 5,
-    ) -> dict[str, Any]:
-        if limit < 1:
-            raise ValueError("limit must be at least 1")
-        limit = min(limit, 50)
+    async def get_next_shifts_for_team(self, team_number: int, limit: int = 5) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            # Only the schedule type is needed here, so use the lightweight
-            # lookup instead of build_dashboard_read_model(), which would also
-            # fetch the user row, list time-off entries, and compute a
-            # team_status entry for every team in the schedule.
-            as_of = datetime.now(UTC)
-            schedule_type = await get_schedule_type_for_user(db, context.user_id)
-            if schedule_type is None:
-                return {
-                    "as_of": _to_iso_datetime(as_of),
-                    "schedule_type": None,
-                    "team_number": team_number,
-                    "items": [],
-                }
-            items = compute_next_shifts_for_team(
-                schedule_type,
-                team_number,
-                as_of=as_of,
-                limit=limit,
-            )
-            return {
-                "as_of": _to_iso_datetime(as_of),
-                "schedule_type": schedule_type,
-                "team_number": team_number,
-                "items": [
-                    {
-                        "team_number": item.team_number,
-                        "date": _to_iso_date(item.date),
-                        "shift_code": item.shift_code,
-                        "shift": item.shift.model_dump(mode="json"),
-                    }
-                    for item in items
-                ],
-            }
+            return await schedule.get_next_shifts_for_team(context, db, team_number, limit)
 
-    async def get_time_off_summary(
-        self,
-        start_date: date | None = None,
-        end_date: date | None = None,
-    ) -> dict[str, Any]:
-        start = start_date or datetime.now(UTC).date()
-        end = end_date or start
+    async def get_sync_status(self) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            entries = await list_time_off_entries(
-                db, user_id=context.user_id, start_date=start, end_date=end
-            )
-            payload_entries = [
-                TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
-                for entry in entries
-            ]
+            return await schedule.get_sync_status(context, db)
 
-            by_type = Counter(entry["entry_type"] for entry in payload_entries)
-            by_kind = Counter(entry["entry_kind"] for entry in payload_entries)
-
-            return {
-                "user_id": context.user_id,
-                "start_date": _to_iso_date(start),
-                "end_date": _to_iso_date(end),
-                "total_entries": len(payload_entries),
-                "counts_by_type": dict(by_type),
-                "counts_by_kind": dict(by_kind),
-                "entries": payload_entries,
-            }
-
-    async def get_work_location_summary(
-        self,
-        start_date: date | None = None,
-        end_date: date | None = None,
-    ) -> dict[str, Any]:
-        start = start_date or datetime.now(UTC).date()
-        end = end_date or start
-        async with self._tool_context() as (context, db):
-            locations = await list_work_locations(db, user_id=context.user_id, start_date=start, end_date=end)
-            payload_locations = [
-                WorkLocationRead.model_validate(location, from_attributes=True).model_dump(mode="json")
-                for location in locations
-            ]
-            by_country = Counter(location["country_code"] for location in payload_locations)
-
-            return {
-                "user_id": context.user_id,
-                "start_date": _to_iso_date(start),
-                "end_date": _to_iso_date(end),
-                "total_days": len(payload_locations),
-                "counts_by_country": dict(by_country),
-                "locations": payload_locations,
-            }
+    # ------------------------------------------------------------------
+    # Time tracking
+    # ------------------------------------------------------------------
 
     async def get_time_tracking_summary(
         self,
         start_at: datetime | None = None,
         end_at: datetime | None = None,
     ) -> dict[str, Any]:
-        """Summarize time-tracking tasks for the authenticated user.
-
-        When both start_at and end_at are omitted, defaults to the trailing
-        30 days rather than the user's entire history, so a plain call stays
-        bounded. Pass explicit dates for a wider or narrower range.
-        """
-        now_utc = datetime.now(UTC)
-        default_range_applied = start_at is None and end_at is None
-        effective_end = end_at or now_utc
-        effective_start = start_at or (effective_end - _DEFAULT_SUMMARY_WINDOW)
         async with self._tool_context() as (context, db):
-            tasks = await list_tasks(
-                db,
-                user_id=context.user_id,
-                start_date=effective_start,
-                end_date=effective_end,
-            )
-            payload_tasks = [TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json") for task in tasks]
-            total_seconds = 0
-            for task in tasks:
-                start = task.start_time
-                if start.tzinfo is None:
-                    start = start.replace(tzinfo=UTC)
-                stop = task.stop_time or now_utc
-                if stop.tzinfo is None:
-                    stop = stop.replace(tzinfo=UTC)
-                total_seconds += max(0, int((stop.astimezone(UTC) - start.astimezone(UTC)).total_seconds()))
-
-            running = await get_running_task(db, context.user_id)
-            running_payload = (
-                TaskRead.model_validate(running, from_attributes=True).model_dump(mode="json")
-                if running is not None
-                else None
-            )
-
-            return {
-                "user_id": context.user_id,
-                "start_at": _to_iso_datetime(effective_start),
-                "end_at": _to_iso_datetime(effective_end),
-                "default_range_applied": default_range_applied,
-                "task_count": len(payload_tasks),
-                "tracked_seconds": total_seconds,
-                "running_task": running_payload,
-                "tasks": payload_tasks,
-            }
+            return await time_tracking.get_time_tracking_summary(context, db, start_at, end_at)
 
     async def list_labels(self) -> dict[str, Any]:
-        """List the authenticated user's active time-tracking labels."""
         async with self._tool_context() as (context, db):
-            labels = await list_labels_for_user(db, context.user_id)
-            return {
-                "labels": [
-                    {
-                        "id": label.id,
-                        "name": label.name,
-                        "color": label.color,
-                    }
-                    for label in labels
-                ]
-            }
+            return await time_tracking.list_labels(context, db)
 
     @_map_domain_errors
     async def delete_label(self, label_id: str) -> dict[str, Any]:
-        """Delete a time-tracking label owned by the authenticated user.
-
-        Raises an error if the label is currently referenced by any tasks or
-        templates.  Returns a confirmation payload on success.
-        """
         async with self._tool_context() as (context, db):
-            await delete_label(db, context.user_id, label_id)
-            audit.append(
-                target=f"user:{context.user_id}:label:{label_id}",
-                action="delete_label",
-                details="via MCP",
-            )
-            return {"deleted": True, "label_id": label_id, "user_id": context.user_id}
-
-    async def get_gantt_tasks(
-        self,
-        active_on: date | None = None,
-        task_id: str | None = None,
-    ) -> dict[str, Any]:
-        async with self._tool_context() as (context, db):
-            if task_id:
-                task = await get_gantt_task(db, context.user_id, task_id)
-                payload_tasks = [GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")]
-            else:
-                tasks = await list_gantt_tasks(db, user_id=context.user_id)
-                payload_tasks = [
-                    GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
-                    for task in tasks
-                ]
-
-            if active_on is not None:
-                payload_tasks = [
-                    task
-                    for task in payload_tasks
-                    if task["start_date"] <= _to_iso_date(active_on) <= task["end_date"]
-                ]
-
-            total_tasks = len(payload_tasks)
-            truncated = total_tasks > _MAX_GANTT_TASKS_RETURNED
-            payload_tasks = payload_tasks[:_MAX_GANTT_TASKS_RETURNED]
-
-            return {
-                "user_id": context.user_id,
-                "active_on": _to_iso_date(active_on) if active_on is not None else None,
-                "total_tasks": total_tasks,
-                "truncated": truncated,
-                "tasks": payload_tasks,
-            }
-
-    async def get_sync_status(self) -> dict[str, Any]:
-        async with self._tool_context() as (context, db):
-            payload = await get_sync_status(db, context.user_id)
-            return payload.model_dump(mode="json")
-
-    # ------------------------------------------------------------------
-    # Personal write tools
-    # ------------------------------------------------------------------
+            return await time_tracking.delete_label_tool(context, db, label_id)
 
     @_map_domain_errors
     async def start_time_entry(
@@ -611,53 +331,13 @@ class WorktimeMcpBackend:
         start_time: datetime | None = None,
         label_id: str | None = None,
     ) -> dict[str, Any]:
-        """Start a new running time entry for the authenticated user.
-
-        Side effects: creates a new TimeTrackingTask row with no stop_time.
-        Only one running task per user is allowed; the call will fail if one
-        already exists.  Returns the created task resource.
-        """
         async with self._tool_context() as (context, db):
-            effective_start = start_time or datetime.now(UTC)
-            payload = TaskCreate(
-                text=text,
-                label_id=label_id,
-                start_time=effective_start,
-                stop_time=None,
-                includes_break=False,
-            )
-            task = await create_task(db, context.user_id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:task:{task.id}",
-                action="start_time_entry",
-                details=f"text={text!r} via MCP",
-            )
-            return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+            return await time_tracking.start_time_entry(context, db, text, start_time, label_id)
 
     @_map_domain_errors
-    async def stop_time_entry(
-        self,
-        stop_time: datetime | None = None,
-    ) -> dict[str, Any]:
-        """Stop the currently running time entry for the authenticated user.
-
-        Side effects: sets stop_time on the active (open) task.
-        Returns the updated task resource, or raises NotFoundError when no
-        running task exists.
-        """
+    async def stop_time_entry(self, stop_time: datetime | None = None) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            running = await get_running_task(db, context.user_id)
-            if running is None:
-                raise NotFoundError("no running task found")
-            effective_stop = stop_time or datetime.now(UTC)
-            payload = TaskUpdate(stop_time=effective_stop)
-            task = await update_task(db, context.user_id, running.id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:task:{task.id}",
-                action="stop_time_entry",
-                details=f"stop_time={_to_iso_datetime(effective_stop)!r} via MCP",
-            )
-            return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+            return await time_tracking.stop_time_entry(context, db, stop_time)
 
     @_map_domain_errors
     async def create_time_tracking_task(
@@ -668,27 +348,10 @@ class WorktimeMcpBackend:
         includes_break: bool = False,
         label_id: str | None = None,
     ) -> dict[str, Any]:
-        """Create a time-tracking task for the authenticated user.
-
-        Side effects: inserts a new TimeTrackingTask row.  When stop_time is
-        omitted the task is left open (running); only one open task is allowed
-        per user.  Returns the created task resource.
-        """
         async with self._tool_context() as (context, db):
-            payload = TaskCreate(
-                text=text,
-                label_id=label_id,
-                start_time=start_time,
-                stop_time=stop_time,
-                includes_break=includes_break,
+            return await time_tracking.create_time_tracking_task(
+                context, db, text, start_time, stop_time, includes_break, label_id
             )
-            task = await create_task(db, context.user_id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:task:{task.id}",
-                action="create_time_tracking_task",
-                details=f"text={text!r} via MCP",
-            )
-            return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
     @_map_domain_errors
     async def update_time_tracking_task(
@@ -702,66 +365,36 @@ class WorktimeMcpBackend:
         clear_stop_time: bool = False,
         clear_label_id: bool = False,
     ) -> dict[str, Any]:
-        """Update a time-tracking task owned by the authenticated user.
-
-        Omit any parameter to leave it unchanged. Set clear_stop_time=True to
-        reopen the task (make it running again) instead of passing a
-        stop_time; set clear_label_id=True to unlink its label. Both take
-        precedence over the corresponding value parameter when true.
-
-        Side effects: updates the specified TimeTrackingTask row.  Authorization
-        is enforced — the task must belong to the caller.  Reopening a task
-        (clear_stop_time=True) fails if another task is already running.
-        Returns the updated task resource.
-        """
         async with self._tool_context() as (context, db):
-            # Verify ownership before updating
-            await get_task(db, context.user_id, task_id)
-            update_data: dict[str, Any] = {}
-            if text is not None:
-                update_data["text"] = text
-            if clear_label_id:
-                update_data["label_id"] = None
-            elif label_id is not None:
-                update_data["label_id"] = label_id
-            if start_time is not None:
-                update_data["start_time"] = start_time
-            if clear_stop_time:
-                update_data["stop_time"] = None
-            elif stop_time is not None:
-                update_data["stop_time"] = stop_time
-            if includes_break is not None:
-                update_data["includes_break"] = includes_break
-
-            payload = TaskUpdate(**update_data)
-            task = await update_task(db, context.user_id, task_id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:task:{task_id}",
-                action="update_time_tracking_task",
-                details="via MCP",
+            return await time_tracking.update_time_tracking_task(
+                context,
+                db,
+                task_id,
+                text,
+                start_time,
+                stop_time,
+                includes_break,
+                label_id,
+                clear_stop_time,
+                clear_label_id,
             )
-            return TaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
     @_map_domain_errors
-    async def delete_time_tracking_task(
-        self,
-        task_id: str,
-    ) -> dict[str, Any]:
-        """Delete a time-tracking task owned by the authenticated user.
-
-        Side effects: soft-deletes the TimeTrackingTask row (sets deleted_at
-        so the deletion propagates through the sync layer to other devices;
-        the row is not removed).  The task must belong to the caller.
-        Returns a confirmation payload.
-        """
+    async def delete_time_tracking_task(self, task_id: str) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            await delete_task(db, context.user_id, task_id)
-            audit.append(
-                target=f"user:{context.user_id}:task:{task_id}",
-                action="delete_time_tracking_task",
-                details="via MCP",
-            )
-            return {"deleted": True, "task_id": task_id, "user_id": context.user_id}
+            return await time_tracking.delete_time_tracking_task(context, db, task_id)
+
+    # ------------------------------------------------------------------
+    # Work location
+    # ------------------------------------------------------------------
+
+    async def get_work_location_summary(
+        self,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await work_location.get_work_location_summary(context, db, start_date, end_date)
 
     @_map_domain_errors
     async def set_work_location(
@@ -770,41 +403,25 @@ class WorktimeMcpBackend:
         country_code: str,
         label: str | None = None,
     ) -> dict[str, Any]:
-        """Set (create or replace) the work location for a given date.
-
-        Side effects: upserts a WorkLocation row for (user_id, date).  Returns
-        the created or updated work-location resource.
-        """
         async with self._tool_context() as (context, db):
-            payload = WorkLocationCreate(date=value_date, country_code=country_code, label=label)
-            location = await create_or_update_work_location(db, context.user_id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:work_location:{value_date.isoformat()}",
-                action="set_work_location",
-                details=f"country_code={country_code!r} via MCP",
-            )
-            return WorkLocationRead.model_validate(location, from_attributes=True).model_dump(mode="json")
+            return await work_location.set_work_location(context, db, value_date, country_code, label)
 
     @_map_domain_errors
-    async def delete_work_location(
-        self,
-        value_date: date,
-    ) -> dict[str, Any]:
-        """Delete the work location entry for a given date.
-
-        Side effects: soft-deletes the WorkLocation row for (user_id, date)
-        (sets deleted_at so the deletion propagates through the sync layer to
-        other devices; the row is not removed).  Returns a confirmation
-        payload.
-        """
+    async def delete_work_location(self, value_date: date) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            await delete_work_location(db, context.user_id, value_date)
-            audit.append(
-                target=f"user:{context.user_id}:work_location:{value_date.isoformat()}",
-                action="delete_work_location",
-                details="via MCP",
-            )
-            return {"deleted": True, "date": value_date.isoformat(), "user_id": context.user_id}
+            return await work_location.delete_work_location_tool(context, db, value_date)
+
+    # ------------------------------------------------------------------
+    # Time off
+    # ------------------------------------------------------------------
+
+    async def get_time_off_summary(
+        self,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await time_off.get_time_off_summary(context, db, start_date, end_date)
 
     @_map_domain_errors
     async def create_time_off_event(
@@ -819,32 +436,20 @@ class WorktimeMcpBackend:
         note: str | None = None,
         entry_id: str | None = None,
     ) -> dict[str, Any]:
-        """Create (or upsert) a personal time-off event.
-
-        Side effects: inserts or updates a TimeOffEntry row.  If entry_id is
-        provided the call is idempotent — re-sending the same payload restores
-        a previously deleted entry.  Returns the created or updated entry.
-        """
         async with self._tool_context() as (context, db):
-            payload = TimeOffEntryCreate(
-                entry_id=entry_id,
-                entry_kind=entry_kind,
-                entry_type=entry_type,
-                entry_flag=entry_flag,
-                date=date,
-                start_date=start_date,
-                end_date=end_date,
-                weekday=weekday,
-                note=note,
+            return await time_off.create_time_off_event(
+                context,
+                db,
+                entry_kind,
+                entry_type,
+                entry_flag,
+                date,
+                start_date,
+                end_date,
+                weekday,
+                note,
+                entry_id,
             )
-            entry, created = await create_or_update_time_off_entry(db, context.user_id, payload)
-            action = "create_time_off_event" if created else "upsert_time_off_event"
-            audit.append(
-                target=f"user:{context.user_id}:time_off:{entry.entry_id}",
-                action=action,
-                details=f"entry_type={entry_type!r} entry_kind={entry_kind!r} via MCP",
-            )
-            return TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
 
     @_map_domain_errors
     async def update_time_off_event(
@@ -859,62 +464,37 @@ class WorktimeMcpBackend:
         weekday: int | None = None,
         note: str | None = None,
     ) -> dict[str, Any]:
-        """Update an existing personal time-off event.
-
-        Side effects: updates the specified TimeOffEntry row.  The entry must
-        belong to the authenticated user.  Returns the updated entry.
-        """
         async with self._tool_context() as (context, db):
-            # Verify ownership before updating
-            await get_time_off_entry(db, context.user_id, entry_id)
-            update_data: dict[str, Any] = {}
-            if entry_kind is not None:
-                update_data["entry_kind"] = entry_kind
-            if entry_type is not None:
-                update_data["entry_type"] = entry_type
-            if entry_flag is not None:
-                update_data["entry_flag"] = entry_flag
-            if date is not None:
-                update_data["date"] = date
-            if start_date is not None:
-                update_data["start_date"] = start_date
-            if end_date is not None:
-                update_data["end_date"] = end_date
-            if weekday is not None:
-                update_data["weekday"] = weekday
-            if note is not None:
-                update_data["note"] = None if note == "" else note
-
-            payload = TimeOffEntryUpdate(**update_data)
-            entry = await update_time_off_entry(db, context.user_id, entry_id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:time_off:{entry_id}",
-                action="update_time_off_event",
-                details="via MCP",
+            return await time_off.update_time_off_event(
+                context,
+                db,
+                entry_id,
+                entry_kind,
+                entry_type,
+                entry_flag,
+                date,
+                start_date,
+                end_date,
+                weekday,
+                note,
             )
-            return TimeOffEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json")
 
     @_map_domain_errors
-    async def delete_time_off_event(
-        self,
-        entry_id: str,
-    ) -> dict[str, Any]:
-        """Soft-delete a personal time-off event.
-
-        Side effects: sets deleted_at on the TimeOffEntry row so the deletion
-        propagates through the sync layer.  The entry must belong to the
-        authenticated user.  Returns a confirmation payload.
-        """
+    async def delete_time_off_event(self, entry_id: str) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            # Verify ownership before deleting
-            await get_time_off_entry(db, context.user_id, entry_id)
-            await delete_time_off_entry(db, context.user_id, entry_id)
-            audit.append(
-                target=f"user:{context.user_id}:time_off:{entry_id}",
-                action="delete_time_off_event",
-                details="via MCP",
-            )
-            return {"deleted": True, "entry_id": entry_id, "user_id": context.user_id}
+            return await time_off.delete_time_off_event(context, db, entry_id)
+
+    # ------------------------------------------------------------------
+    # Gantt
+    # ------------------------------------------------------------------
+
+    async def get_gantt_tasks(
+        self,
+        active_on: date | None = None,
+        task_id: str | None = None,
+    ) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await gantt.get_gantt_tasks(context, db, active_on, task_id)
 
     @_map_domain_errors
     async def create_gantt_task(
@@ -927,27 +507,10 @@ class WorktimeMcpBackend:
         notes: str | None = None,
         label_id: str | None = None,
     ) -> dict[str, Any]:
-        """Create a personal Gantt task.
-
-        Side effects: inserts a new GanttTask row.  Returns the created task.
-        """
         async with self._tool_context() as (context, db):
-            payload = GanttTaskCreate(
-                name=name,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                dependencies=dependencies,
-                notes=notes,
-                label_id=label_id,
+            return await gantt.create_gantt_task(
+                context, db, name, start_date, end_date, progress, dependencies, notes, label_id
             )
-            task = await create_gantt_task(db, context.user_id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:gantt:{task.id}",
-                action="create_gantt_task",
-                details=f"name={name!r} via MCP",
-            )
-            return GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
     @_map_domain_errors
     async def update_gantt_task(
@@ -962,67 +525,83 @@ class WorktimeMcpBackend:
         label_id: str | None = None,
         clear_label_id: bool = False,
     ) -> dict[str, Any]:
-        """Update a personal Gantt task.
-
-        Omit any parameter to leave it unchanged. Set clear_label_id=True to
-        unlink its label; this takes precedence over label_id when true.
-
-        Side effects: updates the specified GanttTask row.  The task must
-        belong to the authenticated user.  Returns the updated task.
-        """
         async with self._tool_context() as (context, db):
-            # Verify ownership before updating
-            await get_gantt_task(db, context.user_id, task_id)
-            update_data: dict[str, Any] = {}
-            if name is not None:
-                update_data["name"] = name
-            if clear_label_id:
-                update_data["label_id"] = None
-            elif label_id is not None:
-                update_data["label_id"] = label_id
-            if start_date is not None:
-                update_data["start_date"] = start_date
-            if end_date is not None:
-                update_data["end_date"] = end_date
-            if progress is not None:
-                update_data["progress"] = progress
-            if dependencies is not None:
-                update_data["dependencies"] = None if dependencies == "" else dependencies
-            if notes is not None:
-                update_data["notes"] = None if notes == "" else notes
-
-            payload = GanttTaskUpdate(**update_data)
-            task = await update_gantt_task(db, context.user_id, task_id, payload)
-            audit.append(
-                target=f"user:{context.user_id}:gantt:{task_id}",
-                action="update_gantt_task",
-                details="via MCP",
+            return await gantt.update_gantt_task(
+                context,
+                db,
+                task_id,
+                name,
+                start_date,
+                end_date,
+                progress,
+                dependencies,
+                notes,
+                label_id,
+                clear_label_id,
             )
-            return GanttTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
 
     @_map_domain_errors
-    async def delete_gantt_task(
-        self,
-        task_id: str,
-    ) -> dict[str, Any]:
-        """Delete a personal Gantt task.
-
-        Side effects: soft-deletes the GanttTask row (sets deleted_at so the
-        deletion propagates through the sync layer to other devices; the row
-        is not removed) and unlinks any time-tracking tasks that referenced
-        it.  The task must belong to the authenticated user.  Returns a
-        confirmation payload.
-        """
+    async def delete_gantt_task(self, task_id: str) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
-            # Verify ownership before deleting
-            await get_gantt_task(db, context.user_id, task_id)
-            await delete_gantt_task(db, context.user_id, task_id)
-            audit.append(
-                target=f"user:{context.user_id}:gantt:{task_id}",
-                action="delete_gantt_task",
-                details="via MCP",
-            )
-            return {"deleted": True, "task_id": task_id, "user_id": context.user_id}
+            return await gantt.delete_gantt_task(context, db, task_id)
+
+
+# ---------------------------------------------------------------------------
+# Capability manifest (issue #1054)
+# ---------------------------------------------------------------------------
+
+
+class ToolEffect(StrEnum):
+    """Side-effect classification for capability discovery."""
+
+    READ = "read"
+    PERSONAL_WRITE = "personal_write"
+    ADMIN_WRITE = "admin_write"
+
+
+@dataclass(frozen=True)
+class ToolCapability:
+    effect: ToolEffect
+    required_tier: str  # "owner" (caller's own data) or "admin"
+
+
+# Single source of truth for both tool registration (create_mcp_server, below)
+# and capability discovery (GET /api/mcp/capabilities, app.main). Because
+# create_mcp_server() registers exactly the tools named here — no more, no
+# less — the capability manifest structurally cannot drift from what's
+# actually registered.
+#
+# Every current tool operates on the caller's own data (context.user_id);
+# none accept a target user_id, so there is no admin_write tool today. That's
+# a deliberate current-state fact, not a design ceiling — a future team-wide
+# write tool would be tagged ADMIN_WRITE / "admin" here.
+MCP_TOOL_CAPABILITIES: dict[str, ToolCapability] = {
+    "whoami": ToolCapability(ToolEffect.READ, "owner"),
+    "get_current_status": ToolCapability(ToolEffect.READ, "owner"),
+    "get_next_shift": ToolCapability(ToolEffect.READ, "owner"),
+    "get_team_status": ToolCapability(ToolEffect.READ, "owner"),
+    "get_next_shifts_for_team": ToolCapability(ToolEffect.READ, "owner"),
+    "get_time_off_summary": ToolCapability(ToolEffect.READ, "owner"),
+    "get_work_location_summary": ToolCapability(ToolEffect.READ, "owner"),
+    "get_time_tracking_summary": ToolCapability(ToolEffect.READ, "owner"),
+    "list_labels": ToolCapability(ToolEffect.READ, "owner"),
+    "delete_label": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "get_gantt_tasks": ToolCapability(ToolEffect.READ, "owner"),
+    "get_sync_status": ToolCapability(ToolEffect.READ, "owner"),
+    "start_time_entry": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "stop_time_entry": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "create_time_tracking_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "update_time_tracking_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "delete_time_tracking_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "set_work_location": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "delete_work_location": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "create_time_off_event": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "update_time_off_event": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "delete_time_off_event": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "create_gantt_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "update_gantt_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "delete_gantt_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+}
 
 
 def create_mcp_server(
@@ -1036,31 +615,9 @@ def create_mcp_server(
         auth=_build_auth_provider(),
     )
 
-    server.tool(name="whoami")(backend.whoami)
-    server.tool(name="get_current_status")(backend.get_current_status)
-    server.tool(name="get_next_shift")(backend.get_next_shift)
-    server.tool(name="get_team_status")(backend.get_team_status)
-    server.tool(name="get_next_shifts_for_team")(backend.get_next_shifts_for_team)
-    server.tool(name="get_time_off_summary")(backend.get_time_off_summary)
-    server.tool(name="get_work_location_summary")(backend.get_work_location_summary)
-    server.tool(name="get_time_tracking_summary")(backend.get_time_tracking_summary)
-    server.tool(name="list_labels")(backend.list_labels)
-    server.tool(name="delete_label")(backend.delete_label)
-    server.tool(name="get_gantt_tasks")(backend.get_gantt_tasks)
-    server.tool(name="get_sync_status")(backend.get_sync_status)
-    server.tool(name="start_time_entry")(backend.start_time_entry)
-    server.tool(name="stop_time_entry")(backend.stop_time_entry)
-    server.tool(name="create_time_tracking_task")(backend.create_time_tracking_task)
-    server.tool(name="update_time_tracking_task")(backend.update_time_tracking_task)
-    server.tool(name="delete_time_tracking_task")(backend.delete_time_tracking_task)
-    server.tool(name="set_work_location")(backend.set_work_location)
-    server.tool(name="delete_work_location")(backend.delete_work_location)
-    server.tool(name="create_time_off_event")(backend.create_time_off_event)
-    server.tool(name="update_time_off_event")(backend.update_time_off_event)
-    server.tool(name="delete_time_off_event")(backend.delete_time_off_event)
-    server.tool(name="create_gantt_task")(backend.create_gantt_task)
-    server.tool(name="update_gantt_task")(backend.update_gantt_task)
-    server.tool(name="delete_gantt_task")(backend.delete_gantt_task)
+    for tool_name in MCP_TOOL_CAPABILITIES:
+        server.tool(name=tool_name)(getattr(backend, tool_name))
+
     return server
 
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -149,9 +149,12 @@ class DbIntegrationClientVerifier(TokenVerifier):
             if client is None:
                 return None
             try:
+                await integration_client_service.enforce_integration_client_rate_limit(session, client.id)
                 await integration_client_service.record_integration_client_usage(session, client)
+            except integration_client_service.RateLimitExceededError:
+                return None
             except SQLAlchemyError:
-                logger.warning("Failed to record integration client usage", exc_info=True)
+                logger.warning("Failed to record integration client usage or rate limit", exc_info=True)
 
         return AccessToken(
             token=token,
@@ -243,16 +246,6 @@ class WorktimeMcpBackend:
                 if is_service_account
                 else "Missing token subject"
             )
-
-        if auth_type == "integration_client":
-            client_id = claims.get("worktime_integration_client_id")
-            rate_limit = claims.get("worktime_integration_client_rate_limit_per_minute")
-            if not isinstance(client_id, int) or not isinstance(rate_limit, int):
-                raise McpAuthError("Invalid integration client rate-limit claims")
-            try:
-                integration_client_service.enforce_integration_client_rate_limit(client_id, rate_limit)
-            except integration_client_service.RateLimitExceededError as exc:
-                raise McpRateLimitError(str(exc)) from exc
 
         user = await get_user(db, user_id)
         realm_access = claims.get("realm_access")

--- a/backend/app/routers/audit.py
+++ b/backend/app/routers/audit.py
@@ -1,0 +1,51 @@
+"""REST API endpoint for reading the transactional mutation audit trail (issue #1054)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit.db import DEFAULT_AUDIT_LIMIT, MAX_AUDIT_LIMIT, AuditAuthorizationError, list_audit_entries
+from app.database.engine import get_session
+from app.routers.auth import AuthenticatedPrincipal, get_authenticated_principal
+from app.schemas import AuditEntryListResponse, AuditEntryRead
+
+router = APIRouter(prefix="/audit", tags=["Audit"])
+
+
+@router.get("", response_model=AuditEntryListResponse)
+async def list_audit_entries_endpoint(
+    user_id: int | None = Query(
+        default=None,
+        ge=1,
+        description="Restrict to one user's audit trail. Admin scope required to read another user's; "
+        "omit entirely (admin only) for the team-wide trail.",
+    ),
+    limit: int = Query(default=DEFAULT_AUDIT_LIMIT, ge=1, le=MAX_AUDIT_LIMIT),
+    before_id: int | None = Query(default=None, ge=1, description="Exclusive keyset cursor for pagination."),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
+    session: AsyncSession = Depends(get_session),
+) -> AuditEntryListResponse:
+    """Bounded, stably-ordered read of the durable mutation audit trail.
+
+    A non-admin caller may only read their own trail (``user_id`` is forced
+    to their own id regardless of what's requested). An admin caller may
+    read any single user's trail or, by omitting ``user_id``, the full
+    team-wide trail.
+    """
+    try:
+        entries = await list_audit_entries(
+            session,
+            requesting_user_id=principal.user_id,
+            is_admin=principal.is_admin,
+            target_user_id=user_id,
+            limit=limit,
+            before_id=before_id,
+        )
+    except AuditAuthorizationError as error:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(error)) from error
+
+    return AuditEntryListResponse(
+        items=[AuditEntryRead.model_validate(entry, from_attributes=True) for entry in entries],
+        total=len(entries),
+    )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -217,11 +217,15 @@ async def get_bearer_principal(
 def get_authenticated_principal(
     principal: AuthenticatedPrincipal = Depends(get_bearer_principal),
 ) -> AuthenticatedPrincipal:
-    """Allow interactive users and delegated personal-access-token callers."""
-    if principal.auth_type not in (AuthType.KEYCLOAK_USER, AuthType.DELEGATED):
+    """Require an interactive user for the general REST API.
+
+    Delegated personal-access tokens stay confined to endpoints that opt into
+    ``require_scoped_principal`` (currently the dedicated Pebble surface).
+    """
+    if principal.auth_type != AuthType.KEYCLOAK_USER:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="This endpoint requires a user session or personal access token",
+            detail="This endpoint requires an interactive Keycloak user session",
         )
     return principal
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -217,11 +217,11 @@ async def get_bearer_principal(
 def get_authenticated_principal(
     principal: AuthenticatedPrincipal = Depends(get_bearer_principal),
 ) -> AuthenticatedPrincipal:
-    """Require a Keycloak user session for the regular application API."""
-    if principal.auth_type != AuthType.KEYCLOAK_USER:
+    """Allow interactive users and delegated personal-access-token callers."""
+    if principal.auth_type not in (AuthType.KEYCLOAK_USER, AuthType.DELEGATED):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="This endpoint requires an interactive Keycloak user session",
+            detail="This endpoint requires a user session or personal access token",
         )
     return principal
 
@@ -315,7 +315,7 @@ def audit_actor_for(principal: AuthenticatedPrincipal) -> AuditActor:
 
 
 def require_oidc_principal(
-    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
+    principal: AuthenticatedPrincipal = Depends(get_bearer_principal),
 ) -> AuthenticatedPrincipal:
     """Require an interactive OIDC session, rejecting personal access tokens.
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.audit.db import AuditActor
 from app.config import settings
 from app.config.oidc_config import OIDCTokenError, decode_token, get_or_create_local_user
 from app.database.engine import get_session
@@ -296,6 +297,22 @@ def require_user_or_admin_match(user_id: int, principal: AuthenticatedPrincipal)
         return
     if principal.user_id != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+
+def audit_actor_for(principal: AuthenticatedPrincipal) -> AuditActor:
+    """Build the transactional-audit actor identity for an authenticated REST caller.
+
+    ``label`` intentionally stays at the id-only ``user:<id>`` form rather
+    than resolving a username, so building an actor never costs an extra DB
+    query on every mutation's hot path — the audit trail can still be joined
+    to ``users`` by ``actor_user_id`` when a human-readable name is needed.
+    """
+    return AuditActor(
+        user_id=principal.user_id,
+        label=f"user:{principal.user_id}",
+        auth_source=principal.auth_type.value,
+        subject=principal.subject,
+    )
 
 
 def require_oidc_principal(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -216,11 +216,14 @@ async def get_bearer_principal(
 def get_authenticated_principal(
     principal: AuthenticatedPrincipal = Depends(get_bearer_principal),
 ) -> AuthenticatedPrincipal:
-    """Require a Keycloak user session for the regular application API."""
-    if principal.auth_type != AuthType.KEYCLOAK_USER:
+    """Require an authenticated principal (OIDC or PAT)."""
+    if principal.auth_type not in (AuthType.KEYCLOAK_USER, AuthType.DELEGATED):
+        # PATs (DELEGATED) and OIDC sessions (KEYCLOAK_USER) are both accepted here;
+        # account-deletion and token-management endpoints use require_oidc_principal
+        # to remain OIDC-only.
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="This endpoint requires an interactive Keycloak user session",
+            detail="This endpoint requires an authenticated principal",
         )
     return principal
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -217,14 +217,11 @@ async def get_bearer_principal(
 def get_authenticated_principal(
     principal: AuthenticatedPrincipal = Depends(get_bearer_principal),
 ) -> AuthenticatedPrincipal:
-    """Require an authenticated principal (OIDC or PAT)."""
-    if principal.auth_type not in (AuthType.KEYCLOAK_USER, AuthType.DELEGATED):
-        # PATs (DELEGATED) and OIDC sessions (KEYCLOAK_USER) are both accepted here;
-        # account-deletion and token-management endpoints use require_oidc_principal
-        # to remain OIDC-only.
+    """Require a Keycloak user session for the regular application API."""
+    if principal.auth_type != AuthType.KEYCLOAK_USER:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="This endpoint requires an authenticated principal",
+            detail="This endpoint requires an interactive Keycloak user session",
         )
     return principal
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -193,6 +193,7 @@ async def get_bearer_principal(
     if settings.SENTRY_DSN:
         try:
             import sentry_sdk
+
             sentry_sdk.set_user({"id": str(local_user.id)})
         except ImportError:
             pass
@@ -248,9 +249,7 @@ def require_scoped_principal(
     ) -> AuthenticatedPrincipal:
         if principal.auth_type == AuthType.KEYCLOAK_USER:
             return principal
-        if principal.auth_type == AuthType.DELEGATED and has_required_scopes(
-            principal.scopes, required
-        ):
+        if principal.auth_type == AuthType.DELEGATED and has_required_scopes(principal.scopes, required):
             return principal
         missing = ", ".join(sorted(required))
         raise HTTPException(

--- a/backend/app/routers/db_gantt.py
+++ b/backend/app/routers/db_gantt.py
@@ -7,7 +7,13 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import get_authenticated_user_id, resolve_scoped_user_id
+from app.routers.auth import (
+    AuthenticatedPrincipal,
+    audit_actor_for,
+    get_authenticated_principal,
+    get_authenticated_user_id,
+    resolve_scoped_user_id,
+)
 from app.schemas import (
     GanttTaskCreate,
     GanttTaskListResponse,
@@ -44,12 +50,12 @@ def _handle_error(error: Exception) -> None:
 async def create_gantt_task_endpoint(
     payload: GanttTaskCreate,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> GanttTaskRead:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        task = await create_gantt_task(session, user_id, payload)
+        task = await create_gantt_task(session, user_id, payload, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
         raise
@@ -104,12 +110,12 @@ async def update_gantt_task_endpoint(
     task_id: str,
     payload: GanttTaskUpdate,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> GanttTaskRead:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        task = await update_gantt_task(session, user_id, task_id, payload)
+        task = await update_gantt_task(session, user_id, task_id, payload, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
         raise
@@ -121,12 +127,12 @@ async def update_gantt_task_endpoint(
 async def delete_gantt_task_endpoint(
     task_id: str,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        await delete_gantt_task(session, user_id, task_id)
+        await delete_gantt_task(session, user_id, task_id, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
 

--- a/backend/app/routers/db_time_off.py
+++ b/backend/app/routers/db_time_off.py
@@ -9,7 +9,12 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import get_authenticated_user_id
+from app.routers.auth import (
+    AuthenticatedPrincipal,
+    audit_actor_for,
+    get_authenticated_principal,
+    get_authenticated_user_id,
+)
 from app.schemas import (
     TimeOffEntryCreate,
     TimeOffEntryListResponse,
@@ -34,10 +39,12 @@ router = APIRouter(prefix="/time-off", tags=["Time Off"])
 @router.post("", response_model=TimeOffEntryRead, status_code=status.HTTP_201_CREATED)
 async def create_or_update_time_off_endpoint(
     payload: TimeOffEntryCreate,
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    entry, created = await create_or_update_time_off_entry(session, authenticated_user_id, payload)
+    entry, created = await create_or_update_time_off_entry(
+        session, principal.user_id, payload, actor=audit_actor_for(principal)
+    )
     response = TimeOffEntryRead.model_validate(entry, from_attributes=True)
     return JSONResponse(
         status_code=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
@@ -99,13 +106,15 @@ async def get_time_off_entry_endpoint(
 async def update_time_off_entry_endpoint(
     entry_id: str,
     payload: TimeOffEntryUpdate,
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
     timings: dict[str, float] = {}
     try:
         with time_operation("query", timings):
-            entry = await update_time_off_entry(session, authenticated_user_id, entry_id, payload)
+            entry = await update_time_off_entry(
+                session, principal.user_id, entry_id, payload, actor=audit_actor_for(principal)
+            )
     except NotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
     except ValidationError as error:
@@ -121,11 +130,11 @@ async def update_time_off_entry_endpoint(
 @router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_time_off_entry_endpoint(
     entry_id: str,
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     try:
-        await delete_time_off_entry(session, authenticated_user_id, entry_id)
+        await delete_time_off_entry(session, principal.user_id, entry_id, actor=audit_actor_for(principal))
     except NotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 

--- a/backend/app/routers/db_time_tracking.py
+++ b/backend/app/routers/db_time_tracking.py
@@ -9,7 +9,13 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import get_authenticated_user_id, resolve_scoped_user_id
+from app.routers.auth import (
+    AuthenticatedPrincipal,
+    audit_actor_for,
+    get_authenticated_principal,
+    get_authenticated_user_id,
+    resolve_scoped_user_id,
+)
 from app.schemas import (
     LabelCreate,
     LabelListResponse,
@@ -65,12 +71,12 @@ def _handle_error(error: Exception) -> None:
 async def create_label_endpoint(
     payload: LabelCreate,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> LabelRead:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        label = await create_label(session, user_id, payload)
+        label = await create_label(session, user_id, payload, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
         raise
@@ -125,12 +131,12 @@ async def update_label_endpoint(
     label_id: str,
     payload: LabelUpdate,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> LabelRead:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        label = await update_label(session, user_id, label_id, payload)
+        label = await update_label(session, user_id, label_id, payload, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
         raise
@@ -142,12 +148,12 @@ async def update_label_endpoint(
 async def delete_label_endpoint(
     label_id: str,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        await delete_label(session, user_id, label_id)
+        await delete_label(session, user_id, label_id, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
 
@@ -158,13 +164,13 @@ async def delete_label_endpoint(
 async def create_task_endpoint(
     payload: TaskCreate,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> TaskRead:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
 
     try:
-        task = await create_task(session, user_id, payload)
+        task = await create_task(session, user_id, payload, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
         raise
@@ -253,12 +259,12 @@ async def update_task_endpoint(
     task_id: str,
     payload: TaskUpdate,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> TaskRead:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        task = await update_task(session, user_id, task_id, payload)
+        task = await update_task(session, user_id, task_id, payload, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
         raise
@@ -270,12 +276,12 @@ async def update_task_endpoint(
 async def delete_task_endpoint(
     task_id: str,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        await delete_task(session, user_id, task_id)
+        await delete_task(session, user_id, task_id, actor=audit_actor_for(principal))
     except (NotFoundError, ConflictError, ValidationError) as error:
         _handle_error(error)
 

--- a/backend/app/routers/db_work_locations.py
+++ b/backend/app/routers/db_work_locations.py
@@ -9,7 +9,13 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import get_authenticated_user_id, resolve_scoped_user_id
+from app.routers.auth import (
+    AuthenticatedPrincipal,
+    audit_actor_for,
+    get_authenticated_principal,
+    get_authenticated_user_id,
+    resolve_scoped_user_id,
+)
 from app.schemas import (
     WorkLocationCreate,
     WorkLocationListResponse,
@@ -33,13 +39,13 @@ router = APIRouter(prefix="/work-locations", tags=["Work Locations"])
 async def create_or_update_work_location_endpoint(
     payload: WorkLocationCreate,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> WorkLocationRead:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
 
     try:
-        location = await create_or_update_work_location(session, user_id, payload)
+        location = await create_or_update_work_location(session, user_id, payload, actor=audit_actor_for(principal))
     except NotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
     except ValidationError as error:
@@ -107,12 +113,12 @@ async def get_work_location_endpoint(
 async def delete_work_location_endpoint(
     value_date: date,
     user_id: int | None = Query(default=None, ge=1),
-    authenticated_user_id: int = Depends(get_authenticated_user_id),
+    principal: AuthenticatedPrincipal = Depends(get_authenticated_principal),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    user_id = resolve_scoped_user_id(user_id, authenticated_user_id)
+    user_id = resolve_scoped_user_id(user_id, principal.user_id)
     try:
-        await delete_work_location(session, user_id, value_date)
+        await delete_work_location(session, user_id, value_date, actor=audit_actor_for(principal))
     except NotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 

--- a/backend/app/routers/holidays.py
+++ b/backend/app/routers/holidays.py
@@ -172,9 +172,7 @@ async def _get_or_fetch_holidays(
         return db_entry.data
 
     # --- Upstream fetch ---
-    logger.debug(
-        "Cache miss for %s holidays: %s — fetching from upstream", holiday_type, cache_key
-    )
+    logger.debug("Cache miss for %s holidays: %s — fetching from upstream", holiday_type, cache_key)
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
@@ -192,9 +190,7 @@ async def _get_or_fetch_holidays(
             )
             # Return stale DB data if available rather than nothing
             if db_entry is not None:
-                logger.info(
-                    "Serving stale DB entry for %s holidays: %s", holiday_type, cache_key
-                )
+                logger.info("Serving stale DB entry for %s holidays: %s", holiday_type, cache_key)
                 return db_entry.data
             return None
 
@@ -203,9 +199,7 @@ async def _get_or_fetch_holidays(
             data = response_filter(data)
 
     except Exception:
-        logger.exception(
-            "Failed to fetch %s holidays from upstream (%s)", holiday_type, cache_key
-        )
+        logger.exception("Failed to fetch %s holidays from upstream (%s)", holiday_type, cache_key)
         # Serve stale DB data on network error
         if db_entry is not None:
             logger.info(

--- a/backend/app/routers/integration_clients.py
+++ b/backend/app/routers/integration_clients.py
@@ -1,0 +1,132 @@
+"""REST API endpoints for managed integration clients (issue #1054).
+
+Replaces the long-lived static-token map (``WORKTIME_MCP_INTEGRATION_KEYS``)
+with revocable, rotatable, rate-limited, database-backed credentials —
+mirroring the personal-access-token pattern in ``app.routers.access_tokens``
+but for automation/integration callers (currently: the MCP server).
+
+Every endpoint here requires ``require_oidc_principal``: an interactive
+Keycloak user session, never a personal access token or an integration
+client itself. This is a structural, not just policy, guarantee against
+privilege escalation — an integration credential is verified exclusively by
+FastMCP's ``TokenVerifier`` machinery (``app.mcp_server``) and never reaches
+``app.routers.auth`` at all, so it has no path to call these
+management endpoints and mint or escalate another credential.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.engine import get_session
+from app.routers.auth import AuthenticatedPrincipal, require_oidc_principal
+from app.schemas import (
+    IntegrationClientCreate,
+    IntegrationClientCreated,
+    IntegrationClientListResponse,
+    IntegrationClientRead,
+    IntegrationClientScope,
+)
+from app.services.db_service import NotFoundError
+from app.services.integration_client_service import (
+    ADMIN_SCOPE,
+    create_integration_client,
+    list_integration_clients_for_user,
+    revoke_integration_client,
+    rotate_integration_client,
+)
+
+router = APIRouter(prefix="/integration-clients", tags=["Integration Clients"])
+
+
+def _require_no_self_escalation(principal: AuthenticatedPrincipal, scopes: list[str]) -> None:
+    """Refuse to grant admin-tier scope unless the caller is already an admin.
+
+    Preserves Worktime's existing is_admin semantics as a deliberate grant:
+    a non-admin user cannot provision a credential more privileged than
+    themselves, and (structurally, see module docstring) no credential can
+    ever reach this endpoint to grant itself a broader one.
+    """
+    if ADMIN_SCOPE in scopes and not principal.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"admin privileges are required to grant the {ADMIN_SCOPE!r} scope",
+        )
+
+
+@router.post("", response_model=IntegrationClientCreated, status_code=status.HTTP_201_CREATED)
+async def create_integration_client_endpoint(
+    payload: IntegrationClientCreate,
+    response: Response,
+    principal: AuthenticatedPrincipal = Depends(require_oidc_principal),
+    session: AsyncSession = Depends(get_session),
+) -> IntegrationClientCreated:
+    response.headers["Cache-Control"] = "no-store"
+    _require_no_self_escalation(principal, list(payload.scopes))
+    client, raw_key = await create_integration_client(
+        session,
+        principal.user_id,
+        name=payload.name,
+        scopes=list(payload.scopes),
+        rate_limit_per_minute=payload.rate_limit_per_minute,
+    )
+    return IntegrationClientCreated(
+        id=client.id,
+        name=client.name,
+        key=raw_key,
+        scopes=cast(list[IntegrationClientScope], client.scopes),
+        rate_limit_per_minute=client.rate_limit_per_minute,
+        created_at=client.created_at,
+    )
+
+
+@router.get("", response_model=IntegrationClientListResponse)
+async def list_integration_clients_endpoint(
+    principal: AuthenticatedPrincipal = Depends(require_oidc_principal),
+    session: AsyncSession = Depends(get_session),
+) -> IntegrationClientListResponse:
+    clients = await list_integration_clients_for_user(session, principal.user_id)
+    return IntegrationClientListResponse(
+        items=[IntegrationClientRead.model_validate(client, from_attributes=True) for client in clients],
+        total=len(clients),
+    )
+
+
+@router.post("/{client_id}/rotate", response_model=IntegrationClientCreated)
+async def rotate_integration_client_endpoint(
+    client_id: int,
+    response: Response,
+    principal: AuthenticatedPrincipal = Depends(require_oidc_principal),
+    session: AsyncSession = Depends(get_session),
+) -> IntegrationClientCreated:
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        client, raw_key = await rotate_integration_client(session, principal.user_id, client_id)
+    except NotFoundError as error:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+
+    return IntegrationClientCreated(
+        id=client.id,
+        name=client.name,
+        key=raw_key,
+        scopes=cast(list[IntegrationClientScope], client.scopes),
+        rate_limit_per_minute=client.rate_limit_per_minute,
+        created_at=client.created_at,
+    )
+
+
+@router.delete("/{client_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_integration_client_endpoint(
+    client_id: int,
+    principal: AuthenticatedPrincipal = Depends(require_oidc_principal),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    try:
+        await revoke_integration_client(session, principal.user_id, client_id)
+    except NotFoundError as error:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/integration_clients.py
+++ b/backend/app/routers/integration_clients.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.engine import get_session
-from app.routers.auth import AuthenticatedPrincipal, require_oidc_principal
+from app.routers.auth import AuthenticatedPrincipal, audit_actor_for, require_oidc_principal
 from app.schemas import (
     IntegrationClientCreate,
     IntegrationClientCreated,
@@ -72,6 +72,7 @@ async def create_integration_client_endpoint(
         name=payload.name,
         scopes=list(payload.scopes),
         rate_limit_per_minute=payload.rate_limit_per_minute,
+        actor=audit_actor_for(principal),
     )
     return IntegrationClientCreated(
         id=client.id,
@@ -104,7 +105,9 @@ async def rotate_integration_client_endpoint(
 ) -> IntegrationClientCreated:
     response.headers["Cache-Control"] = "no-store"
     try:
-        client, raw_key = await rotate_integration_client(session, principal.user_id, client_id)
+        client, raw_key = await rotate_integration_client(
+            session, principal.user_id, client_id, actor=audit_actor_for(principal)
+        )
     except NotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 
@@ -125,7 +128,7 @@ async def revoke_integration_client_endpoint(
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     try:
-        await revoke_integration_client(session, principal.user_id, client_id)
+        await revoke_integration_client(session, principal.user_id, client_id, actor=audit_actor_for(principal))
     except NotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -271,6 +271,79 @@ class AccessTokenListResponse(ListResponse[AccessTokenRead]):
     pass
 
 
+IntegrationClientScope = Literal["worktime:mcp", "worktime:admin"]
+
+
+class IntegrationClientCreate(BaseModel):
+    """Payload for provisioning a new managed integration client (issue #1054).
+
+    ``worktime:admin`` is a deliberate, explicit grant — never implied by
+    ``worktime:mcp`` — matching Worktime's existing ``is_admin`` semantics.
+    Only an admin caller may request it; see
+    app.routers.integration_clients.create_integration_client_endpoint.
+    """
+
+    name: str = Field(min_length=1, max_length=120)
+    scopes: list[IntegrationClientScope] = ["worktime:mcp"]
+    rate_limit_per_minute: int = Field(default=120, ge=1, le=6000)
+
+    @field_validator("scopes")
+    @classmethod
+    def deduplicate_scopes(cls, value: list[IntegrationClientScope]) -> list[IntegrationClientScope]:
+        if not value:
+            raise ValueError("at least one scope is required")
+        return list(dict.fromkeys(value))
+
+
+class IntegrationClientCreated(BaseModel):
+    """Response returned once, at creation/rotation time, including the raw key value."""
+
+    id: int
+    name: str
+    key: str
+    scopes: list[IntegrationClientScope]
+    rate_limit_per_minute: int
+    created_at: dt_datetime
+
+
+class IntegrationClientRead(BaseModel):
+    """A previously issued integration client, without its raw key."""
+
+    id: int
+    name: str
+    key_preview: str
+    scopes: list[IntegrationClientScope]
+    rate_limit_per_minute: int
+    is_active: bool
+    created_at: dt_datetime
+    last_used_at: dt_datetime | None
+    revoked_at: dt_datetime | None
+
+
+class IntegrationClientListResponse(ListResponse[IntegrationClientRead]):
+    pass
+
+
+class AuditEntryRead(BaseModel):
+    """A single transactional audit-trail entry (issue #1054)."""
+
+    id: int
+    actor_user_id: int | None
+    actor_label: str
+    subject: str | None
+    auth_source: str
+    action: str
+    resource_type: str
+    resource_id: str
+    request_id: str | None
+    details: dict[str, Any]
+    created_at: dt_datetime
+
+
+class AuditEntryListResponse(ListResponse[AuditEntryRead]):
+    pass
+
+
 class TaskListResponse(ListResponse[TaskRead]):
     pass
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -15,7 +15,6 @@ from app.utils.datetime import ensure_utc
 ISO_ALPHA2_CODES = frozenset(country.alpha_2 for country in pycountry.countries)
 
 
-
 class ListResponse[T](BaseModel):
     """Generic paged list response."""
 
@@ -224,9 +223,7 @@ class WorkLocationUpdate(BaseModel):
     country_code: str | None = None
     label: str | None = None
 
-    _validate_country_code = field_validator("country_code")(
-        WorkLocationCreate.validate_country_code
-    )
+    _validate_country_code = field_validator("country_code")(WorkLocationCreate.validate_country_code)
 
 
 AccessTokenScope = Literal["pebble:read", "pebble:write"]
@@ -284,7 +281,7 @@ class IntegrationClientCreate(BaseModel):
     """
 
     name: str = Field(min_length=1, max_length=120)
-    scopes: list[IntegrationClientScope] = ["worktime:mcp"]
+    scopes: list[IntegrationClientScope] = Field(default_factory=lambda: ["worktime:mcp"])
     rate_limit_per_minute: int = Field(default=120, ge=1, le=6000)
 
     @field_validator("scopes")
@@ -404,11 +401,7 @@ class GanttTaskUpdate(BaseModel):
 
     @model_validator(mode="after")
     def validate_date_range(self) -> GanttTaskUpdate:
-        if (
-            self.start_date is not None
-            and self.end_date is not None
-            and self.end_date < self.start_date
-        ):
+        if self.start_date is not None and self.end_date is not None and self.end_date < self.start_date:
             raise ValueError("end_date cannot be earlier than start_date")
         return self
 
@@ -891,15 +884,9 @@ class SyncPushRequest(BaseModel):
     labels: list[LabelSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
     tasks: list[TaskSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
     templates: list[TemplateSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
-    work_locations: list[WorkLocationSyncItem] = Field(
-        default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS
-    )
-    time_off_entries: list[TimeOffEntrySyncItem] = Field(
-        default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS
-    )
-    gantt_tasks: list[GanttTaskSyncItem] = Field(
-        default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS
-    )
+    work_locations: list[WorkLocationSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
+    time_off_entries: list[TimeOffEntrySyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
+    gantt_tasks: list[GanttTaskSyncItem] = Field(default_factory=list, max_length=MAX_SYNC_PUSH_ITEMS)
 
 
 class SyncPushResponse(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date as dt_date
 from datetime import datetime as dt_datetime
 from datetime import time as dt_time
-from typing import cast, Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 import pycountry
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -281,7 +281,9 @@ class IntegrationClientCreate(BaseModel):
     """
 
     name: str = Field(min_length=1, max_length=120)
-    scopes: list[IntegrationClientScope] = Field(default_factory=lambda: cast(list[IntegrationClientScope], ["worktime:mcp"]))
+    scopes: list[IntegrationClientScope] = Field(
+        default_factory=lambda: cast(list[IntegrationClientScope], ["worktime:mcp"])
+    )
     rate_limit_per_minute: int = Field(default=120, ge=1, le=6000)
 
     @field_validator("scopes")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date as dt_date
 from datetime import datetime as dt_datetime
 from datetime import time as dt_time
-from typing import Annotated, Any, Literal
+from typing import cast, Annotated, Any, Literal
 
 import pycountry
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -281,7 +281,7 @@ class IntegrationClientCreate(BaseModel):
     """
 
     name: str = Field(min_length=1, max_length=120)
-    scopes: list[IntegrationClientScope] = Field(default_factory=lambda: ["worktime:mcp"])  # ty: ignore[invalid-assignment]
+    scopes: list[IntegrationClientScope] = Field(default_factory=lambda: cast(list[IntegrationClientScope], ["worktime:mcp"]))
     rate_limit_per_minute: int = Field(default=120, ge=1, le=6000)
 
     @field_validator("scopes")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -281,7 +281,7 @@ class IntegrationClientCreate(BaseModel):
     """
 
     name: str = Field(min_length=1, max_length=120)
-    scopes: list[IntegrationClientScope] = Field(default_factory=lambda: ["worktime:mcp"])
+    scopes: list[IntegrationClientScope] = Field(default_factory=lambda: ["worktime:mcp"])  # ty: ignore[invalid-assignment]
     rate_limit_per_minute: int = Field(default=120, ge=1, le=6000)
 
     @field_validator("scopes")

--- a/backend/app/services/access_token_service.py
+++ b/backend/app/services/access_token_service.py
@@ -49,9 +49,7 @@ async def rotate_pebble_access_token(
     """Replace the auto-paired Pebble token and return its raw value once."""
     # Serialize rotations for one user. Without this lock, overlapping
     # transactions can both delete before either inserts its replacement.
-    await session.execute(
-        select(User.id).where(User.id == user_id).with_for_update()
-    )
+    await session.execute(select(User.id).where(User.id == user_id).with_for_update())
     await session.execute(
         delete(AccessToken).where(
             AccessToken.user_id == user_id,
@@ -70,9 +68,7 @@ async def rotate_pebble_access_token(
 
 async def list_access_tokens_for_user(session: AsyncSession, user_id: int) -> list[AccessToken]:
     result = await session.execute(
-        select(AccessToken)
-        .where(AccessToken.user_id == user_id)
-        .order_by(AccessToken.created_at.desc())
+        select(AccessToken).where(AccessToken.user_id == user_id).order_by(AccessToken.created_at.desc())
     )
     return list(result.scalars().all())
 
@@ -87,9 +83,7 @@ async def revoke_access_token(session: AsyncSession, user_id: int, token_id: str
 
 async def authenticate_access_token(session: AsyncSession, raw_token: str) -> AccessToken | None:
     """Look up a token by its hash and record last-used time. Returns None if unknown/revoked."""
-    result = await session.execute(
-        select(AccessToken).where(AccessToken.token_hash == _hash_token(raw_token))
-    )
+    result = await session.execute(select(AccessToken).where(AccessToken.token_hash == _hash_token(raw_token)))
     token = result.scalar_one_or_none()
     if token is None:
         return None

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import Any, overload
 from uuid import uuid4
 
 from sqlalchemy import delete, or_, select, update
@@ -713,6 +713,22 @@ async def get_gantt_task(session: AsyncSession, user_id: int, task_id: str) -> G
     if task is None or task.user_id != user_id or task.deleted_at is not None:
         raise NotFoundError("gantt task not found")
     return task
+
+
+@overload
+async def list_gantt_tasks(session: AsyncSession, *, user_id: int) -> list[GanttTask]: ...
+
+
+@overload
+async def list_gantt_tasks(
+    session: AsyncSession, *, user_id: int, active_on: date | None, limit: int
+) -> tuple[list[GanttTask], int]: ...
+
+
+@overload
+async def list_gantt_tasks(
+    session: AsyncSession, *, user_id: int, active_on: date | None = None, limit: int | None = None
+) -> list[GanttTask] | tuple[list[GanttTask], int]: ...
 
 
 async def list_gantt_tasks(

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.audit.db import AuditActor, write_audit_entry
 from app.database.models import (
     Base,
     GanttTask,
@@ -57,6 +58,36 @@ class ValidationError(Exception):
 
 
 MAX_USER_LIST_LIMIT = 1000
+
+
+async def _audit(
+    session: AsyncSession,
+    actor: AuditActor | None,
+    *,
+    action: str,
+    resource_type: str,
+    resource_id: str,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Stage a transactional audit entry when *actor* is provided.
+
+    ``actor`` defaults to ``None`` everywhere in this module so existing
+    callers (including the large body of unit tests that call these
+    functions directly) keep working unchanged. Production write paths —
+    REST routers and MCP tools — always pass an actor; see
+    app.audit.db.write_audit_entry for the transactional contract (staged
+    here, committed by the caller as part of the same transaction).
+    """
+    if actor is None:
+        return
+    await write_audit_entry(
+        session,
+        actor=actor,
+        action=action,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        details=details,
+    )
 
 
 def _get_non_nullable_model_fields(model: type[Base]) -> set[str]:
@@ -227,7 +258,9 @@ async def _ensure_label_for_user(session: AsyncSession, user_id: int, label_id: 
     return label
 
 
-async def create_label(session: AsyncSession, user_id: int, payload: LabelCreate) -> Label:
+async def create_label(
+    session: AsyncSession, user_id: int, payload: LabelCreate, *, actor: AuditActor | None = None
+) -> Label:
     await _ensure_user_exists(session, user_id)
     result = await session.execute(
         select(Label).where(
@@ -241,6 +274,8 @@ async def create_label(session: AsyncSession, user_id: int, payload: LabelCreate
 
     label = Label(user_id=user_id, **payload.model_dump())
     session.add(label)
+    await session.flush()
+    await _audit(session, actor, action="create_label", resource_type="label", resource_id=label.id)
     await session.commit()
     await session.refresh(label)
     await notify_sync_changed(user_id)
@@ -265,7 +300,12 @@ async def list_labels_for_user(session: AsyncSession, user_id: int) -> list[Labe
 
 
 async def update_label(
-    session: AsyncSession, user_id: int, label_id: str, payload: LabelUpdate
+    session: AsyncSession,
+    user_id: int,
+    label_id: str,
+    payload: LabelUpdate,
+    *,
+    actor: AuditActor | None = None,
 ) -> Label:
     label = await _ensure_label_for_user(session, user_id, label_id)
 
@@ -288,13 +328,16 @@ async def update_label(
     # silently overwrite this edit (conflict detection compares client_updated_at).
     label.client_updated_at = datetime.now(UTC)
     session.add(label)
+    await _audit(session, actor, action="update_label", resource_type="label", resource_id=label_id)
     await session.commit()
     await session.refresh(label)
     await notify_sync_changed(user_id)
     return label
 
 
-async def delete_label(session: AsyncSession, user_id: int, label_id: str) -> None:
+async def delete_label(
+    session: AsyncSession, user_id: int, label_id: str, *, actor: AuditActor | None = None
+) -> None:
     label = await _ensure_label_for_user(session, user_id, label_id)
 
     task_count = await session.scalar(
@@ -319,6 +362,7 @@ async def delete_label(session: AsyncSession, user_id: int, label_id: str) -> No
     label.deleted_at = now
     label.client_updated_at = now
     session.add(label)
+    await _audit(session, actor, action="delete_label", resource_type="label", resource_id=label_id)
     await session.commit()
     await notify_sync_changed(user_id)
 
@@ -343,7 +387,9 @@ async def _validate_task_gantt_reference(
         raise NotFoundError("gantt task not found")
 
 
-async def create_task(session: AsyncSession, user_id: int, payload: TaskCreate) -> TimeTrackingTask:
+async def create_task(
+    session: AsyncSession, user_id: int, payload: TaskCreate, *, actor: AuditActor | None = None
+) -> TimeTrackingTask:
     await _ensure_user_exists(session, user_id)
     await _validate_task_label_reference(session, user_id, payload.label_id)
     await _validate_task_gantt_reference(session, user_id, payload.gantt_task_id)
@@ -355,6 +401,8 @@ async def create_task(session: AsyncSession, user_id: int, payload: TaskCreate) 
 
     task = TimeTrackingTask(user_id=user_id, **payload.model_dump())
     session.add(task)
+    await session.flush()
+    await _audit(session, actor, action="create_task", resource_type="time_tracking_task", resource_id=task.id)
     await session.commit()
     await session.refresh(task)
     await notify_sync_changed(user_id)
@@ -407,7 +455,12 @@ async def get_running_task(session: AsyncSession, user_id: int) -> TimeTrackingT
 
 
 async def update_task(
-    session: AsyncSession, user_id: int, task_id: str, payload: TaskUpdate
+    session: AsyncSession,
+    user_id: int,
+    task_id: str,
+    payload: TaskUpdate,
+    *,
+    actor: AuditActor | None = None,
 ) -> TimeTrackingTask:
     task = await get_task(session, user_id, task_id)
 
@@ -436,18 +489,22 @@ async def update_task(
     # silently overwrite this edit (conflict detection compares client_updated_at).
     task.client_updated_at = datetime.now(UTC)
     session.add(task)
+    await _audit(session, actor, action="update_task", resource_type="time_tracking_task", resource_id=task_id)
     await session.commit()
     await session.refresh(task)
     await notify_sync_changed(user_id)
     return task
 
 
-async def delete_task(session: AsyncSession, user_id: int, task_id: str) -> None:
+async def delete_task(
+    session: AsyncSession, user_id: int, task_id: str, *, actor: AuditActor | None = None
+) -> None:
     task = await get_task(session, user_id, task_id)
     now = datetime.now(UTC)
     task.deleted_at = now
     task.client_updated_at = now
     session.add(task)
+    await _audit(session, actor, action="delete_task", resource_type="time_tracking_task", resource_id=task_id)
     await session.commit()
     await notify_sync_changed(user_id)
 
@@ -527,7 +584,7 @@ async def delete_template(session: AsyncSession, user_id: int, template_id: str)
 
 
 async def create_or_update_work_location(
-    session: AsyncSession, user_id: int, payload: WorkLocationCreate
+    session: AsyncSession, user_id: int, payload: WorkLocationCreate, *, actor: AuditActor | None = None
 ) -> WorkLocation:
     await _ensure_user_exists(session, user_id)
 
@@ -552,6 +609,13 @@ async def create_or_update_work_location(
         location.client_updated_at = datetime.now(UTC)
 
     session.add(location)
+    await _audit(
+        session,
+        actor,
+        action="create_or_update_work_location",
+        resource_type="work_location",
+        resource_id=payload.date.isoformat(),
+    )
     await session.commit()
     await session.refresh(location)
     await notify_sync_changed(user_id)
@@ -595,7 +659,12 @@ async def list_work_locations(
 
 
 async def update_work_location(
-    session: AsyncSession, user_id: int, value_date: date, payload: WorkLocationUpdate
+    session: AsyncSession,
+    user_id: int,
+    value_date: date,
+    payload: WorkLocationUpdate,
+    *,
+    actor: AuditActor | None = None,
 ) -> WorkLocation:
     location = await get_work_location(session, user_id, value_date)
     data = payload.model_dump(exclude_unset=True)
@@ -608,18 +677,34 @@ async def update_work_location(
     # silently overwrite this edit (conflict detection compares client_updated_at).
     location.client_updated_at = datetime.now(UTC)
     session.add(location)
+    await _audit(
+        session,
+        actor,
+        action="update_work_location",
+        resource_type="work_location",
+        resource_id=value_date.isoformat(),
+    )
     await session.commit()
     await session.refresh(location)
     await notify_sync_changed(user_id)
     return location
 
 
-async def delete_work_location(session: AsyncSession, user_id: int, value_date: date) -> None:
+async def delete_work_location(
+    session: AsyncSession, user_id: int, value_date: date, *, actor: AuditActor | None = None
+) -> None:
     location = await get_work_location(session, user_id, value_date)
     now = datetime.now(UTC)
     location.deleted_at = now
     location.client_updated_at = now
     session.add(location)
+    await _audit(
+        session,
+        actor,
+        action="delete_work_location",
+        resource_type="work_location",
+        resource_id=value_date.isoformat(),
+    )
     await session.commit()
     await notify_sync_changed(user_id)
 
@@ -628,7 +713,7 @@ async def delete_work_location(session: AsyncSession, user_id: int, value_date: 
 
 
 async def create_gantt_task(
-    session: AsyncSession, user_id: int, payload: GanttTaskCreate
+    session: AsyncSession, user_id: int, payload: GanttTaskCreate, *, actor: AuditActor | None = None
 ) -> GanttTask:
     await _ensure_user_exists(session, user_id)
     await _validate_task_label_reference(session, user_id, payload.label_id)
@@ -637,6 +722,8 @@ async def create_gantt_task(
 
     task = GanttTask(user_id=user_id, **payload.model_dump())
     session.add(task)
+    await session.flush()
+    await _audit(session, actor, action="create_gantt_task", resource_type="gantt_task", resource_id=task.id)
     await session.commit()
     await session.refresh(task)
     await notify_sync_changed(user_id)
@@ -660,7 +747,12 @@ async def list_gantt_tasks(session: AsyncSession, *, user_id: int) -> list[Gantt
 
 
 async def update_gantt_task(
-    session: AsyncSession, user_id: int, task_id: str, payload: GanttTaskUpdate
+    session: AsyncSession,
+    user_id: int,
+    task_id: str,
+    payload: GanttTaskUpdate,
+    *,
+    actor: AuditActor | None = None,
 ) -> GanttTask:
     task = await get_gantt_task(session, user_id, task_id)
 
@@ -678,13 +770,16 @@ async def update_gantt_task(
     # silently overwrite this edit (conflict detection compares client_updated_at).
     task.client_updated_at = datetime.now(UTC)
     session.add(task)
+    await _audit(session, actor, action="update_gantt_task", resource_type="gantt_task", resource_id=task_id)
     await session.commit()
     await session.refresh(task)
     await notify_sync_changed(user_id)
     return task
 
 
-async def delete_gantt_task(session: AsyncSession, user_id: int, task_id: str) -> None:
+async def delete_gantt_task(
+    session: AsyncSession, user_id: int, task_id: str, *, actor: AuditActor | None = None
+) -> None:
     task = await get_gantt_task(session, user_id, task_id)
     now = datetime.now(UTC)
     task.deleted_at = now
@@ -695,6 +790,7 @@ async def delete_gantt_task(session: AsyncSession, user_id: int, task_id: str) -
         .where(TimeTrackingTask.gantt_task_id == task.id)
         .values(gantt_task_id=None, client_updated_at=now, updated_at=now)
     )
+    await _audit(session, actor, action="delete_gantt_task", resource_type="gantt_task", resource_id=task_id)
     await session.commit()
     await notify_sync_changed(user_id)
 
@@ -824,7 +920,11 @@ async def list_time_off_entries(
 
 
 async def create_or_update_time_off_entry(
-    session: AsyncSession, user_id: int, payload: TimeOffEntryCreate
+    session: AsyncSession,
+    user_id: int,
+    payload: TimeOffEntryCreate,
+    *,
+    actor: AuditActor | None = None,
 ) -> tuple[TimeOffEntry, bool]:
     """Upsert a time-off entry for (user_id, entry_id).
 
@@ -884,6 +984,8 @@ async def create_or_update_time_off_entry(
         created = False
 
     session.add(entry)
+    audit_action = "create_time_off_entry" if created else "update_time_off_entry"
+    await _audit(session, actor, action=audit_action, resource_type="time_off_entry", resource_id=entry_id)
     try:
         await session.commit()
     except IntegrityError:
@@ -914,15 +1016,27 @@ async def create_or_update_time_off_entry(
         entry.updated_at = now
         entry.client_updated_at = now
         session.add(entry)
-        await session.commit()
         created = False
+        # The rollback above discarded the audit entry staged before the
+        # failed commit — re-stage it against the now-clean session before
+        # retrying, using the corrected action (a concurrent insert winning
+        # means this attempt is always an update, never a create).
+        await _audit(
+            session, actor, action="update_time_off_entry", resource_type="time_off_entry", resource_id=entry_id
+        )
+        await session.commit()
     await session.refresh(entry)
     await notify_sync_changed(user_id)
     return entry, created
 
 
 async def update_time_off_entry(
-    session: AsyncSession, user_id: int, entry_id: str, payload: TimeOffEntryUpdate
+    session: AsyncSession,
+    user_id: int,
+    entry_id: str,
+    payload: TimeOffEntryUpdate,
+    *,
+    actor: AuditActor | None = None,
 ) -> TimeOffEntry:
     entry = await get_time_off_entry(session, user_id, entry_id)
     data = payload.model_dump(exclude_unset=True)
@@ -952,13 +1066,18 @@ async def update_time_off_entry(
     # silently overwrite this edit (conflict detection compares client_updated_at).
     entry.client_updated_at = now
     session.add(entry)
+    await _audit(
+        session, actor, action="update_time_off_entry", resource_type="time_off_entry", resource_id=entry_id
+    )
     await session.commit()
     await session.refresh(entry)
     await notify_sync_changed(user_id)
     return entry
 
 
-async def delete_time_off_entry(session: AsyncSession, user_id: int, entry_id: str) -> None:
+async def delete_time_off_entry(
+    session: AsyncSession, user_id: int, entry_id: str, *, actor: AuditActor | None = None
+) -> None:
     """Soft-delete a time-off entry so deletions sync to other devices."""
     entry = await get_time_off_entry(session, user_id, entry_id)
     now = datetime.now(UTC)
@@ -966,5 +1085,8 @@ async def delete_time_off_entry(session: AsyncSession, user_id: int, entry_id: s
     entry.updated_at = now
     entry.client_updated_at = now
     session.add(entry)
+    await _audit(
+        session, actor, action="delete_time_off_entry", resource_type="time_off_entry", resource_id=entry_id
+    )
     await session.commit()
     await notify_sync_changed(user_id)

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -91,18 +91,13 @@ async def _audit(
 
 
 def _get_non_nullable_model_fields(model: type[Base]) -> set[str]:
-    return {
-        column.name
-        for column in model.__table__.columns
-        if not column.nullable and not column.primary_key
-    }
+    return {column.name for column in model.__table__.columns if not column.nullable and not column.primary_key}
 
 
 # User operations
 
-async def create_user(
-    session: AsyncSession, payload: UserCreate, *, oidc_subject: str | None = None
-) -> User:
+
+async def create_user(session: AsyncSession, payload: UserCreate, *, oidc_subject: str | None = None) -> User:
     existing = await get_user_by_username(session, payload.username)
     if existing is not None:
         raise ConflictError("username already exists")
@@ -146,9 +141,7 @@ async def get_user_export_data(
     async def _list_rows(model: type[Base], *order_by: Any) -> list[Any]:
         typed_model: Any = model
         result = await session.execute(
-            select(model)
-            .where(typed_model.user_id == user_id, typed_model.deleted_at.is_(None))
-            .order_by(*order_by)
+            select(model).where(typed_model.user_id == user_id, typed_model.deleted_at.is_(None)).order_by(*order_by)
         )
         return list(result.scalars().all())
 
@@ -196,9 +189,7 @@ async def list_users(
 
     total_result = await session.execute(select(sql_func.count()).select_from(User))
     total = int(total_result.scalar_one())
-    users_result = await session.execute(
-        select(User).order_by(User.id).offset(offset).limit(limit)
-    )
+    users_result = await session.execute(select(User).order_by(User.id).offset(offset).limit(limit))
     users = list(users_result.scalars().all())
     return users, total
 
@@ -246,6 +237,7 @@ async def delete_user_uncommitted(session: AsyncSession, user_id: int) -> None:
 
 
 # Label operations
+
 
 async def _ensure_user_exists(session: AsyncSession, user_id: int) -> User:
     return await get_user(session, user_id)
@@ -335,9 +327,7 @@ async def update_label(
     return label
 
 
-async def delete_label(
-    session: AsyncSession, user_id: int, label_id: str, *, actor: AuditActor | None = None
-) -> None:
+async def delete_label(session: AsyncSession, user_id: int, label_id: str, *, actor: AuditActor | None = None) -> None:
     label = await _ensure_label_for_user(session, user_id, label_id)
 
     task_count = await session.scalar(
@@ -369,17 +359,14 @@ async def delete_label(
 
 # Task operations
 
-async def _validate_task_label_reference(
-    session: AsyncSession, user_id: int, label_id: str | None
-) -> None:
+
+async def _validate_task_label_reference(session: AsyncSession, user_id: int, label_id: str | None) -> None:
     if label_id is None:
         return
     await _ensure_label_for_user(session, user_id, label_id)
 
 
-async def _validate_task_gantt_reference(
-    session: AsyncSession, user_id: int, gantt_task_id: str | None
-) -> None:
+async def _validate_task_gantt_reference(session: AsyncSession, user_id: int, gantt_task_id: str | None) -> None:
     if gantt_task_id is None:
         return
     gantt_task = await session.get(GanttTask, gantt_task_id)
@@ -496,9 +483,7 @@ async def update_task(
     return task
 
 
-async def delete_task(
-    session: AsyncSession, user_id: int, task_id: str, *, actor: AuditActor | None = None
-) -> None:
+async def delete_task(session: AsyncSession, user_id: int, task_id: str, *, actor: AuditActor | None = None) -> None:
     task = await get_task(session, user_id, task_id)
     now = datetime.now(UTC)
     task.deleted_at = now
@@ -511,9 +496,8 @@ async def delete_task(
 
 # Template operations
 
-async def create_template(
-    session: AsyncSession, user_id: int, payload: TemplateCreate
-) -> TimeTrackingTemplate:
+
+async def create_template(session: AsyncSession, user_id: int, payload: TemplateCreate) -> TimeTrackingTemplate:
     await _ensure_user_exists(session, user_id)
     await _validate_task_label_reference(session, user_id, payload.label_id)
 
@@ -525,9 +509,7 @@ async def create_template(
     return template
 
 
-async def get_template(
-    session: AsyncSession, user_id: int, template_id: str
-) -> TimeTrackingTemplate:
+async def get_template(session: AsyncSession, user_id: int, template_id: str) -> TimeTrackingTemplate:
     """Get a template scoped to a specific user to prevent cross-user access."""
     template = await session.get(TimeTrackingTemplate, template_id)
     if template is None or template.user_id != user_id or template.deleted_at is not None:
@@ -535,9 +517,7 @@ async def get_template(
     return template
 
 
-async def list_templates_for_user(
-    session: AsyncSession, user_id: int
-) -> list[TimeTrackingTemplate]:
+async def list_templates_for_user(session: AsyncSession, user_id: int) -> list[TimeTrackingTemplate]:
     result = await session.execute(
         select(TimeTrackingTemplate)
         .where(
@@ -622,9 +602,7 @@ async def create_or_update_work_location(
     return location
 
 
-async def get_work_location(
-    session: AsyncSession, user_id: int, value_date: date
-) -> WorkLocation:
+async def get_work_location(session: AsyncSession, user_id: int, value_date: date) -> WorkLocation:
     result = await session.execute(
         select(WorkLocation).where(
             WorkLocation.user_id == user_id,
@@ -737,13 +715,32 @@ async def get_gantt_task(session: AsyncSession, user_id: int, task_id: str) -> G
     return task
 
 
-async def list_gantt_tasks(session: AsyncSession, *, user_id: int) -> list[GanttTask]:
-    result = await session.execute(
-        select(GanttTask)
-        .where(GanttTask.user_id == user_id, GanttTask.deleted_at.is_(None))
-        .order_by(GanttTask.start_date)
-    )
-    return list(result.scalars().all())
+async def list_gantt_tasks(
+    session: AsyncSession, *, user_id: int, active_on: date | None = None, limit: int | None = None
+) -> tuple[list[GanttTask], int] | list[GanttTask]:
+    # Deterministic ordering and bounded retrieval; active_on filtering in DB
+    base_where = [GanttTask.user_id == user_id, GanttTask.deleted_at.is_(None)]
+    if active_on is not None:
+        base_where.extend([GanttTask.start_date <= active_on, GanttTask.end_date >= active_on])
+    # Count query for truncated flag
+    if active_on is not None or limit is not None:
+        from sqlalchemy import func
+
+        count_stmt = select(func.count()).select_from(GanttTask).where(*base_where)
+        count_result = await session.execute(count_stmt)
+        total = int(count_result.scalar() or 0)
+        stmt = select(GanttTask).where(*base_where).order_by(GanttTask.start_date, GanttTask.id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        result = await session.execute(stmt)
+        tasks = list(result.scalars().all())
+        # If caller expects new tuple signature (active_on/limit supplied), return tuple
+        if active_on is not None or limit is not None:
+            return tasks, total
+        return tasks
+    result = await session.execute(select(GanttTask).where(*base_where).order_by(GanttTask.start_date, GanttTask.id))
+    tasks = list(result.scalars().all())
+    return tasks
 
 
 async def update_gantt_task(
@@ -1066,9 +1063,7 @@ async def update_time_off_entry(
     # silently overwrite this edit (conflict detection compares client_updated_at).
     entry.client_updated_at = now
     session.add(entry)
-    await _audit(
-        session, actor, action="update_time_off_entry", resource_type="time_off_entry", resource_id=entry_id
-    )
+    await _audit(session, actor, action="update_time_off_entry", resource_type="time_off_entry", resource_id=entry_id)
     await session.commit()
     await session.refresh(entry)
     await notify_sync_changed(user_id)
@@ -1085,8 +1080,6 @@ async def delete_time_off_entry(
     entry.updated_at = now
     entry.client_updated_at = now
     session.add(entry)
-    await _audit(
-        session, actor, action="delete_time_off_entry", resource_type="time_off_entry", resource_id=entry_id
-    )
+    await _audit(session, actor, action="delete_time_off_entry", resource_type="time_off_entry", resource_id=entry_id)
     await session.commit()
     await notify_sync_changed(user_id)

--- a/backend/app/services/integration_client_service.py
+++ b/backend/app/services/integration_client_service.py
@@ -1,0 +1,215 @@
+"""Service layer for managed, database-backed integration clients (issue #1054).
+
+Replaces the long-lived static-token map previously parsed once from
+``WORKTIME_MCP_INTEGRATION_KEYS`` at process startup. Each ``IntegrationClient``
+row is a revocable, rotatable, rate-limited credential bound to one Worktime
+user, mirroring the ``AccessToken`` pattern already used for personal access
+tokens (``app.services.access_token_service``) but scoped for
+automation/integration callers such as the MCP server.
+"""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+import time
+from collections import deque
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database.models import IntegrationClient, User
+from app.services.db_service import NotFoundError
+
+KEY_PREFIX = "wtic_"
+DEFAULT_SCOPES = ("worktime:mcp",)
+ADMIN_SCOPE = "worktime:admin"
+MCP_SCOPE = "worktime:mcp"
+DEFAULT_RATE_LIMIT_PER_MINUTE = 120
+MAX_RATE_LIMIT_PER_MINUTE = 6000
+_KEY_PREVIEW_LENGTH = 4
+_LAST_USED_UPDATE_INTERVAL = timedelta(minutes=15)
+
+
+class RateLimitExceededError(Exception):
+    """Raised when an integration client exceeds its configured per-minute rate limit."""
+
+
+def hash_integration_key(raw_key: str) -> str:
+    """Hash a raw integration-client key for storage/lookup.
+
+    Server-generated high-entropy tokens (``secrets.token_urlsafe``), not user
+    passwords — HMAC-SHA256 with a server-side secret is correct: it adds
+    defense-in-depth against a stolen database dump without materially
+    changing the (already infeasible) brute-force cost of the raw key.
+    """
+    secret = settings.resolved_integration_key_hash_secret()
+    return hmac.new(secret.encode("utf-8"), raw_key.encode("utf-8"), sha256).hexdigest()
+
+
+def _validate_scopes(scopes: list[str]) -> list[str]:
+    deduped = list(dict.fromkeys(scopes))
+    if not deduped:
+        raise ValueError("at least one scope is required")
+    for scope in deduped:
+        if scope not in (MCP_SCOPE, ADMIN_SCOPE):
+            raise ValueError(f"unknown integration-client scope: {scope!r}")
+    return deduped
+
+
+async def create_integration_client(
+    session: AsyncSession,
+    user_id: int,
+    *,
+    name: str,
+    scopes: list[str] | None = None,
+    rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE,
+) -> tuple[IntegrationClient, str]:
+    """Create an integration client and return it alongside the raw key (shown only once).
+
+    Callers are responsible for authorization — specifically, that granting
+    ``worktime:admin`` requires the acting principal to already be an admin
+    (see ``app.routers.integration_clients``), so a credential can never mint
+    another credential with broader privileges than its own caller.
+    """
+    user = await session.get(User, user_id)
+    if user is None:
+        raise NotFoundError("user not found")
+    if rate_limit_per_minute < 1 or rate_limit_per_minute > MAX_RATE_LIMIT_PER_MINUTE:
+        raise ValueError(
+            f"rate_limit_per_minute must be between 1 and {MAX_RATE_LIMIT_PER_MINUTE}"
+        )
+
+    validated_scopes = _validate_scopes(list(scopes) if scopes is not None else list(DEFAULT_SCOPES))
+    raw_key = KEY_PREFIX + secrets.token_urlsafe(32)
+    client = IntegrationClient(
+        user_id=user_id,
+        name=name,
+        key_hash=hash_integration_key(raw_key),
+        key_preview=raw_key[-_KEY_PREVIEW_LENGTH:],
+        scopes=validated_scopes,
+        rate_limit_per_minute=rate_limit_per_minute,
+    )
+    session.add(client)
+    await session.commit()
+    await session.refresh(client)
+    return client, raw_key
+
+
+async def list_integration_clients_for_user(
+    session: AsyncSession, user_id: int
+) -> list[IntegrationClient]:
+    result = await session.execute(
+        select(IntegrationClient)
+        .where(IntegrationClient.user_id == user_id)
+        .order_by(IntegrationClient.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def get_integration_client_for_user(
+    session: AsyncSession, user_id: int, client_id: int
+) -> IntegrationClient:
+    client = await session.get(IntegrationClient, client_id)
+    if client is None or client.user_id != user_id:
+        raise NotFoundError("integration client not found")
+    return client
+
+
+async def revoke_integration_client(session: AsyncSession, user_id: int, client_id: int) -> IntegrationClient:
+    """Disable a client (revocable, not deleted, so audit history stays intact)."""
+    client = await get_integration_client_for_user(session, user_id, client_id)
+    client.is_active = False
+    client.revoked_at = datetime.now(UTC)
+    session.add(client)
+    await session.commit()
+    await session.refresh(client)
+    return client
+
+
+async def rotate_integration_client(
+    session: AsyncSession, user_id: int, client_id: int
+) -> tuple[IntegrationClient, str]:
+    """Replace a client's key in place, immediately invalidating the old one."""
+    client = await get_integration_client_for_user(session, user_id, client_id)
+    raw_key = KEY_PREFIX + secrets.token_urlsafe(32)
+    client.key_hash = hash_integration_key(raw_key)
+    client.key_preview = raw_key[-_KEY_PREVIEW_LENGTH:]
+    client.is_active = True
+    client.revoked_at = None
+    session.add(client)
+    await session.commit()
+    await session.refresh(client)
+    return client, raw_key
+
+
+async def get_active_integration_client_by_key(
+    session: AsyncSession, raw_key: str
+) -> IntegrationClient | None:
+    """Look up an active client by raw key. Returns None for unknown/inactive/revoked keys."""
+    result = await session.execute(
+        select(IntegrationClient).where(IntegrationClient.key_hash == hash_integration_key(raw_key))
+    )
+    client = result.scalar_one_or_none()
+    if client is None or not client.is_active:
+        return None
+    return client
+
+
+async def record_integration_client_usage(session: AsyncSession, client: IntegrationClient) -> None:
+    """Update last_used_at, throttled to avoid a write on every single call."""
+    now = datetime.now(UTC)
+    last_used_at = client.last_used_at
+    if last_used_at is not None:
+        if last_used_at.tzinfo is None:
+            last_used_at = last_used_at.replace(tzinfo=UTC)
+        if now - last_used_at < _LAST_USED_UPDATE_INTERVAL:
+            return
+    client.last_used_at = now
+    session.add(client)
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Per-client rate limiting (in-process sliding window)
+# ---------------------------------------------------------------------------
+#
+# Deliberately in-process rather than DB- or Redis-backed: Worktime's MCP
+# server runs as a single process (see docs/integrations/LOCAL_MCP_SERVER.md),
+# so a per-process window is sufficient defense-in-depth against a
+# misbehaving/compromised integration credential without adding an
+# infrastructure dependency. A multi-process deployment would need a shared
+# store instead — noted as a follow-up, not a requirement for this issue.
+_WINDOW_SECONDS = 60.0
+_usage_windows: dict[int, deque[float]] = {}
+
+
+def enforce_integration_client_rate_limit(client_id: int, rate_limit_per_minute: int) -> None:
+    """Raise RateLimitExceededError once *client_id* exceeds its per-minute budget.
+
+    Takes the client id and configured limit directly (rather than an ORM
+    instance) so callers that only have the verified token's claims — as
+    ``WorktimeMcpBackend.resolve_context`` does, once per tool call — can
+    enforce the limit without an extra DB round-trip. Resets naturally as old
+    timestamps age out of the window — no background task required.
+    """
+    now = time.monotonic()
+    window = _usage_windows.setdefault(client_id, deque())
+    cutoff = now - _WINDOW_SECONDS
+    while window and window[0] < cutoff:
+        window.popleft()
+
+    if len(window) >= rate_limit_per_minute:
+        raise RateLimitExceededError(
+            f"integration client {client_id!r} exceeded its rate limit of "
+            f"{rate_limit_per_minute} requests/minute"
+        )
+    window.append(now)
+
+
+def reset_rate_limit_state() -> None:
+    """Clear all in-process rate-limit windows. Test-only helper."""
+    _usage_windows.clear()

--- a/backend/app/services/integration_client_service.py
+++ b/backend/app/services/integration_client_service.py
@@ -158,6 +158,8 @@ async def rotate_integration_client(
 ) -> tuple[IntegrationClient, str]:
     """Replace a client's key in place, immediately invalidating the old one."""
     client = await get_integration_client_for_user(session, user_id, client_id)
+    if not client.is_active or client.revoked_at is not None:
+        raise ValueError("Cannot rotate a revoked or inactive integration client")
     raw_key = KEY_PREFIX + secrets.token_urlsafe(32)
     client.key_hash = hash_integration_key(raw_key)
     client.key_preview = raw_key[-_KEY_PREVIEW_LENGTH:]

--- a/backend/app/services/integration_client_service.py
+++ b/backend/app/services/integration_client_service.py
@@ -238,9 +238,10 @@ async def enforce_integration_client_rate_limit(session: AsyncSession, client_id
         client.rate_limit_window_started_at = now
         client.rate_limit_window_count = 1
     elif client.rate_limit_window_count >= client.rate_limit_per_minute:
+        rate_limit = client.rate_limit_per_minute
         await session.rollback()
         raise RateLimitExceededError(
-            f"integration client {client_id!r} exceeded its rate limit of {client.rate_limit_per_minute} requests/minute"
+            f"integration client {client_id!r} exceeded its rate limit of {rate_limit} requests/minute"
         )
     else:
         client.rate_limit_window_count += 1

--- a/backend/app/services/integration_client_service.py
+++ b/backend/app/services/integration_client_service.py
@@ -20,6 +20,7 @@ from hashlib import sha256
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.audit.db import AuditActor, write_audit_entry
 from app.config import settings
 from app.database.models import IntegrationClient, User
 from app.services.db_service import NotFoundError
@@ -67,6 +68,7 @@ async def create_integration_client(
     name: str,
     scopes: list[str] | None = None,
     rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE,
+    actor: AuditActor | None = None,
 ) -> tuple[IntegrationClient, str]:
     """Create an integration client and return it alongside the raw key (shown only once).
 
@@ -74,14 +76,14 @@ async def create_integration_client(
     ``worktime:admin`` requires the acting principal to already be an admin
     (see ``app.routers.integration_clients``), so a credential can never mint
     another credential with broader privileges than its own caller.
+    When *actor* is supplied the creation is recorded in the transactional
+    audit trail (same DB transaction as the credential row).
     """
     user = await session.get(User, user_id)
     if user is None:
         raise NotFoundError("user not found")
     if rate_limit_per_minute < 1 or rate_limit_per_minute > MAX_RATE_LIMIT_PER_MINUTE:
-        raise ValueError(
-            f"rate_limit_per_minute must be between 1 and {MAX_RATE_LIMIT_PER_MINUTE}"
-        )
+        raise ValueError(f"rate_limit_per_minute must be between 1 and {MAX_RATE_LIMIT_PER_MINUTE}")
 
     validated_scopes = _validate_scopes(list(scopes) if scopes is not None else list(DEFAULT_SCOPES))
     raw_key = KEY_PREFIX + secrets.token_urlsafe(32)
@@ -94,14 +96,24 @@ async def create_integration_client(
         rate_limit_per_minute=rate_limit_per_minute,
     )
     session.add(client)
+    await session.flush()
+    effective_actor = actor or AuditActor(
+        user_id=user_id, label=f"user:{user_id}", auth_source="keycloak_user", subject=str(user_id)
+    )
+    await write_audit_entry(
+        session,
+        actor=effective_actor,
+        action="integration_client_created",
+        resource_type="integration_client",
+        resource_id=str(client.id),
+        details={"name": name, "scopes": validated_scopes, "rate_limit_per_minute": rate_limit_per_minute},
+    )
     await session.commit()
     await session.refresh(client)
     return client, raw_key
 
 
-async def list_integration_clients_for_user(
-    session: AsyncSession, user_id: int
-) -> list[IntegrationClient]:
+async def list_integration_clients_for_user(session: AsyncSession, user_id: int) -> list[IntegrationClient]:
     result = await session.execute(
         select(IntegrationClient)
         .where(IntegrationClient.user_id == user_id)
@@ -110,28 +122,39 @@ async def list_integration_clients_for_user(
     return list(result.scalars().all())
 
 
-async def get_integration_client_for_user(
-    session: AsyncSession, user_id: int, client_id: int
-) -> IntegrationClient:
+async def get_integration_client_for_user(session: AsyncSession, user_id: int, client_id: int) -> IntegrationClient:
     client = await session.get(IntegrationClient, client_id)
     if client is None or client.user_id != user_id:
         raise NotFoundError("integration client not found")
     return client
 
 
-async def revoke_integration_client(session: AsyncSession, user_id: int, client_id: int) -> IntegrationClient:
+async def revoke_integration_client(
+    session: AsyncSession, user_id: int, client_id: int, *, actor: AuditActor | None = None
+) -> IntegrationClient:
     """Disable a client (revocable, not deleted, so audit history stays intact)."""
     client = await get_integration_client_for_user(session, user_id, client_id)
     client.is_active = False
     client.revoked_at = datetime.now(UTC)
     session.add(client)
+    effective_actor = actor or AuditActor(
+        user_id=user_id, label=f"user:{user_id}", auth_source="keycloak_user", subject=str(user_id)
+    )
+    await write_audit_entry(
+        session,
+        actor=effective_actor,
+        action="integration_client_revoked",
+        resource_type="integration_client",
+        resource_id=str(client.id),
+        details={"name": client.name},
+    )
     await session.commit()
     await session.refresh(client)
     return client
 
 
 async def rotate_integration_client(
-    session: AsyncSession, user_id: int, client_id: int
+    session: AsyncSession, user_id: int, client_id: int, *, actor: AuditActor | None = None
 ) -> tuple[IntegrationClient, str]:
     """Replace a client's key in place, immediately invalidating the old one."""
     client = await get_integration_client_for_user(session, user_id, client_id)
@@ -141,14 +164,23 @@ async def rotate_integration_client(
     client.is_active = True
     client.revoked_at = None
     session.add(client)
+    effective_actor = actor or AuditActor(
+        user_id=user_id, label=f"user:{user_id}", auth_source="keycloak_user", subject=str(user_id)
+    )
+    await write_audit_entry(
+        session,
+        actor=effective_actor,
+        action="integration_client_rotated",
+        resource_type="integration_client",
+        resource_id=str(client.id),
+        details={"name": client.name},
+    )
     await session.commit()
     await session.refresh(client)
     return client, raw_key
 
 
-async def get_active_integration_client_by_key(
-    session: AsyncSession, raw_key: str
-) -> IntegrationClient | None:
+async def get_active_integration_client_by_key(session: AsyncSession, raw_key: str) -> IntegrationClient | None:
     """Look up an active client by raw key. Returns None for unknown/inactive/revoked keys."""
     result = await session.execute(
         select(IntegrationClient).where(IntegrationClient.key_hash == hash_integration_key(raw_key))
@@ -204,8 +236,7 @@ def enforce_integration_client_rate_limit(client_id: int, rate_limit_per_minute:
 
     if len(window) >= rate_limit_per_minute:
         raise RateLimitExceededError(
-            f"integration client {client_id!r} exceeded its rate limit of "
-            f"{rate_limit_per_minute} requests/minute"
+            f"integration client {client_id!r} exceeded its rate limit of {rate_limit_per_minute} requests/minute"
         )
     window.append(now)
 

--- a/backend/app/services/integration_client_service.py
+++ b/backend/app/services/integration_client_service.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import hmac
 import secrets
-import time
-from collections import deque
 from datetime import UTC, datetime, timedelta
 from hashlib import sha256
 
@@ -39,6 +37,10 @@ class RateLimitExceededError(Exception):
     """Raised when an integration client exceeds its configured per-minute rate limit."""
 
 
+def _hash_integration_key_with_secret(raw_key: str, secret: str) -> str:
+    return hmac.new(secret.encode("utf-8"), raw_key.encode("utf-8"), sha256).hexdigest()
+
+
 def hash_integration_key(raw_key: str) -> str:
     """Hash a raw integration-client key for storage/lookup.
 
@@ -48,7 +50,18 @@ def hash_integration_key(raw_key: str) -> str:
     changing the (already infeasible) brute-force cost of the raw key.
     """
     secret = settings.resolved_integration_key_hash_secret()
-    return hmac.new(secret.encode("utf-8"), raw_key.encode("utf-8"), sha256).hexdigest()
+    return _hash_integration_key_with_secret(raw_key, secret)
+
+
+def integration_key_hash_candidates(raw_key: str) -> list[str]:
+    """Return current then optional previous-secret hashes for bounded rotation."""
+    candidates = [hash_integration_key(raw_key)]
+    previous = settings.INTEGRATION_KEY_HASH_SECRET_PREVIOUS.strip()
+    if previous:
+        previous_hash = _hash_integration_key_with_secret(raw_key, previous)
+        if previous_hash not in candidates:
+            candidates.append(previous_hash)
+    return candidates
 
 
 def _validate_scopes(scopes: list[str]) -> list[str]:
@@ -184,12 +197,17 @@ async def rotate_integration_client(
 
 async def get_active_integration_client_by_key(session: AsyncSession, raw_key: str) -> IntegrationClient | None:
     """Look up an active client by raw key. Returns None for unknown/inactive/revoked keys."""
+    current_hash, *fallback_hashes = integration_key_hash_candidates(raw_key)
     result = await session.execute(
-        select(IntegrationClient).where(IntegrationClient.key_hash == hash_integration_key(raw_key))
+        select(IntegrationClient).where(IntegrationClient.key_hash.in_([current_hash, *fallback_hashes]))
     )
     client = result.scalar_one_or_none()
     if client is None or not client.is_active:
         return None
+    if client.key_hash != current_hash:
+        client.key_hash = current_hash
+        await session.commit()
+        await session.refresh(client)
     return client
 
 
@@ -207,42 +225,23 @@ async def record_integration_client_usage(session: AsyncSession, client: Integra
     await session.commit()
 
 
-# ---------------------------------------------------------------------------
-# Per-client rate limiting (in-process sliding window)
-# ---------------------------------------------------------------------------
-#
-# Deliberately in-process rather than DB- or Redis-backed: Worktime's MCP
-# server runs as a single process (see docs/integrations/LOCAL_MCP_SERVER.md),
-# so a per-process window is sufficient defense-in-depth against a
-# misbehaving/compromised integration credential without adding an
-# infrastructure dependency. A multi-process deployment would need a shared
-# store instead — noted as a follow-up, not a requirement for this issue.
-_WINDOW_SECONDS = 60.0
-_usage_windows: dict[int, deque[float]] = {}
-
-
-def enforce_integration_client_rate_limit(client_id: int, rate_limit_per_minute: int) -> None:
-    """Raise RateLimitExceededError once *client_id* exceeds its per-minute budget.
-
-    Takes the client id and configured limit directly (rather than an ORM
-    instance) so callers that only have the verified token's claims — as
-    ``WorktimeMcpBackend.resolve_context`` does, once per tool call — can
-    enforce the limit without an extra DB round-trip. Resets naturally as old
-    timestamps age out of the window — no background task required.
-    """
-    now = time.monotonic()
-    window = _usage_windows.setdefault(client_id, deque())
-    cutoff = now - _WINDOW_SECONDS
-    while window and window[0] < cutoff:
-        window.popleft()
-
-    if len(window) >= rate_limit_per_minute:
+async def enforce_integration_client_rate_limit(session: AsyncSession, client_id: int) -> None:
+    """Consume one database-backed fixed-window request across all workers."""
+    client = await session.scalar(select(IntegrationClient).where(IntegrationClient.id == client_id).with_for_update())
+    if client is None:
+        raise RateLimitExceededError("integration client no longer exists")
+    now = datetime.now(UTC)
+    started = client.rate_limit_window_started_at
+    if started is not None and started.tzinfo is None:
+        started = started.replace(tzinfo=UTC)
+    if started is None or now - started >= timedelta(minutes=1):
+        client.rate_limit_window_started_at = now
+        client.rate_limit_window_count = 1
+    elif client.rate_limit_window_count >= client.rate_limit_per_minute:
+        await session.rollback()
         raise RateLimitExceededError(
-            f"integration client {client_id!r} exceeded its rate limit of {rate_limit_per_minute} requests/minute"
+            f"integration client {client_id!r} exceeded its rate limit of {client.rate_limit_per_minute} requests/minute"
         )
-    window.append(now)
-
-
-def reset_rate_limit_state() -> None:
-    """Clear all in-process rate-limit windows. Test-only helper."""
-    _usage_windows.clear()
+    else:
+        client.rate_limit_window_count += 1
+    await session.commit()

--- a/backend/app/services/read_models_service.py
+++ b/backend/app/services/read_models_service.py
@@ -413,17 +413,13 @@ def _build_time_off_summary(
                 starts_on, ends_on = entry.start_date, entry.end_date
             else:
                 starts_on, ends_on = today, today
-            active_items.append(
-                _to_time_off_item(entry, starts_on=starts_on, ends_on=ends_on, is_active=True)
-            )
+            active_items.append(_to_time_off_item(entry, starts_on=starts_on, ends_on=ends_on, is_active=True))
             continue
 
         window = _resolve_time_off_window(entry, today)
         if window is None:
             continue
-        upcoming_items.append(
-            _to_time_off_item(entry, starts_on=window[0], ends_on=window[1], is_active=False)
-        )
+        upcoming_items.append(_to_time_off_item(entry, starts_on=window[0], ends_on=window[1], is_active=False))
 
     active_items.sort(key=lambda item: (item.starts_on, item.ends_on, item.entry_id))
     upcoming_items.sort(key=lambda item: (item.starts_on, item.ends_on, item.entry_id))

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -141,14 +141,10 @@ class BulkDeleteGuardError(Exception):
         )
 
 
-async def _count_active(
-    session: AsyncSession, model: type[SyncEntityModel], user_id: int
-) -> int:
+async def _count_active(session: AsyncSession, model: type[SyncEntityModel], user_id: int) -> int:
     return (
         await session.scalar(
-            select(sql_func.count())
-            .select_from(model)
-            .where(model.user_id == user_id, model.deleted_at.is_(None))
+            select(sql_func.count()).select_from(model).where(model.user_id == user_id, model.deleted_at.is_(None))
         )
     ) or 0
 
@@ -172,9 +168,7 @@ async def _count_active_in(
     ) or 0
 
 
-async def _assert_not_bulk_delete(
-    session: AsyncSession, user_id: int, changes: SyncPushRequest
-) -> None:
+async def _assert_not_bulk_delete(session: AsyncSession, user_id: int, changes: SyncPushRequest) -> None:
     """Raise BulkDeleteGuardError when *changes* would wipe most of the account.
 
     Only deletes that would actually tombstone a currently-active row are
@@ -230,21 +224,18 @@ def _get_provided_fields(item: BaseModel) -> set[str]:
     return provided
 
 
-async def _validate_task_label_reference(
-    session: AsyncSession, user_id: int, label_id: str | None
-) -> None:
+async def _validate_task_label_reference(session: AsyncSession, user_id: int, label_id: str | None) -> None:
     if label_id is None:
         return
 
     label = await session.get(Label, label_id)
     if label is None or label.user_id != user_id or label.deleted_at is not None:
         from app.services.db_service import ValidationError
+
         raise ValidationError("label not found")
 
 
-async def _label_name_taken(
-    session: AsyncSession, user_id: int, name: str, *, exclude_id: str | None
-) -> bool:
+async def _label_name_taken(session: AsyncSession, user_id: int, name: str, *, exclude_id: str | None) -> bool:
     """Whether another *active* label already owns (user_id, name).
 
     Mirrors the ``uq_active_label_user_name`` partial unique index so callers
@@ -264,9 +255,7 @@ async def _label_name_taken(
     return result.scalar_one_or_none() is not None
 
 
-async def _push_label(
-    session: AsyncSession, user_id: int, item: LabelSyncItem
-) -> SyncRecordResult:
+async def _push_label(session: AsyncSession, user_id: int, item: LabelSyncItem) -> SyncRecordResult:
     now = _now()
     label: Label | None = await session.get(Label, item.id)
 
@@ -314,6 +303,7 @@ async def _push_label(
     if label is None:
         if item.name is None or item.color is None:
             from app.services.db_service import ValidationError
+
             raise ValidationError("name and color are required for label create")
         if await _label_name_taken(session, user_id, item.name, exclude_id=None):
             return SyncRecordResult(
@@ -377,9 +367,7 @@ async def _push_label(
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
 
-async def _push_task(
-    session: AsyncSession, user_id: int, item: TaskSyncItem
-) -> SyncRecordResult:
+async def _push_task(session: AsyncSession, user_id: int, item: TaskSyncItem) -> SyncRecordResult:
     now = _now()
     task: TimeTrackingTask | None = await session.get(TimeTrackingTask, item.id)
 
@@ -402,9 +390,11 @@ async def _push_task(
     if task is None:
         if item.text is None or item.start_time is None:
             from app.services.db_service import ValidationError
+
             raise ValidationError("text and start_time are required for task create")
         if item.stop_time is not None and as_utc(item.stop_time) < as_utc(item.start_time):
             from app.services.db_service import ValidationError
+
             raise ValidationError("stop_time cannot be earlier than start_time")
         await _validate_task_label_reference(session, user_id, item.label_id)
         await _validate_task_gantt_reference(session, user_id, item.gantt_task_id)
@@ -441,13 +431,12 @@ async def _push_task(
         )
     provided_fields = _get_provided_fields(item) - {"action", "client_updated_at"}
     candidate_start_time = (
-        item.start_time
-        if "start_time" in provided_fields and item.start_time is not None
-        else task.start_time
+        item.start_time if "start_time" in provided_fields and item.start_time is not None else task.start_time
     )
     candidate_stop_time = item.stop_time if "stop_time" in provided_fields else task.stop_time
     if candidate_stop_time is not None and as_utc(candidate_stop_time) < as_utc(candidate_start_time):
         from app.services.db_service import ValidationError
+
         raise ValidationError("stop_time cannot be earlier than start_time")
     if "text" in provided_fields and item.text is not None:
         task.text = item.text
@@ -471,9 +460,7 @@ async def _push_task(
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
 
-async def _push_template(
-    session: AsyncSession, user_id: int, item: TemplateSyncItem
-) -> SyncRecordResult:
+async def _push_template(session: AsyncSession, user_id: int, item: TemplateSyncItem) -> SyncRecordResult:
     now = _now()
     template: TimeTrackingTemplate | None = await session.get(TimeTrackingTemplate, item.id)
 
@@ -496,6 +483,7 @@ async def _push_template(
     if template is None:
         if item.text is None or item.start_time is None or item.stop_time is None:
             from app.services.db_service import ValidationError
+
             raise ValidationError("text, start_time and stop_time are required for template create")
         await _validate_task_label_reference(session, user_id, item.label_id)
         template = TimeTrackingTemplate(
@@ -543,9 +531,7 @@ async def _push_template(
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
 
-async def _push_work_location(
-    session: AsyncSession, user_id: int, item: WorkLocationSyncItem
-) -> SyncRecordResult:
+async def _push_work_location(session: AsyncSession, user_id: int, item: WorkLocationSyncItem) -> SyncRecordResult:
     """Work locations use (user_id, date) as their natural key."""
     now = _now()
     date_key = item.date.isoformat()
@@ -585,6 +571,7 @@ async def _push_work_location(
     if location is None:
         if item.country_code is None:
             from app.services.db_service import ValidationError
+
             raise ValidationError("country_code is required for work_location create")
         location = WorkLocation(
             user_id=user_id,
@@ -616,9 +603,7 @@ async def _push_work_location(
     return SyncRecordResult(id=date_key, status="ok", server_updated_at=now)
 
 
-async def _push_time_off_entry(
-    session: AsyncSession, user_id: int, item: TimeOffEntrySyncItem
-) -> SyncRecordResult:
+async def _push_time_off_entry(session: AsyncSession, user_id: int, item: TimeOffEntrySyncItem) -> SyncRecordResult:
     """Time-off entries use (user_id, entry_id) as their natural key."""
     now = _now()
     provided_fields = _get_provided_fields(item) - {"id", "action", "client_updated_at"}
@@ -658,6 +643,7 @@ async def _push_time_off_entry(
         # Create items always provide a full shape; update items can upsert when they do.
         if item.entry_kind is None:
             from app.services.db_service import ValidationError
+
             raise ValidationError("entry_kind is required to create a time-off entry")
         entry = TimeOffEntry(
             entry_id=item.id,
@@ -708,9 +694,7 @@ async def _push_time_off_entry(
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
 
-async def _push_gantt_task(
-    session: AsyncSession, user_id: int, item: GanttTaskSyncItem
-) -> SyncRecordResult:
+async def _push_gantt_task(session: AsyncSession, user_id: int, item: GanttTaskSyncItem) -> SyncRecordResult:
     now = _now()
     task: GanttTask | None = await session.get(GanttTask, item.id)
 
@@ -746,6 +730,7 @@ async def _push_gantt_task(
     if task is None:
         if item.name is None or item.start_date is None or item.end_date is None:
             from app.services.db_service import ValidationError
+
             raise ValidationError("name, start_date and end_date are required for gantt task create")
         await _validate_task_label_reference(session, user_id, item.label_id)
         task = GanttTask(
@@ -802,9 +787,7 @@ async def _push_gantt_task(
     return SyncRecordResult(id=item.id, status="ok", server_updated_at=now)
 
 
-type SyncEntityModel = (
-    Label | TimeTrackingTask | TimeTrackingTemplate | WorkLocation | TimeOffEntry | GanttTask
-)
+type SyncEntityModel = Label | TimeTrackingTask | TimeTrackingTemplate | WorkLocation | TimeOffEntry | GanttTask
 
 
 async def _get_synced_entities[SyncEntityModelT: SyncEntityModel](
@@ -830,9 +813,7 @@ async def _get_synced_entities[SyncEntityModelT: SyncEntityModel](
 # ---------------------------------------------------------------------------
 
 
-async def push_changes(
-    session: AsyncSession, user_id: int, changes: SyncPushRequest
-) -> SyncPushResponse:
+async def push_changes(session: AsyncSession, user_id: int, changes: SyncPushRequest) -> SyncPushResponse:
     """Apply a batched set of client changes within a single transaction."""
     results: dict[str, list[SyncRecordResult]] = {
         "labels": [],
@@ -874,9 +855,7 @@ async def push_changes(
     return SyncPushResponse(results=results)
 
 
-async def pull_changes(
-    session: AsyncSession, user_id: int, since: datetime
-) -> SyncPullResponse:
+async def pull_changes(session: AsyncSession, user_id: int, since: datetime) -> SyncPullResponse:
     """Return all records (including soft-deleted) modified after *since*."""
     since_utc = as_utc(since)
 

--- a/backend/app/utils/sse_manager.py
+++ b/backend/app/utils/sse_manager.py
@@ -269,6 +269,4 @@ async def notify_sync_changed(user_id: int) -> None:
     try:
         await sync_event_manager.broadcast_sync_changed(user_id)
     except Exception:
-        logger.warning(
-            "SSE: broadcast_sync_changed failed for user %d (non-fatal)", user_id, exc_info=True
-        )
+        logger.warning("SSE: broadcast_sync_changed failed for user %d (non-fatal)", user_id, exc_info=True)

--- a/backend/app/utils/statistics.py
+++ b/backend/app/utils/statistics.py
@@ -10,16 +10,16 @@ import statistics
 
 def calculate_avg(measurements: list[float]) -> float:
     """Calculate the mean (average) of a list of measurements.
-    
+
     Args:
         measurements: List of numeric measurements
-        
+
     Returns:
         The arithmetic mean of the measurements
-        
+
     Raises:
         statistics.StatisticsError: If measurements list is empty
-        
+
     Example:
         >>> calculate_avg([10.0, 20.0, 30.0])
         20.0
@@ -29,57 +29,54 @@ def calculate_avg(measurements: list[float]) -> float:
 
 def calculate_percentile(measurements: list[float], percentile: int) -> float:
     """Calculate the specified percentile of a list of measurements.
-    
+
     Uses Python's quantiles function to calculate the percentile value.
     The percentile parameter should be an integer between 0 and 100.
-    
+
     Args:
         measurements: List of numeric measurements (at least 2 required)
         percentile: The percentile to calculate (0-100)
-        
+
     Returns:
         The value at the specified percentile
-        
+
     Raises:
         statistics.StatisticsError: If measurements list has fewer than 2 elements
         ValueError: If percentile is not between 0 and 100
-        
+
     Example:
         >>> calculate_percentile([10.0, 20.0, 30.0, 40.0, 50.0], 95)
         48.0
     """
     if not 0 <= percentile <= 100:
         raise ValueError(f"Percentile must be between 0 and 100, got {percentile}")
-    
+
     if len(measurements) < 2:
         raise statistics.StatisticsError("must have at least two data points")
-    
+
     # quantiles() returns n-1 cut points for n quantiles
     # For a percentile, we need to use method='inclusive' for accurate results
     # Convert percentile (0-100) to a fraction (0-1)
-    return statistics.quantiles(measurements, n=100, method='inclusive')[percentile - 1]
+    return statistics.quantiles(measurements, n=100, method="inclusive")[percentile - 1]
 
 
 def calculate_stats(measurements: list[float]) -> dict[str, float]:
     """Calculate both average and 95th percentile statistics.
-    
+
     This is a convenience function that combines calculate_avg and
     calculate_percentile to return commonly used statistics in a single call.
-    
+
     Args:
         measurements: List of numeric measurements (at least 2 required for percentile)
-        
+
     Returns:
         Dictionary with 'avg' and 'p95' keys containing the respective values
-        
+
     Raises:
         statistics.StatisticsError: If measurements list is empty or has fewer than 2 elements
-        
+
     Example:
         >>> calculate_stats([10.0, 20.0, 30.0, 40.0, 50.0])
         {'avg': 30.0, 'p95': 48.0}
     """
-    return {
-        'avg': calculate_avg(measurements),
-        'p95': calculate_percentile(measurements, 95)
-    }
+    return {"avg": calculate_avg(measurements), "p95": calculate_percentile(measurements, 95)}

--- a/backend/app/utils/timing.py
+++ b/backend/app/utils/timing.py
@@ -11,14 +11,14 @@ from contextlib import contextmanager
 @contextmanager
 def time_operation(operation_name: str, timings: dict[str, float]):
     """Context manager for timing an operation.
-    
+
     Measures the elapsed time of a code block and stores the result
     in milliseconds in the provided timings dictionary.
-    
+
     Args:
         operation_name: Name/key to use for storing the timing result
         timings: Dictionary to store the timing result in
-        
+
     Example:
         timings = {}
         with time_operation("database_query", timings):

--- a/backend/migrations/versions/004_integration_clients.py
+++ b/backend/migrations/versions/004_integration_clients.py
@@ -1,0 +1,82 @@
+"""Add managed, database-backed integration clients.
+
+Replaces the long-lived static-token map parsed from
+WORKTIME_MCP_INTEGRATION_KEYS with revocable, rotatable, rate-limited,
+per-user credentials. WORKTIME_MCP_INTEGRATION_KEYS keeps working alongside
+this table for a documented overlap/migration period — see
+docs/integrations/LOCAL_MCP_SERVER.md.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-08-07
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "integration_clients",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("key_hash", sa.String(length=128), nullable=False, unique=True),
+        sa.Column("key_preview", sa.String(length=8), nullable=False),
+        sa.Column(
+            "scopes",
+            sa.JSON(),
+            nullable=False,
+            server_default='["worktime:mcp"]',
+        ),
+        sa.Column(
+            "rate_limit_per_minute",
+            sa.Integer(),
+            nullable=False,
+            server_default="120",
+        ),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_integration_clients_user_id", "integration_clients", ["user_id"]
+    )
+    op.create_index(
+        "ix_integration_clients_key_hash", "integration_clients", ["key_hash"], unique=True
+    )
+    op.create_index(
+        "ix_integration_clients_user_id_created_at",
+        "integration_clients",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_integration_clients_user_id_created_at", table_name="integration_clients")
+    op.drop_index("ix_integration_clients_key_hash", table_name="integration_clients")
+    op.drop_index("ix_integration_clients_user_id", table_name="integration_clients")
+    op.drop_table("integration_clients")

--- a/backend/migrations/versions/004_integration_clients.py
+++ b/backend/migrations/versions/004_integration_clients.py
@@ -61,13 +61,11 @@ def upgrade() -> None:
         ),
         sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rate_limit_window_started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rate_limit_window_count", sa.Integer(), nullable=False, server_default="0"),
     )
-    op.create_index(
-        "ix_integration_clients_user_id", "integration_clients", ["user_id"]
-    )
-    op.create_index(
-        "ix_integration_clients_key_hash", "integration_clients", ["key_hash"], unique=True
-    )
+    op.create_index("ix_integration_clients_user_id", "integration_clients", ["user_id"])
+    op.create_index("ix_integration_clients_key_hash", "integration_clients", ["key_hash"], unique=True)
     op.create_index(
         "ix_integration_clients_user_id_created_at",
         "integration_clients",

--- a/backend/migrations/versions/004_integration_clients.py
+++ b/backend/migrations/versions/004_integration_clients.py
@@ -33,7 +33,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("name", sa.String(length=120), nullable=False),
-        sa.Column("key_hash", sa.String(length=128), nullable=False, unique=True),
+        sa.Column("key_hash", sa.String(length=128), nullable=False),
         sa.Column("key_preview", sa.String(length=8), nullable=False),
         sa.Column(
             "scopes",

--- a/backend/migrations/versions/005_audit_entries.py
+++ b/backend/migrations/versions/005_audit_entries.py
@@ -50,15 +50,11 @@ def upgrade() -> None:
     op.create_index("ix_audit_entries_auth_source", "audit_entries", ["auth_source"])
     op.create_index("ix_audit_entries_action", "audit_entries", ["action"])
     op.create_index("ix_audit_entries_resource_type", "audit_entries", ["resource_type"])
-    op.create_index("ix_audit_entries_created_at", "audit_entries", ["created_at"])
-    op.create_index(
-        "ix_audit_entries_created_at_id", "audit_entries", ["created_at", "id"]
-    )
+    op.create_index("ix_audit_entries_created_at_id", "audit_entries", ["created_at", "id"])
 
 
 def downgrade() -> None:
     op.drop_index("ix_audit_entries_created_at_id", table_name="audit_entries")
-    op.drop_index("ix_audit_entries_created_at", table_name="audit_entries")
     op.drop_index("ix_audit_entries_resource_type", table_name="audit_entries")
     op.drop_index("ix_audit_entries_action", table_name="audit_entries")
     op.drop_index("ix_audit_entries_auth_source", table_name="audit_entries")

--- a/backend/migrations/versions/005_audit_entries.py
+++ b/backend/migrations/versions/005_audit_entries.py
@@ -47,16 +47,10 @@ def upgrade() -> None:
         ),
     )
     op.create_index("ix_audit_entries_actor_user_id", "audit_entries", ["actor_user_id"])
-    op.create_index("ix_audit_entries_auth_source", "audit_entries", ["auth_source"])
-    op.create_index("ix_audit_entries_action", "audit_entries", ["action"])
-    op.create_index("ix_audit_entries_resource_type", "audit_entries", ["resource_type"])
     op.create_index("ix_audit_entries_created_at_id", "audit_entries", ["created_at", "id"])
 
 
 def downgrade() -> None:
     op.drop_index("ix_audit_entries_created_at_id", table_name="audit_entries")
-    op.drop_index("ix_audit_entries_resource_type", table_name="audit_entries")
-    op.drop_index("ix_audit_entries_action", table_name="audit_entries")
-    op.drop_index("ix_audit_entries_auth_source", table_name="audit_entries")
     op.drop_index("ix_audit_entries_actor_user_id", table_name="audit_entries")
     op.drop_table("audit_entries")

--- a/backend/migrations/versions/005_audit_entries.py
+++ b/backend/migrations/versions/005_audit_entries.py
@@ -1,0 +1,66 @@
+"""Add the transactional audit_entries table.
+
+Durable, authoritative record of REST/MCP mutations, written in the same
+database transaction as the mutation it describes. The rotated file logger
+added in #984 (app.audit.logger) remains as secondary, best-effort
+operational telemetry only.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-08-07
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_entries",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "actor_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("actor_label", sa.String(), nullable=False),
+        sa.Column("subject", sa.String(), nullable=True),
+        sa.Column("auth_source", sa.String(), nullable=False),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column("resource_type", sa.String(), nullable=False),
+        sa.Column("resource_id", sa.String(), nullable=False),
+        sa.Column("request_id", sa.String(), nullable=True),
+        sa.Column("details", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_audit_entries_actor_user_id", "audit_entries", ["actor_user_id"])
+    op.create_index("ix_audit_entries_auth_source", "audit_entries", ["auth_source"])
+    op.create_index("ix_audit_entries_action", "audit_entries", ["action"])
+    op.create_index("ix_audit_entries_resource_type", "audit_entries", ["resource_type"])
+    op.create_index("ix_audit_entries_created_at", "audit_entries", ["created_at"])
+    op.create_index(
+        "ix_audit_entries_created_at_id", "audit_entries", ["created_at", "id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_entries_created_at_id", table_name="audit_entries")
+    op.drop_index("ix_audit_entries_created_at", table_name="audit_entries")
+    op.drop_index("ix_audit_entries_resource_type", table_name="audit_entries")
+    op.drop_index("ix_audit_entries_action", table_name="audit_entries")
+    op.drop_index("ix_audit_entries_auth_source", table_name="audit_entries")
+    op.drop_index("ix_audit_entries_actor_user_id", table_name="audit_entries")
+    op.drop_table("audit_entries")

--- a/backend/tests/test_access_tokens.py
+++ b/backend/tests/test_access_tokens.py
@@ -20,6 +20,7 @@ from app.database.models import AccessToken
 from app.routers.auth import (
     PEBBLE_READ_SCOPE,
     PEBBLE_WRITE_SCOPE,
+    AuthenticatedPrincipal,
     AuthType,
     get_authenticated_principal,
     get_bearer_principal,
@@ -40,10 +41,12 @@ def _fake_request() -> Request:
     return Request(scope={"type": "http", "headers": []})
 
 
-def test_regular_api_accepts_delegated_pat_but_oidc_boundary_rejects_it() -> None:
-    principal = SimpleNamespace(auth_type=AuthType.DELEGATED)
+def test_regular_api_and_oidc_boundary_reject_delegated_pat() -> None:
+    principal = AuthenticatedPrincipal(user_id=1, auth_type=AuthType.DELEGATED)
 
-    assert get_authenticated_principal(principal) is principal
+    with pytest.raises(HTTPException) as regular_error:
+        get_authenticated_principal(principal)
+    assert regular_error.value.status_code == 403
     with pytest.raises(HTTPException) as exc_info:
         require_oidc_principal(principal)
     assert exc_info.value.status_code == 403

--- a/backend/tests/test_access_tokens.py
+++ b/backend/tests/test_access_tokens.py
@@ -21,8 +21,10 @@ from app.routers.auth import (
     PEBBLE_READ_SCOPE,
     PEBBLE_WRITE_SCOPE,
     AuthType,
+    get_authenticated_principal,
     get_bearer_principal,
     has_required_scopes,
+    require_oidc_principal,
 )
 from app.schemas import AccessTokenCreate, UserCreate
 from app.services.access_token_service import (
@@ -36,6 +38,15 @@ from app.services.db_service import NotFoundError, create_user
 
 def _fake_request() -> Request:
     return Request(scope={"type": "http", "headers": []})
+
+
+def test_regular_api_accepts_delegated_pat_but_oidc_boundary_rejects_it() -> None:
+    principal = SimpleNamespace(auth_type=AuthType.DELEGATED)
+
+    assert get_authenticated_principal(principal) is principal
+    with pytest.raises(HTTPException) as exc_info:
+        require_oidc_principal(principal)
+    assert exc_info.value.status_code == 403
 
 
 async def test_authentication_throttles_recent_activity_write() -> None:
@@ -144,10 +155,7 @@ async def test_concurrent_pebble_rotations_leave_one_active_token(
         )
         assert len(list(tokens.scalars())) == 1
 
-        authenticated = [
-            await authenticate_access_token(verification_session, raw_token)
-            for raw_token in raw_tokens
-        ]
+        authenticated = [await authenticate_access_token(verification_session, raw_token) for raw_token in raw_tokens]
         assert sum(token is not None for token in authenticated) == 1
 
 

--- a/backend/tests/test_audit_db.py
+++ b/backend/tests/test_audit_db.py
@@ -1,0 +1,196 @@
+"""Tests for the transactional mutation audit trail (issue #1054).
+
+Distinct from tests/test_audit.py, which covers the pre-existing (#984)
+rotated file logger — that one remains as secondary, best-effort operational
+telemetry. This file covers the new authoritative, transactional DB record.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit.db import (
+    MAX_AUDIT_LIMIT,
+    AuditActor,
+    AuditAuthorizationError,
+    list_audit_entries,
+    write_audit_entry,
+)
+from app.schemas import LabelCreate, TaskCreate, UserCreate
+from app.services import db_service
+from app.services.db_service import NotFoundError
+
+
+async def test_write_audit_entry_is_visible_after_caller_commits(db_session: AsyncSession) -> None:
+    """write_audit_entry() only stages the row — the caller commits."""
+    user = await db_service.create_user(db_session, UserCreate(username="audit-stage", display_name="Stage"))
+    actor = AuditActor(user_id=user.id, label="user:1", auth_source="oidc")
+
+    await write_audit_entry(db_session, actor=actor, action="test_action", resource_type="test", resource_id="abc")
+    await db_session.commit()
+
+    entries = await list_audit_entries(db_session, requesting_user_id=user.id, is_admin=False)
+    assert len(entries) == 1
+    assert entries[0].action == "test_action"
+    assert entries[0].resource_id == "abc"
+    assert entries[0].actor_label == "user:1"
+
+
+async def test_create_task_with_actor_writes_audit_entry_in_same_transaction(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="audit-task", display_name="Task"))
+    actor = AuditActor(user_id=user.id, label="user:test", auth_source="keycloak_user")
+
+    task = await db_service.create_task(
+        db_session,
+        user.id,
+        TaskCreate(text="hello", start_time=datetime.now(UTC)),
+        actor=actor,
+    )
+
+    entries = await list_audit_entries(db_session, requesting_user_id=user.id, is_admin=False)
+    assert any(e.action == "create_task" and e.resource_id == task.id for e in entries)
+
+
+async def test_mutation_without_actor_writes_no_audit_entry(db_session: AsyncSession) -> None:
+    """actor defaults to None: existing/test call sites without an actor stay audit-free."""
+    user = await db_service.create_user(db_session, UserCreate(username="no-actor", display_name="No Actor"))
+    await db_service.create_label(db_session, user.id, LabelCreate(name="NoActorLabel", color="#123456"))
+
+    entries = await list_audit_entries(db_session, requesting_user_id=user.id, is_admin=False)
+    assert entries == []
+
+
+async def test_list_audit_entries_rejects_out_of_range_limit(db_session: AsyncSession) -> None:
+    with pytest.raises(ValueError, match="limit must be between"):
+        await list_audit_entries(db_session, requesting_user_id=1, is_admin=True, limit=0)
+    with pytest.raises(ValueError, match="limit must be between"):
+        await list_audit_entries(db_session, requesting_user_id=1, is_admin=True, limit=MAX_AUDIT_LIMIT + 1)
+
+
+async def test_list_audit_entries_non_admin_cannot_read_another_users_trail(db_session: AsyncSession) -> None:
+    owner = await db_service.create_user(db_session, UserCreate(username="audit-owner", display_name="Owner"))
+    other = await db_service.create_user(db_session, UserCreate(username="audit-other", display_name="Other"))
+
+    with pytest.raises(AuditAuthorizationError):
+        await list_audit_entries(db_session, requesting_user_id=other.id, is_admin=False, target_user_id=owner.id)
+
+
+async def test_list_audit_entries_non_admin_forced_to_own_trail(db_session: AsyncSession) -> None:
+    owner = await db_service.create_user(db_session, UserCreate(username="audit-forced", display_name="Forced"))
+    actor = AuditActor(user_id=owner.id, label="user:forced", auth_source="oidc")
+    await write_audit_entry(db_session, actor=actor, action="x", resource_type="t", resource_id="1")
+    await db_session.commit()
+
+    # target_user_id omitted entirely — non-admin still only sees their own.
+    entries = await list_audit_entries(db_session, requesting_user_id=owner.id, is_admin=False)
+    assert len(entries) == 1
+    assert entries[0].actor_user_id == owner.id
+
+
+async def test_list_audit_entries_admin_can_read_team_wide_trail(db_session: AsyncSession) -> None:
+    alice = await db_service.create_user(db_session, UserCreate(username="audit-alice", display_name="Alice"))
+    bob = await db_service.create_user(db_session, UserCreate(username="audit-bob", display_name="Bob"))
+    await write_audit_entry(
+        db_session,
+        actor=AuditActor(user_id=alice.id, label="user:alice", auth_source="oidc"),
+        action="a",
+        resource_type="t",
+        resource_id="1",
+    )
+    await write_audit_entry(
+        db_session,
+        actor=AuditActor(user_id=bob.id, label="user:bob", auth_source="oidc"),
+        action="b",
+        resource_type="t",
+        resource_id="2",
+    )
+    await db_session.commit()
+
+    entries = await list_audit_entries(db_session, requesting_user_id=alice.id, is_admin=True)
+    assert {e.actor_user_id for e in entries} == {alice.id, bob.id}
+
+
+async def test_list_audit_entries_stable_pagination_with_before_id(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="audit-page", display_name="Page"))
+    for i in range(5):
+        await write_audit_entry(
+            db_session,
+            actor=AuditActor(user_id=user.id, label="user:page", auth_source="oidc"),
+            action=f"action-{i}",
+            resource_type="t",
+            resource_id=str(i),
+        )
+    await db_session.commit()
+
+    first_page = await list_audit_entries(db_session, requesting_user_id=user.id, is_admin=False, limit=2)
+    assert len(first_page) == 2
+    second_page = await list_audit_entries(
+        db_session, requesting_user_id=user.id, is_admin=False, limit=2, before_id=first_page[-1].id
+    )
+    assert len(second_page) == 2
+    # Descending, non-overlapping, contiguous pages.
+    assert first_page[-1].id > second_page[0].id
+    assert {e.id for e in first_page}.isdisjoint({e.id for e in second_page})
+
+
+async def test_delete_label_without_actor_still_raises_expected_domain_errors(db_session: AsyncSession) -> None:
+    """Sanity check: adding the optional actor param didn't change existing behavior/signatures."""
+    user = await db_service.create_user(db_session, UserCreate(username="audit-sanity", display_name="Sanity"))
+    with pytest.raises(NotFoundError):
+        await db_service.delete_label(db_session, user.id, "does-not-exist")
+
+
+async def test_audit_rest_endpoint_scopes_to_own_trail_for_non_admin(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    admin_headers = auth_headers(user_id=1, is_admin=True)
+    owner_id = create_user_factory(db_client, admin_headers, "audit-rest-owner")
+    other_id = create_user_factory(db_client, admin_headers, "audit-rest-other")
+    owner_headers = auth_headers(user_id=owner_id)
+
+    create_response = db_client.post(
+        "/api/time-tracking/labels",
+        json={"name": "AuditLabel", "color": "#abcdef"},
+        headers=owner_headers,
+    )
+    assert create_response.status_code == 201, create_response.text
+
+    own_trail = db_client.get("/api/audit", headers=owner_headers)
+    assert own_trail.status_code == 200
+    assert own_trail.json()["total"] >= 1
+    assert all(item["actor_user_id"] == owner_id for item in own_trail.json()["items"])
+
+    forbidden = db_client.get(f"/api/audit?user_id={other_id}", headers=owner_headers)
+    assert forbidden.status_code == 403
+
+
+async def test_audit_rest_endpoint_allows_admin_team_wide_read(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    admin_headers = auth_headers(user_id=1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "audit-rest-admin-target")
+    user_headers = auth_headers(user_id=user_id)
+
+    create_response = db_client.post(
+        "/api/time-tracking/labels",
+        json={"name": "AdminVisibleLabel", "color": "#123123"},
+        headers=user_headers,
+    )
+    assert create_response.status_code == 201, create_response.text
+
+    team_wide = db_client.get("/api/audit", headers=admin_headers)
+    assert team_wide.status_code == 200
+    assert any(item["actor_user_id"] == user_id for item in team_wide.json()["items"])
+
+    scoped = db_client.get(f"/api/audit?user_id={user_id}", headers=admin_headers)
+    assert scoped.status_code == 200
+    assert all(item["actor_user_id"] == user_id for item in scoped.json()["items"])

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -48,6 +48,7 @@ def test_custom_settings():
         os.environ["DATABASE_ECHO"] = "true"
         os.environ["OIDC_ISSUER_URL"] = "https://auth.example.com/application/o/worktime"
         os.environ["TRUSTED_HOSTS"] = "worktime.tjor.im"
+        os.environ["INTEGRATION_KEY_HASH_SECRET"] = "test-secret"
 
         # Create new settings instance
         settings = Settings()
@@ -105,6 +106,7 @@ def test_cors_origins_wildcard_production():
         ENVIRONMENT="production",
         CORS_ORIGINS="*",
         TRUSTED_HOSTS="worktime.tjor.im",
+        INTEGRATION_KEY_HASH_SECRET="test-secret",
     )
     origins = settings.get_cors_origins_list()
 
@@ -118,7 +120,9 @@ def test_environment_validation():
     settings_dev = Settings(ENVIRONMENT="development")
     assert settings_dev.ENVIRONMENT == "development"
 
-    settings_prod = Settings(ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im")
+    settings_prod = Settings(
+        ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im", INTEGRATION_KEY_HASH_SECRET="test-secret"
+    )
     assert settings_prod.ENVIRONMENT == "production"
     
     # Invalid environment should raise error
@@ -287,7 +291,12 @@ def test_trusted_hosts_always_allows_localhost_for_healthcheck():
     """get_trusted_hosts_list() always allows "localhost" so Docker's own
     HEALTHCHECK (curling http://localhost:PORT/health from inside the
     container) keeps working regardless of the configured production allowlist."""
-    settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im")
+    settings = Settings(
+        _env_file=None,
+        ENVIRONMENT="production",
+        TRUSTED_HOSTS="worktime.tjor.im",
+        INTEGRATION_KEY_HASH_SECRET="test-secret",
+    )
     assert "localhost" in settings.get_trusted_hosts_list()
 
 
@@ -315,7 +324,12 @@ def test_trusted_hosts_separator_only_in_production_raises():
 
 def test_trusted_hosts_explicit_in_production_succeeds():
     """An explicit TRUSTED_HOSTS value starts normally in production."""
-    settings = Settings(_env_file=None, ENVIRONMENT="production", TRUSTED_HOSTS="worktime.tjor.im")
+    settings = Settings(
+        _env_file=None,
+        ENVIRONMENT="production",
+        TRUSTED_HOSTS="worktime.tjor.im",
+        INTEGRATION_KEY_HASH_SECRET="test-secret",
+    )
     assert settings.get_trusted_hosts_list() == ["worktime.tjor.im", "localhost"]
 
 

--- a/backend/tests/test_integration_clients.py
+++ b/backend/tests/test_integration_clients.py
@@ -19,17 +19,9 @@ from app.services.integration_client_service import (
     get_active_integration_client_by_key,
     hash_integration_key,
     list_integration_clients_for_user,
-    reset_rate_limit_state,
     revoke_integration_client,
     rotate_integration_client,
 )
-
-
-@pytest.fixture(autouse=True)
-def _reset_rate_limits():
-    reset_rate_limit_state()
-    yield
-    reset_rate_limit_state()
 
 
 async def test_create_integration_client_returns_raw_key_once(db_session: AsyncSession) -> None:
@@ -40,6 +32,26 @@ async def test_create_integration_client_returns_raw_key_once(db_session: AsyncS
     assert raw_key.startswith("wtic_")
     assert client.key_preview == raw_key[-4:]
     assert client.key_hash == hash_integration_key(raw_key)
+
+
+async def test_previous_hash_secret_is_upgraded_on_use(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.config import settings
+    from app.services import integration_client_service as service
+
+    user = await db_service.create_user(db_session, UserCreate(username="secret-owner", display_name="Secret Owner"))
+    raw_key = "wtic_previous_secret_key"
+    monkeypatch.setattr(settings, "INTEGRATION_KEY_HASH_SECRET", "current-secret")
+    monkeypatch.setattr(settings, "INTEGRATION_KEY_HASH_SECRET_PREVIOUS", "previous-secret")
+    client, _ = await create_integration_client(db_session, user.id, name="old-secret")
+    client.key_hash = service._hash_integration_key_with_secret(raw_key, "previous-secret")
+    await db_session.commit()
+
+    authenticated = await get_active_integration_client_by_key(db_session, raw_key)
+
+    assert authenticated is not None
+    assert authenticated.key_hash == hash_integration_key(raw_key)
     assert client.key_hash != raw_key
     assert client.scopes == ["worktime:mcp"]
     assert client.rate_limit_per_minute == 120
@@ -105,15 +117,18 @@ async def test_list_integration_clients_scoped_to_owner(db_session: AsyncSession
     assert [c.name for c in clients] == ["mine"]
 
 
-def test_rate_limit_enforced_then_recovers_with_fresh_window() -> None:
-    enforce_integration_client_rate_limit(client_id=1, rate_limit_per_minute=2)
-    enforce_integration_client_rate_limit(client_id=1, rate_limit_per_minute=2)
+async def test_rate_limit_enforced_per_client_in_database(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="rate-owner", display_name="Rate Owner"))
+    first, _ = await create_integration_client(db_session, user.id, name="first", rate_limit_per_minute=2)
+    second, _ = await create_integration_client(db_session, user.id, name="second", rate_limit_per_minute=1)
+
+    await enforce_integration_client_rate_limit(db_session, first.id)
+    await enforce_integration_client_rate_limit(db_session, first.id)
 
     with pytest.raises(RateLimitExceededError):
-        enforce_integration_client_rate_limit(client_id=1, rate_limit_per_minute=2)
+        await enforce_integration_client_rate_limit(db_session, first.id)
 
-    # A different client id has its own independent window.
-    enforce_integration_client_rate_limit(client_id=2, rate_limit_per_minute=1)
+    await enforce_integration_client_rate_limit(db_session, second.id)
 
 
 async def test_create_integration_client_endpoint_returns_key_and_hides_it_on_list(

--- a/backend/tests/test_integration_clients.py
+++ b/backend/tests/test_integration_clients.py
@@ -1,0 +1,223 @@
+"""Tests for managed integration clients (issue #1054)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas import UserCreate
+from app.services import db_service
+from app.services.db_service import NotFoundError
+from app.services.integration_client_service import (
+    ADMIN_SCOPE,
+    RateLimitExceededError,
+    create_integration_client,
+    enforce_integration_client_rate_limit,
+    get_active_integration_client_by_key,
+    hash_integration_key,
+    list_integration_clients_for_user,
+    reset_rate_limit_state,
+    revoke_integration_client,
+    rotate_integration_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limits():
+    reset_rate_limit_state()
+    yield
+    reset_rate_limit_state()
+
+
+async def test_create_integration_client_returns_raw_key_once(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="ic-owner", display_name="IC Owner"))
+
+    client, raw_key = await create_integration_client(db_session, user.id, name="home-assistant")
+
+    assert raw_key.startswith("wtic_")
+    assert client.key_preview == raw_key[-4:]
+    assert client.key_hash == hash_integration_key(raw_key)
+    assert client.key_hash != raw_key
+    assert client.scopes == ["worktime:mcp"]
+    assert client.rate_limit_per_minute == 120
+    assert client.is_active is True
+
+
+async def test_create_integration_client_rejects_unknown_scope(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="ic-badscope", display_name="Bad Scope"))
+
+    with pytest.raises(ValueError, match="unknown integration-client scope"):
+        await create_integration_client(db_session, user.id, name="bad", scopes=["not:a:real:scope"])
+
+
+async def test_create_integration_client_rejects_out_of_range_rate_limit(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="ic-badrate", display_name="Bad Rate"))
+
+    with pytest.raises(ValueError, match="rate_limit_per_minute"):
+        await create_integration_client(db_session, user.id, name="bad", rate_limit_per_minute=0)
+
+
+async def test_rotate_integration_client_invalidates_old_key(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="ic-rotate", display_name="Rotate"))
+    client, old_key = await create_integration_client(db_session, user.id, name="rotatable")
+
+    rotated_client, new_key = await rotate_integration_client(db_session, user.id, client.id)
+
+    assert rotated_client.id == client.id
+    assert new_key != old_key
+    assert await get_active_integration_client_by_key(db_session, old_key) is None
+    found = await get_active_integration_client_by_key(db_session, new_key)
+    assert found is not None
+    assert found.id == client.id
+
+
+async def test_revoke_integration_client_deactivates_it(db_session: AsyncSession) -> None:
+    user = await db_service.create_user(db_session, UserCreate(username="ic-revoke", display_name="Revoke"))
+    client, raw_key = await create_integration_client(db_session, user.id, name="revokable")
+
+    revoked = await revoke_integration_client(db_session, user.id, client.id)
+
+    assert revoked.is_active is False
+    assert revoked.revoked_at is not None
+    assert await get_active_integration_client_by_key(db_session, raw_key) is None
+
+
+async def test_revoke_integration_client_rejects_cross_user_access(db_session: AsyncSession) -> None:
+    owner = await db_service.create_user(db_session, UserCreate(username="ic-owner2", display_name="Owner"))
+    attacker = await db_service.create_user(db_session, UserCreate(username="ic-attacker", display_name="Attacker"))
+    client, _raw_key = await create_integration_client(db_session, owner.id, name="owned")
+
+    with pytest.raises(NotFoundError):
+        await revoke_integration_client(db_session, attacker.id, client.id)
+
+
+async def test_list_integration_clients_scoped_to_owner(db_session: AsyncSession) -> None:
+    owner = await db_service.create_user(db_session, UserCreate(username="ic-list-owner", display_name="Owner"))
+    other = await db_service.create_user(db_session, UserCreate(username="ic-list-other", display_name="Other"))
+    await create_integration_client(db_session, owner.id, name="mine")
+    await create_integration_client(db_session, other.id, name="not-mine")
+
+    clients = await list_integration_clients_for_user(db_session, owner.id)
+
+    assert [c.name for c in clients] == ["mine"]
+
+
+def test_rate_limit_enforced_then_recovers_with_fresh_window() -> None:
+    enforce_integration_client_rate_limit(client_id=1, rate_limit_per_minute=2)
+    enforce_integration_client_rate_limit(client_id=1, rate_limit_per_minute=2)
+
+    with pytest.raises(RateLimitExceededError):
+        enforce_integration_client_rate_limit(client_id=1, rate_limit_per_minute=2)
+
+    # A different client id has its own independent window.
+    enforce_integration_client_rate_limit(client_id=2, rate_limit_per_minute=1)
+
+
+async def test_create_integration_client_endpoint_returns_key_and_hides_it_on_list(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    admin_headers = auth_headers(user_id=1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "ic-rest-user")
+    headers = auth_headers(user_id=user_id)
+
+    response = db_client.post(
+        "/api/integration-clients",
+        json={"name": "home-assistant", "scopes": ["worktime:mcp"]},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["key"].startswith("wtic_")
+
+    list_response = db_client.get("/api/integration-clients", headers=headers)
+    assert list_response.status_code == 200
+    items = list_response.json()["items"]
+    assert len(items) == 1
+    assert "key" not in items[0]
+    assert items[0]["key_preview"] == body["key"][-4:]
+
+
+async def test_non_admin_cannot_grant_admin_scope_to_integration_client(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    admin_headers = auth_headers(user_id=1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "ic-nonadmin")
+    headers = auth_headers(user_id=user_id, is_admin=False)
+
+    response = db_client.post(
+        "/api/integration-clients",
+        json={"name": "escalated", "scopes": [ADMIN_SCOPE]},
+        headers=headers,
+    )
+
+    assert response.status_code == 403
+
+
+async def test_admin_can_grant_admin_scope_to_integration_client(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    admin_headers = auth_headers(user_id=1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "ic-admin")
+    headers = auth_headers(user_id=user_id, is_admin=True)
+
+    response = db_client.post(
+        "/api/integration-clients",
+        json={"name": "admin-client", "scopes": [ADMIN_SCOPE]},
+        headers=headers,
+    )
+
+    assert response.status_code == 201, response.text
+
+
+async def test_personal_access_token_cannot_manage_integration_clients(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    """A PAT session (require_oidc_principal boundary) must not reach these
+    management endpoints — the same structural boundary that keeps an MCP
+    integration credential from ever minting/escalating another one, since
+    neither is an interactive Keycloak session."""
+    admin_headers = auth_headers(user_id=1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "ic-pat-user")
+    pat_headers = auth_headers(user_id=user_id, via_pat=True)
+
+    response = db_client.post(
+        "/api/integration-clients",
+        json={"name": "via-pat"},
+        headers=pat_headers,
+    )
+
+    assert response.status_code == 403
+
+
+async def test_revoke_and_rotate_integration_client_endpoints(
+    db_client: TestClient,
+    auth_headers: Callable[..., dict[str, str]],
+    create_user_factory: Callable[..., int],
+) -> None:
+    admin_headers = auth_headers(user_id=1, is_admin=True)
+    user_id = create_user_factory(db_client, admin_headers, "ic-lifecycle")
+    headers = auth_headers(user_id=user_id)
+
+    created = db_client.post("/api/integration-clients", json={"name": "lifecycle"}, headers=headers).json()
+    client_id = created["id"]
+
+    rotate_response = db_client.post(f"/api/integration-clients/{client_id}/rotate", headers=headers)
+    assert rotate_response.status_code == 200
+    assert rotate_response.json()["key"] != created["key"]
+
+    revoke_response = db_client.delete(f"/api/integration-clients/{client_id}", headers=headers)
+    assert revoke_response.status_code == 204
+
+    missing_response = db_client.delete("/api/integration-clients/999999", headers=headers)
+    assert missing_response.status_code == 404

--- a/backend/tests/test_integration_clients.py
+++ b/backend/tests/test_integration_clients.py
@@ -121,14 +121,16 @@ async def test_rate_limit_enforced_per_client_in_database(db_session: AsyncSessi
     user = await db_service.create_user(db_session, UserCreate(username="rate-owner", display_name="Rate Owner"))
     first, _ = await create_integration_client(db_session, user.id, name="first", rate_limit_per_minute=2)
     second, _ = await create_integration_client(db_session, user.id, name="second", rate_limit_per_minute=1)
+    first_id = first.id
+    second_id = second.id
 
-    await enforce_integration_client_rate_limit(db_session, first.id)
-    await enforce_integration_client_rate_limit(db_session, first.id)
+    await enforce_integration_client_rate_limit(db_session, first_id)
+    await enforce_integration_client_rate_limit(db_session, first_id)
 
     with pytest.raises(RateLimitExceededError):
-        await enforce_integration_client_rate_limit(db_session, first.id)
+        await enforce_integration_client_rate_limit(db_session, first_id)
 
-    await enforce_integration_client_rate_limit(db_session, second.id)
+    await enforce_integration_client_rate_limit(db_session, second_id)
 
 
 async def test_create_integration_client_endpoint_returns_key_and_hides_it_on_list(

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -67,7 +67,20 @@ def test_redoc_docs(client):
 def test_404_handling(client):
     """Test that 404 errors are handled properly."""
     response = client.get("/nonexistent")
-    
+
     assert response.status_code == 404
     data = response.json()
     assert "detail" in data
+
+
+def test_mcp_capabilities_reports_disabled_with_empty_tools_when_unmounted(client):
+    """WORKTIME_MCP_BASE_URL is unset for the test app, so the MCP server isn't
+    mounted — the capability manifest must say so and list no tools, rather
+    than advertising tools that aren't actually reachable."""
+    response = client.get("/api/mcp/capabilities")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["enabled"] is False
+    assert data["mount_path"] == "/mcp"
+    assert data["tools"] == []

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -7,18 +7,21 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth import AccessToken, MultiAuth
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.mcp_server import (
+    MCP_TOOL_CAPABILITIES,
+    DbIntegrationClientVerifier,
     McpAuthError,
+    McpRateLimitError,
     WorktimeMcpBackend,
     _build_auth_provider,
     create_mcp_server,
 )
 from app.schemas import GanttTaskCreate, LabelCreate, TaskCreate, TimeOffEntryCreate, UserCreate
-from app.services import db_service
+from app.services import db_service, integration_client_service
 
 
 def _token_for_user(user_id: int, *, is_admin: bool = False) -> AccessToken:
@@ -48,13 +51,35 @@ def test_build_auth_provider_accepts_client_credentials_without_user_scopes(monk
     with patch("app.mcp_server.KeycloakAuthProvider") as provider:
         auth = _build_auth_provider()
 
-    assert auth is provider.return_value
+    # Always wrapped in MultiAuth: the DB-backed managed-integration-client
+    # verifier (issue #1054) runs unconditionally alongside Keycloak, even
+    # with no legacy WORKTIME_MCP_INTEGRATION_KEYS configured.
+    assert isinstance(auth, MultiAuth)
+    assert auth.server is provider.return_value
+    assert len(auth.verifiers) == 1
+    assert isinstance(auth.verifiers[0], DbIntegrationClientVerifier)
     provider.assert_called_once_with(
         realm_url="https://auth.example/realms/worktime",
         base_url="https://api.example/mcp",
         required_scopes=[],
         audience="worktime",
     )
+
+
+def test_build_auth_provider_adds_legacy_verifier_when_configured(monkeypatch) -> None:
+    """WORKTIME_MCP_INTEGRATION_KEYS still works, stacked on top of the DB verifier."""
+    from app.mcp_server import IntegrationKeyVerifier
+
+    monkeypatch.setenv("WORKTIME_MCP_BASE_URL", "https://api.example/mcp")
+    monkeypatch.setenv("WORKTIME_MCP_INTEGRATION_KEYS", "legacy-token=1:admin")
+
+    with patch("app.mcp_server.KeycloakAuthProvider"):
+        auth = _build_auth_provider()
+
+    assert isinstance(auth, MultiAuth)
+    assert len(auth.verifiers) == 2
+    assert isinstance(auth.verifiers[0], DbIntegrationClientVerifier)
+    assert isinstance(auth.verifiers[1], IntegrationKeyVerifier)
 
 
 async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) -> None:
@@ -89,6 +114,24 @@ async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) 
         "update_gantt_task",
         "delete_gantt_task",
     }
+
+
+async def test_capability_manifest_cannot_drift_from_registered_tools(test_db: AsyncEngine) -> None:
+    """MCP_TOOL_CAPABILITIES is the single source of truth create_mcp_server()
+    registers tools from — this asserts that guarantee holds, and also
+    that every capability entry has a sane effect/tier."""
+    server = create_mcp_server(session_factory=_make_factory(test_db))
+    tools = await server.list_tools(run_middleware=False)
+    tool_names = {tool.name for tool in tools}
+
+    assert tool_names == set(MCP_TOOL_CAPABILITIES)
+    for name, capability in MCP_TOOL_CAPABILITIES.items():
+        assert capability.required_tier in ("owner", "admin"), name
+        # No tool today accepts a target user id, so none should claim
+        # admin_write or an "admin" tier — this is a current-state fact this
+        # test pins down so a future admin-scoped tool has to update it
+        # deliberately rather than silently mis-tagging itself.
+        assert capability.required_tier == "owner", name
 
 
 async def test_whoami_and_time_tracking_summary_happy_path(
@@ -959,3 +1002,190 @@ value_date=date(2026, 5, 1),
     entry = lines[-1]
     assert entry["action"] == "set_work_location"
     assert f"user:{user.id}" in entry["target"]
+
+
+async def test_write_tools_produce_transactional_db_audit_entries(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Write tools stage a durable AuditEntry row in the same transaction as
+    the mutation (issue #1054) — the authoritative record, distinct from the
+    best-effort file logger covered above."""
+    from sqlalchemy import select
+
+    from app.database.models import AuditEntry
+
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="db-audit-user", display_name="DB Audit User")
+        )
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
+
+    payload = await backend.set_work_location(value_date=date(2026, 5, 1), country_code="DE")
+
+    async with session_factory() as session:
+        result = await session.execute(
+            select(AuditEntry).where(AuditEntry.resource_type == "work_location")
+        )
+        entries = list(result.scalars().all())
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.action == "create_or_update_work_location"
+    assert entry.resource_id == "2026-05-01"
+    assert entry.actor_user_id == user.id
+    assert entry.auth_source == "oidc"
+    assert payload["country_code"] == "DE"
+
+
+async def test_whoami_includes_integration_client_identity_when_present(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """whoami surfaces the managed integration client's id/name/scopes — never
+    raw key material, which the server never has after creation anyway."""
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="ic-whoami-user", display_name="IC Whoami")
+        )
+
+    token = AccessToken(
+        token="wtic_sometoken",
+        client_id="integration-client-7",
+        scopes=["worktime:mcp"],
+        claims={
+            "worktime_user_id": user.id,
+            "worktime_is_admin": False,
+            "sub": "integration-client:7",
+            "auth_type": "integration_client",
+            "worktime_integration_client_id": 7,
+            "worktime_integration_client_name": "home-assistant",
+            "worktime_integration_client_scopes": ["worktime:mcp"],
+            "worktime_integration_client_rate_limit_per_minute": 1000,
+        },
+    )
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: token)
+
+    payload = await backend.whoami()
+
+    assert payload["auth_type"] == "integration_client"
+    assert payload["integration_client"] == {
+        "id": 7,
+        "name": "home-assistant",
+        "scopes": ["worktime:mcp"],
+    }
+
+
+async def test_whoami_omits_integration_client_for_regular_users(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="plain-whoami-user", display_name="Plain")
+        )
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
+
+    payload = await backend.whoami()
+
+    assert payload["integration_client"] is None
+
+
+async def test_resolve_context_enforces_integration_client_rate_limit(
+    test_db: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An integration client exceeding its configured per-minute budget gets a
+    clear McpRateLimitError instead of a silent failure or unlimited access."""
+    integration_client_service.reset_rate_limit_state()
+    session_factory = _make_factory(test_db)
+    backend = WorktimeMcpBackend(session_factory)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="rate-limited-user", display_name="Rate Limited")
+        )
+
+    token = AccessToken(
+        token="wtic_ratelimited",
+        client_id="integration-client-99",
+        scopes=["worktime:mcp"],
+        claims={
+            "worktime_user_id": user.id,
+            "worktime_is_admin": False,
+            "sub": "integration-client:99",
+            "auth_type": "integration_client",
+            "worktime_integration_client_id": 99,
+            "worktime_integration_client_name": "throttled-bot",
+            "worktime_integration_client_scopes": ["worktime:mcp"],
+            "worktime_integration_client_rate_limit_per_minute": 2,
+        },
+    )
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: token)
+
+    async with session_factory() as session:
+        await backend.resolve_context(session)
+    async with session_factory() as session:
+        await backend.resolve_context(session)
+
+    async with session_factory() as session:
+        with pytest.raises(McpRateLimitError, match="rate limit"):
+            await backend.resolve_context(session)
+
+    integration_client_service.reset_rate_limit_state()
+
+
+async def test_db_integration_client_verifier_accepts_active_client(
+    test_db: AsyncEngine,
+) -> None:
+    session_factory = _make_factory(test_db)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="verifier-user", display_name="Verifier")
+        )
+        client, raw_key = await integration_client_service.create_integration_client(
+            session, user.id, name="test-client"
+        )
+
+    verifier = DbIntegrationClientVerifier(session_factory)
+    access_token = await verifier.verify_token(raw_key)
+
+    assert access_token is not None
+    assert access_token.claims["worktime_user_id"] == user.id
+    assert access_token.claims["worktime_integration_client_id"] == client.id
+    assert access_token.claims["auth_type"] == "integration_client"
+    assert access_token.claims["worktime_is_admin"] is False
+
+
+async def test_db_integration_client_verifier_rejects_unknown_and_revoked(
+    test_db: AsyncEngine,
+) -> None:
+    session_factory = _make_factory(test_db)
+    verifier = DbIntegrationClientVerifier(session_factory)
+
+    assert await verifier.verify_token("wtic_unknown-key-value") is None
+    # Not our prefix at all — must not be confused with an OIDC bearer token.
+    assert await verifier.verify_token("some-other-bearer-token") is None
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="revoked-verifier-user", display_name="Revoked")
+        )
+        client, raw_key = await integration_client_service.create_integration_client(
+            session, user.id, name="to-revoke"
+        )
+        await integration_client_service.revoke_integration_client(session, user.id, client.id)
+
+    assert await verifier.verify_token(raw_key) is None

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -15,7 +15,6 @@ from app.mcp_server import (
     MCP_TOOL_CAPABILITIES,
     DbIntegrationClientVerifier,
     McpAuthError,
-    McpRateLimitError,
     WorktimeMcpBackend,
     _build_auth_provider,
     create_mcp_server,
@@ -392,7 +391,7 @@ async def test_start_and_stop_time_entry(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     start_payload = await backend.start_time_entry(
-text="Working on feature",
+        text="Working on feature",
         start_time=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
     )
     assert start_payload["text"] == "Working on feature"
@@ -400,7 +399,7 @@ text="Working on feature",
     assert start_payload["user_id"] == user.id
 
     stop_payload = await backend.stop_time_entry(
-stop_time=datetime(2026, 5, 1, 10, 30, tzinfo=UTC),
+        stop_time=datetime(2026, 5, 1, 10, 30, tzinfo=UTC),
     )
     assert stop_payload["id"] == start_payload["id"]
     assert stop_payload["stop_time"] is not None
@@ -426,13 +425,13 @@ async def test_start_time_entry_blocks_second_running_task(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     await backend.start_time_entry(
-text="First task",
+        text="First task",
         start_time=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
     )
 
     with pytest.raises(ValueError, match="only one running task"):
         await backend.start_time_entry(
-        text="Second task",
+            text="Second task",
             start_time=datetime(2026, 5, 1, 9, 30, tzinfo=UTC),
         )
 
@@ -480,7 +479,7 @@ async def test_create_time_tracking_task(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     payload = await backend.create_time_tracking_task(
-text="Completed task",
+        text="Completed task",
         start_time=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
         stop_time=datetime(2026, 5, 1, 11, 0, tzinfo=UTC),
         includes_break=True,
@@ -521,7 +520,7 @@ async def test_update_time_tracking_task(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     updated = await backend.update_time_tracking_task(
-task_id=task.id,
+        task_id=task.id,
         text="Updated text",
     )
     assert updated["text"] == "Updated text"
@@ -559,7 +558,7 @@ async def test_update_time_tracking_task_unauthorized(
 
     with pytest.raises(ValueError):
         await backend.update_time_tracking_task(
-        task_id=task.id,
+            task_id=task.id,
             text="Hacked",
         )
 
@@ -586,7 +585,7 @@ async def test_create_update_delete_time_tracking_task(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     created = await backend.create_time_tracking_task(
-text="Task to delete",
+        text="Task to delete",
         start_time=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
         stop_time=datetime(2026, 5, 1, 10, 0, tzinfo=UTC),
     )
@@ -594,13 +593,13 @@ text="Task to delete",
     task_id = created["id"]
 
     updated = await backend.update_time_tracking_task(
-task_id=task_id,
+        task_id=task_id,
         text="Updated before delete",
     )
     assert updated["text"] == "Updated before delete"
 
     deleted = await backend.delete_time_tracking_task(
-task_id=task_id,
+        task_id=task_id,
     )
     assert deleted["deleted"] is True
     assert deleted["task_id"] == task_id
@@ -622,9 +621,7 @@ async def test_delete_time_tracking_task_unauthorized(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        owner = await db_service.create_user(
-            session, UserCreate(username="task-owner", display_name="Task Owner")
-        )
+        owner = await db_service.create_user(session, UserCreate(username="task-owner", display_name="Task Owner"))
         attacker = await db_service.create_user(
             session, UserCreate(username="task-attacker", display_name="Task Attacker")
         )
@@ -664,7 +661,7 @@ async def test_set_work_location(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     payload = await backend.set_work_location(
-value_date=date(2026, 5, 1),
+        value_date=date(2026, 5, 1),
         country_code="BE",
         label="HQ",
     )
@@ -674,7 +671,7 @@ value_date=date(2026, 5, 1),
 
     # Idempotent: calling again overwrites
     payload2 = await backend.set_work_location(
-value_date=date(2026, 5, 1),
+        value_date=date(2026, 5, 1),
         country_code="NL",
     )
     assert payload2["country_code"] == "NL"
@@ -700,12 +697,12 @@ async def test_delete_work_location(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     await backend.set_work_location(
-value_date=date(2026, 5, 1),
+        value_date=date(2026, 5, 1),
         country_code="BE",
     )
 
     deleted = await backend.delete_work_location(
-value_date=date(2026, 5, 1),
+        value_date=date(2026, 5, 1),
     )
     assert deleted["deleted"] is True
     assert deleted["date"] == "2026-05-01"
@@ -713,7 +710,7 @@ value_date=date(2026, 5, 1),
 
     with pytest.raises(ValueError):
         await backend.delete_work_location(
-        value_date=date(2026, 5, 1),
+            value_date=date(2026, 5, 1),
         )
 
 
@@ -738,7 +735,7 @@ async def test_set_work_location_invalid_country(
 
     with pytest.raises(ValidationError):
         await backend.set_work_location(
-        value_date=date(2026, 5, 1),
+            value_date=date(2026, 5, 1),
             country_code="ZZ",
         )
 
@@ -763,7 +760,7 @@ async def test_create_update_delete_time_off_event(
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     created = await backend.create_time_off_event(
-entry_kind="date",
+        entry_kind="date",
         entry_type="vacation",
         date=date(2026, 8, 1),
         note="Summer holiday",
@@ -773,13 +770,13 @@ entry_kind="date",
     entry_id = created["entry_id"]
 
     updated = await backend.update_time_off_event(
-entry_id=entry_id,
+        entry_id=entry_id,
         note="Summer holiday (updated)",
     )
     assert updated["note"] == "Summer holiday (updated)"
 
     deleted = await backend.delete_time_off_event(
-entry_id=entry_id,
+        entry_id=entry_id,
     )
     assert deleted["deleted"] is True
     assert deleted["entry_id"] == entry_id
@@ -800,20 +797,18 @@ async def test_create_time_off_event_idempotent_with_entry_id(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="idempotent-user", display_name="Idempotent")
-        )
+        user = await db_service.create_user(session, UserCreate(username="idempotent-user", display_name="Idempotent"))
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     first = await backend.create_time_off_event(
-entry_kind="date",
+        entry_kind="date",
         entry_type="vacation",
         date=date(2026, 9, 1),
         entry_id="fixed-entry-id",
     )
     second = await backend.create_time_off_event(
-entry_kind="date",
+        entry_kind="date",
         entry_type="ill",
         date=date(2026, 9, 1),
         entry_id="fixed-entry-id",
@@ -837,12 +832,8 @@ async def test_delete_time_off_event_unauthorized(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        owner = await db_service.create_user(
-            session, UserCreate(username="to-owner", display_name="TO Owner")
-        )
-        attacker = await db_service.create_user(
-            session, UserCreate(username="to-attacker", display_name="TO Attacker")
-        )
+        owner = await db_service.create_user(session, UserCreate(username="to-owner", display_name="TO Owner"))
+        attacker = await db_service.create_user(session, UserCreate(username="to-attacker", display_name="TO Attacker"))
         entry, _ = await db_service.create_or_update_time_off_entry(
             session,
             owner.id,
@@ -870,14 +861,12 @@ async def test_create_update_delete_gantt_task(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="gantt-user", display_name="Gantt User")
-        )
+        user = await db_service.create_user(session, UserCreate(username="gantt-user", display_name="Gantt User"))
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     created = await backend.create_gantt_task(
-name="Sprint 1",
+        name="Sprint 1",
         start_date=date(2026, 6, 1),
         end_date=date(2026, 6, 14),
         progress=0,
@@ -887,7 +876,7 @@ name="Sprint 1",
     task_id = created["id"]
 
     updated = await backend.update_gantt_task(
-task_id=task_id,
+        task_id=task_id,
         progress=50,
         notes="Halfway done",
     )
@@ -895,7 +884,7 @@ task_id=task_id,
     assert updated["notes"] == "Halfway done"
 
     deleted = await backend.delete_gantt_task(
-task_id=task_id,
+        task_id=task_id,
     )
     assert deleted["deleted"] is True
     assert deleted["task_id"] == task_id
@@ -916,15 +905,13 @@ async def test_create_gantt_task_invalid_date_range(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="gantt-invalid", display_name="Gantt Invalid")
-        )
+        user = await db_service.create_user(session, UserCreate(username="gantt-invalid", display_name="Gantt Invalid"))
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     with pytest.raises(ValidationError):
         await backend.create_gantt_task(
-        name="Bad range",
+            name="Bad range",
             start_date=date(2026, 6, 14),
             end_date=date(2026, 6, 1),
         )
@@ -945,9 +932,7 @@ async def test_delete_gantt_task_unauthorized(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        owner = await db_service.create_user(
-            session, UserCreate(username="gantt-owner", display_name="Gantt Owner")
-        )
+        owner = await db_service.create_user(session, UserCreate(username="gantt-owner", display_name="Gantt Owner"))
         attacker = await db_service.create_user(
             session, UserCreate(username="gantt-attacker", display_name="Gantt Attacker")
         )
@@ -981,14 +966,12 @@ async def test_write_tools_produce_audit_log_entries(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="audit-user", display_name="Audit User")
-        )
+        user = await db_service.create_user(session, UserCreate(username="audit-user", display_name="Audit User"))
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     await backend.set_work_location(
-value_date=date(2026, 5, 1),
+        value_date=date(2026, 5, 1),
         country_code="DE",
     )
     # append() dispatches the file write to a background thread when called
@@ -1019,18 +1002,14 @@ async def test_write_tools_produce_transactional_db_audit_entries(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="db-audit-user", display_name="DB Audit User")
-        )
+        user = await db_service.create_user(session, UserCreate(username="db-audit-user", display_name="DB Audit User"))
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
     payload = await backend.set_work_location(value_date=date(2026, 5, 1), country_code="DE")
 
     async with session_factory() as session:
-        result = await session.execute(
-            select(AuditEntry).where(AuditEntry.resource_type == "work_location")
-        )
+        result = await session.execute(select(AuditEntry).where(AuditEntry.resource_type == "work_location"))
         entries = list(result.scalars().all())
 
     assert len(entries) == 1
@@ -1052,9 +1031,7 @@ async def test_whoami_includes_integration_client_identity_when_present(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="ic-whoami-user", display_name="IC Whoami")
-        )
+        user = await db_service.create_user(session, UserCreate(username="ic-whoami-user", display_name="IC Whoami"))
 
     token = AccessToken(
         token="wtic_sometoken",
@@ -1091,9 +1068,7 @@ async def test_whoami_omits_integration_client_for_regular_users(
     backend = WorktimeMcpBackend(session_factory)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="plain-whoami-user", display_name="Plain")
-        )
+        user = await db_service.create_user(session, UserCreate(username="plain-whoami-user", display_name="Plain"))
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
 
@@ -1102,59 +1077,13 @@ async def test_whoami_omits_integration_client_for_regular_users(
     assert payload["integration_client"] is None
 
 
-async def test_resolve_context_enforces_integration_client_rate_limit(
-    test_db: AsyncEngine,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An integration client exceeding its configured per-minute budget gets a
-    clear McpRateLimitError instead of a silent failure or unlimited access."""
-    integration_client_service.reset_rate_limit_state()
-    session_factory = _make_factory(test_db)
-    backend = WorktimeMcpBackend(session_factory)
-
-    async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="rate-limited-user", display_name="Rate Limited")
-        )
-
-    token = AccessToken(
-        token="wtic_ratelimited",
-        client_id="integration-client-99",
-        scopes=["worktime:mcp"],
-        claims={
-            "worktime_user_id": user.id,
-            "worktime_is_admin": False,
-            "sub": "integration-client:99",
-            "auth_type": "integration_client",
-            "worktime_integration_client_id": 99,
-            "worktime_integration_client_name": "throttled-bot",
-            "worktime_integration_client_scopes": ["worktime:mcp"],
-            "worktime_integration_client_rate_limit_per_minute": 2,
-        },
-    )
-    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: token)
-
-    async with session_factory() as session:
-        await backend.resolve_context(session)
-    async with session_factory() as session:
-        await backend.resolve_context(session)
-
-    async with session_factory() as session:
-        with pytest.raises(McpRateLimitError, match="rate limit"):
-            await backend.resolve_context(session)
-
-    integration_client_service.reset_rate_limit_state()
-
-
 async def test_db_integration_client_verifier_accepts_active_client(
     test_db: AsyncEngine,
 ) -> None:
     session_factory = _make_factory(test_db)
 
     async with session_factory() as session:
-        user = await db_service.create_user(
-            session, UserCreate(username="verifier-user", display_name="Verifier")
-        )
+        user = await db_service.create_user(session, UserCreate(username="verifier-user", display_name="Verifier"))
         client, raw_key = await integration_client_service.create_integration_client(
             session, user.id, name="test-client"
         )
@@ -1183,9 +1112,7 @@ async def test_db_integration_client_verifier_rejects_unknown_and_revoked(
         user = await db_service.create_user(
             session, UserCreate(username="revoked-verifier-user", display_name="Revoked")
         )
-        client, raw_key = await integration_client_service.create_integration_client(
-            session, user.id, name="to-revoke"
-        )
+        client, raw_key = await integration_client_service.create_integration_client(session, user.id, name="to-revoke")
         await integration_client_service.revoke_integration_client(session, user.id, client.id)
 
     assert await verifier.verify_token(raw_key) is None

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -39,6 +39,14 @@ credential via this endpoint. Every client is also rate-limited
 per-minute (`rate_limit_per_minute`); calls beyond the limit fail with a
 clear error instead of a silent 429 (MCP tool calls are JSON-RPC, not HTTP).
 
+### Rotate the managed-key hashing secret
+
+Set the new `INTEGRATION_KEY_HASH_SECRET` and temporarily retain the old value
+as `INTEGRATION_KEY_HASH_SECRET_PREVIOUS`. Credentials verified with the old
+secret are rehashed with the current secret on successful use. Remove the
+previous value after every active client has authenticated or after the
+operator-defined overlap window; only one previous secret is accepted.
+
 ### Legacy static integration keys (deprecated, still supported)
 
 `WORKTIME_MCP_INTEGRATION_KEYS` — a comma-separated `token=user_id` or
@@ -49,7 +57,9 @@ process, so treat any configured value as a credential that needs manual
 lifecycle management. New integrations should provision a managed
 integration client instead; existing `WORKTIME_MCP_INTEGRATION_KEYS`
 deployments should migrate off it before its removal (tracked in a future
-issue — this env var is not being silently dropped in the meantime).
+issue). Support ends with the first Worktime release on or after **2026-11-01**;
+that release will refuse `WORKTIME_MCP_INTEGRATION_KEYS` and operators must
+provision managed clients before upgrading.
 
 Example (legacy, deprecated):
 

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -1,6 +1,10 @@
 # Local Worktime MCP Server
 
-Worktime now ships a FastMCP v3 server in `backend/app/mcp_server.py` with read-only tools for schedule/work status queries.
+Worktime ships a FastMCP v3 server in `backend/app/mcp_server.py` — split into
+a thin assembler (auth, tool registration) plus focused domain modules under
+`backend/app/mcp/` (identity, schedule, time_tracking, work_location,
+time_off, gantt) — exposing both read tools and personal write tools scoped
+to the authenticated caller's own data.
 
 ## Prerequisites
 
@@ -12,12 +16,42 @@ uv run alembic upgrade head
 
 Configure backend auth as usual (`OIDC_ISSUER_URL`, optional `OIDC_AUDIENCE`, etc).
 
-Optional integration-key auth for local automation:
+## Automation credentials (managed integration clients)
 
-- `WORKTIME_MCP_INTEGRATION_KEYS` format: `token=user_id` or `token=user_id:admin`
-- Multiple entries: comma-separated
+Automation callers (e.g. a home automation hub, a personal script) authenticate
+with a **managed integration client** instead of an interactive OIDC login:
 
-Example:
+1. Sign in normally and create one via `POST /api/integration-clients`
+   (`name`, optional `scopes` — defaults to `["worktime:mcp"]` — and
+   `rate_limit_per_minute`, default 120). The response includes the raw key
+   **once**; only its hash is stored server-side.
+2. Use that key as the MCP client's Bearer token.
+3. List (`GET /api/integration-clients`), rotate
+   (`POST /api/integration-clients/{id}/rotate`), or revoke
+   (`DELETE /api/integration-clients/{id}`) at any time — no server restart
+   required. A revoked/rotated-away key stops working on its very next call.
+
+`worktime:admin` is a separate, deliberate scope — granting it requires the
+requesting Keycloak session to already be an admin; a non-admin caller (and,
+structurally, any integration-client or personal-access-token caller — see
+`backend/app/routers/integration_clients.py`) cannot mint or escalate a
+credential via this endpoint. Every client is also rate-limited
+per-minute (`rate_limit_per_minute`); calls beyond the limit fail with a
+clear error instead of a silent 429 (MCP tool calls are JSON-RPC, not HTTP).
+
+### Legacy static integration keys (deprecated, still supported)
+
+`WORKTIME_MCP_INTEGRATION_KEYS` — a comma-separated `token=user_id` or
+`token=user_id:admin` env var parsed once at process startup — still works
+alongside managed integration clients, for a migration/overlap period. It has
+**no rotation or revocation** short of removing the entry and restarting the
+process, so treat any configured value as a credential that needs manual
+lifecycle management. New integrations should provision a managed
+integration client instead; existing `WORKTIME_MCP_INTEGRATION_KEYS`
+deployments should migrate off it before its removal (tracked in a future
+issue — this env var is not being silently dropped in the meantime).
+
+Example (legacy, deprecated):
 
 ```bash
 export WORKTIME_MCP_INTEGRATION_KEYS="local-agent-token=1:admin"
@@ -62,15 +96,50 @@ uv run python -m app.mcp_server
 }
 ```
 
-## Exposed read-only tools
+## Capability discovery
 
-- `whoami`
+`GET /api/mcp/capabilities` returns the authoritative, drift-proof list of
+registered tools (sourced directly from `app.mcp_server.MCP_TOOL_CAPABILITIES`,
+the same dict used to register tools), each tagged with its side-effect
+classification (`read` / `personal_write` / `admin_write`) and required
+ownership tier (`owner` / `admin`). Use it instead of trusting this table if
+the two ever appear to disagree — this doc can drift; that endpoint cannot.
+
+## Exposed read tools
+
+- `whoami` — includes managed integration-client identity/scopes when the
+  caller authenticated that way (never raw key material)
 - `get_current_status`
 - `get_next_shift`
 - `get_team_status`
+- `get_next_shifts_for_team`
 - `get_time_off_summary`
-- `get_hday_events`
 - `get_work_location_summary`
 - `get_time_tracking_summary`
+- `list_labels`
 - `get_gantt_tasks`
 - `get_sync_status`
+
+## Exposed write tools
+
+All write tools are scoped to the authenticated caller's own data (no tool
+accepts a target user id) and share Worktime's domain-error mapping — a
+`ConflictError`/`NotFoundError`/`ValidationError` from the underlying service
+surfaces as a `ValueError` with the original, actionable message.
+
+- `delete_label`
+- `start_time_entry` / `stop_time_entry`
+- `create_time_tracking_task` / `update_time_tracking_task` / `delete_time_tracking_task`
+- `set_work_location` / `delete_work_location`
+- `create_time_off_event` / `update_time_off_event` / `delete_time_off_event`
+- `create_gantt_task` / `update_gantt_task` / `delete_gantt_task`
+
+## Mutation audit trail
+
+Every write tool call (and its REST equivalent) writes a durable audit entry
+in the *same* database transaction as the mutation itself — see
+`backend/app/audit/db.py`. Read it back via `GET /api/audit` (bounded,
+`(created_at, id)`-ordered, own trail for non-admins, any/all with admin
+scope). The rotated file logger from #984 (`backend/app/audit/logger.py`)
+keeps running as secondary, best-effort operational telemetry; it is not the
+authoritative record.


### PR DESCRIPTION
Issue #1054: Replace static WORKTIME_MCP_INTEGRATION_KEYS with revocable, rotatable, per-user managed integration clients stored in the database. Add a durable, transactional audit trail (audit_entries table) where mutations are recorded in the same transaction as the mutation itself, providing an authoritative record alongside the existing file logger.

Key changes:
- New IntegrationClient model with per-client rate limiting and lifecycle management (create, rotate, revoke)
- New AuditEntry model and audit.db module for transactional audit staging
- REST endpoints: POST/GET/DELETE /api/integration-clients (managed credentials), GET /api/audit (read trail)
- Refactor MCP server into focused domain modules under app/mcp/ (identity, schedule, time_tracking, work_location, time_off, gantt) while keeping app/mcp_server.py as the thin assembler
- DbIntegrationClientVerifier for FastMCP token verification alongside legacy IntegrationKeyVerifier during migration period
- Add INTEGRATION_KEY_HASH_SECRET config setting with production validation
- All write operations now stage audit entries; non-admin callers see only their own trail, admins see team-wide or filtered views
- Update docs/integrations/LOCAL_MCP_SERVER.md with managed client provisioning flow and capability discovery endpoint