### PR TITLE
Upgrade MCP server to FastMCP v4 and remove static keys

### DIFF
--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -347,9 +347,8 @@ class CachedHoliday(Base):
 class IntegrationClient(Base):
     """Managed, database-backed credential for automation/integration callers (e.g. MCP).
 
-    Replaces the long-lived static-token map previously parsed once from
-    ``WORKTIME_MCP_INTEGRATION_KEYS`` at process startup. Each row is a
-    revocable, rotatable, rate-limited credential bound to one Worktime user.
+    Each row is a revocable, rotatable, rate-limited credential bound to one
+    Worktime user.
     Only the HMAC hash of the raw key is stored (see
     ``app.services.integration_client_service.hash_integration_key``); the raw
     value is returned once at creation/rotation time and cannot be recovered.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,7 +40,7 @@ if _worktime_mcp_base_url:
     from .mcp_server import create_mcp_server as _create_mcp_server
 
     _mcp = _create_mcp_server()
-    _mcp_app = _mcp.http_app(path="/")
+    _mcp_app = _mcp.http_app(path="/", stateless_http=True)
 else:
     from .mcp_server import MCP_TOOL_CAPABILITIES as _MCP_TOOL_CAPABILITIES
 
@@ -242,16 +242,19 @@ async def mcp_capabilities() -> dict[str, object]:
     return {
         "enabled": enabled,
         "mount_path": "/mcp",
+        "version": _mcp.version if _mcp is not None else None,
         "tools": [
             {
                 "name": name,
-                "side_effect": capability.effect.value,
+                "effect": capability.effect.value,
                 "required_tier": capability.required_tier,
             }
-            for name, capability in _MCP_TOOL_CAPABILITIES.items()
+            for name, capability in sorted(_MCP_TOOL_CAPABILITIES.items())
         ]
         if enabled
         else [],
+        "resources": [],
+        "prompts": [],
     }
 
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -26,6 +26,7 @@ from fastmcp.server.auth import AccessToken, MultiAuth
 from fastmcp.server.auth.auth import TokenVerifier
 from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
 from fastmcp.server.dependencies import get_access_token
+from mcp.types import ToolAnnotations
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -55,76 +56,6 @@ __all__ = [
     "WorktimeMcpBackend",
     "create_mcp_server",
 ]
-
-
-class IntegrationKeyVerifier(TokenVerifier):
-    """Accept legacy static integration keys mapped to local users.
-
-    Deprecated (issue #1054): superseded by ``DbIntegrationClientVerifier``,
-    which looks up revocable, rotatable, rate-limited credentials in the
-    database instead of a fixed in-memory map parsed once at startup. This
-    verifier keeps running, alongside the new one, only while
-    ``WORKTIME_MCP_INTEGRATION_KEYS`` is set, for a documented migration
-    overlap period — see docs/integrations/LOCAL_MCP_SERVER.md for the
-    end-of-support plan. New integrations should provision a managed
-    integration client instead of a static key.
-    """
-
-    def __init__(self, key_mapping: dict[str, tuple[int, bool]]) -> None:
-        self._key_mapping = key_mapping
-
-    async def verify_token(self, token: str) -> AccessToken | None:
-        mapping = self._key_mapping.get(token)
-        if mapping is None:
-            return None
-
-        user_id, is_admin = mapping
-        return AccessToken(
-            token=token,
-            client_id=f"integration-user-{user_id}",
-            scopes=["worktime:mcp"],
-            claims={
-                "worktime_user_id": user_id,
-                "worktime_is_admin": is_admin,
-                "sub": f"integration-key:{user_id}",
-                "auth_type": "integration_key",
-            },
-        )
-
-
-def _parse_integration_key_mapping(value: str) -> dict[str, tuple[int, bool]]:
-    """Parse WORKTIME_MCP_INTEGRATION_KEYS into a token->(user_id,is_admin) map.
-
-    Format:
-      token=user_id
-      token=user_id:admin
-      token=user_id:user
-    Multiple entries are comma-separated.
-
-    Deprecated (issue #1054): this static, long-lived credential store has no
-    rotation or revocation short of removing the entry and restarting the
-    process. Prefer a managed integration client (``/api/integration-clients``,
-    ``app.services.integration_client_service``), which is DB-backed,
-    per-client rate-limited, and can be revoked or rotated without a
-    restart. WORKTIME_MCP_INTEGRATION_KEYS keeps working for now — see
-    docs/integrations/LOCAL_MCP_SERVER.md for the migration/overlap plan —
-    but new integrations should not adopt it.
-    """
-    mapping: dict[str, tuple[int, bool]] = {}
-    for item in (part.strip() for part in value.split(",") if part.strip()):
-        token, sep, raw_target = item.partition("=")
-        if not sep:
-            continue
-
-        user_part, role_sep, role = raw_target.partition(":")
-        try:
-            user_id = int(user_part)
-        except ValueError:
-            continue
-
-        is_admin = role_sep == ":" and role.strip().lower() == "admin"
-        mapping[token.strip()] = (user_id, is_admin)
-    return mapping
 
 
 class DbIntegrationClientVerifier(TokenVerifier):
@@ -176,13 +107,7 @@ class DbIntegrationClientVerifier(TokenVerifier):
 def _build_auth_provider(
     session_factory: async_sessionmaker[AsyncSession] | None = None,
 ) -> KeycloakAuthProvider | MultiAuth:
-    """Build FastMCP auth provider: Keycloak + managed integration clients (+ legacy static keys).
-
-    The DB-backed ``DbIntegrationClientVerifier`` runs unconditionally
-    alongside Keycloak. The legacy ``IntegrationKeyVerifier`` is added on top,
-    for the documented migration/overlap period, only when
-    ``WORKTIME_MCP_INTEGRATION_KEYS`` is set — see docs/integrations/LOCAL_MCP_SERVER.md.
-    """
+    """Build the FastMCP auth provider from Keycloak and managed clients."""
     base_url = os.environ.get("WORKTIME_MCP_BASE_URL", "http://localhost:8000/mcp")
     realm_url = os.environ.get("WORKTIME_MCP_KEYCLOAK_REALM_URL", settings.OIDC_ISSUER_URL)
     audience = settings.OIDC_AUDIENCE or None
@@ -194,20 +119,8 @@ def _build_auth_provider(
         audience=audience,
     )
 
-    verifiers: list[TokenVerifier] = [DbIntegrationClientVerifier(session_factory or get_session_factory())]
-
-    integration_keys = _parse_integration_key_mapping(os.environ.get("WORKTIME_MCP_INTEGRATION_KEYS", ""))
-    if integration_keys:
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "WORKTIME_MCP_INTEGRATION_KEYS is deprecated and will be removed in the next "
-            "release — migrate to managed integration clients (POST /api/integration-clients) "
-            "before the overlap period ends. See docs/integrations/LOCAL_MCP_SERVER.md."
-        )
-        verifiers.append(IntegrationKeyVerifier(integration_keys))
-
-    return MultiAuth(server=keycloak, verifiers=verifiers)
+    verifier = DbIntegrationClientVerifier(session_factory or get_session_factory())
+    return MultiAuth(server=keycloak, verifiers=[verifier])
 
 
 class WorktimeMcpBackend:
@@ -605,6 +518,24 @@ MCP_TOOL_CAPABILITIES: dict[str, ToolCapability] = {
 }
 
 
+def tool_annotations(tool_name: str) -> ToolAnnotations:
+    """Return explicit MCP safety metadata for ChatGPT and other clients."""
+    capability = MCP_TOOL_CAPABILITIES.get(tool_name)
+    if capability is not None and capability.effect is ToolEffect.READ:
+        return ToolAnnotations(
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+            open_world_hint=False,
+        )
+
+    return ToolAnnotations(
+        read_only_hint=False,
+        destructive_hint=not tool_name.startswith("create_"),
+        open_world_hint=False,
+    )
+
+
 def create_mcp_server(
     session_factory: async_sessionmaker[AsyncSession] | None = None,
 ) -> FastMCP:
@@ -618,7 +549,7 @@ def create_mcp_server(
     )
 
     for tool_name in MCP_TOOL_CAPABILITIES:
-        server.tool(name=tool_name)(getattr(backend, tool_name))
+        server.tool(name=tool_name, annotations=tool_annotations(tool_name))(getattr(backend, tool_name))
 
     return server
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -11,7 +11,6 @@ delegate to — mirroring champagnefestival's ``app/mcp/`` package shape.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 from collections.abc import AsyncGenerator
@@ -22,8 +21,7 @@ from enum import StrEnum
 from typing import Any
 
 from fastmcp import FastMCP
-from fastmcp.server.auth import AccessToken, MultiAuth
-from fastmcp.server.auth.auth import TokenVerifier
+from fastmcp.server.auth import AccessToken, MultiAuth, TokenVerifier
 from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
 from fastmcp.server.dependencies import get_access_token
 from mcp.types import ToolAnnotations
@@ -45,6 +43,7 @@ from app.mcp.context import (
 from app.schemas import EntryFlag, EntryKind, EntryType
 from app.services import integration_client_service
 from app.services.db_service import get_user
+from app.version import APP_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +78,8 @@ class DbIntegrationClientVerifier(TokenVerifier):
             client = await integration_client_service.get_active_integration_client_by_key(session, token)
             if client is None:
                 return None
+            if integration_client_service.MCP_SCOPE not in client.scopes:
+                return None
             try:
                 await integration_client_service.enforce_integration_client_rate_limit(session, client.id)
                 await integration_client_service.record_integration_client_usage(session, client)
@@ -95,6 +96,8 @@ class DbIntegrationClientVerifier(TokenVerifier):
                 "worktime_user_id": client.user_id,
                 "worktime_is_admin": integration_client_service.ADMIN_SCOPE in client.scopes,
                 "sub": f"integration-client:{client.id}",
+                "auth_source": "integration",
+                "integration_client_id": client.id,
                 "auth_type": "integration_client",
                 "worktime_integration_client_id": client.id,
                 "worktime_integration_client_name": client.name,
@@ -544,6 +547,7 @@ def create_mcp_server(
     backend = WorktimeMcpBackend(factory)
     server = FastMCP(
         "worktime",
+        version=APP_VERSION,
         instructions="Worktime assistant tools — read and personal write access",
         auth=_build_auth_provider(factory),
     )
@@ -554,14 +558,12 @@ def create_mcp_server(
     return server
 
 
-async def _run_stdio() -> None:
-    server = create_mcp_server()
-    await server.run_stdio_async()
-
-
 def main() -> None:
-    """Run the Worktime MCP server over stdio."""
-    asyncio.run(_run_stdio())
+    """Reject stdio startup because Worktime tools require bearer auth."""
+    raise SystemExit(
+        "Worktime MCP requires authenticated HTTP transport; run the FastAPI "
+        "application with WORKTIME_MCP_BASE_URL configured and connect to /mcp."
+    )
 
 
 if __name__ == "__main__":

--- a/backend/app/routers/integration_clients.py
+++ b/backend/app/routers/integration_clients.py
@@ -1,7 +1,6 @@
 """REST API endpoints for managed integration clients (issue #1054).
 
-Replaces the long-lived static-token map (``WORKTIME_MCP_INTEGRATION_KEYS``)
-with revocable, rotatable, rate-limited, database-backed credentials —
+Provides revocable, rotatable, rate-limited, database-backed credentials,
 mirroring the personal-access-token pattern in ``app.routers.access_tokens``
 but for automation/integration callers (currently: the MCP server).
 

--- a/backend/app/services/integration_client_service.py
+++ b/backend/app/services/integration_client_service.py
@@ -1,11 +1,9 @@
 """Service layer for managed, database-backed integration clients (issue #1054).
 
-Replaces the long-lived static-token map previously parsed once from
-``WORKTIME_MCP_INTEGRATION_KEYS`` at process startup. Each ``IntegrationClient``
-row is a revocable, rotatable, rate-limited credential bound to one Worktime
-user, mirroring the ``AccessToken`` pattern already used for personal access
-tokens (``app.services.access_token_service``) but scoped for
-automation/integration callers such as the MCP server.
+Each ``IntegrationClient`` row is a revocable, rotatable, rate-limited
+credential bound to one Worktime user, mirroring the ``AccessToken`` pattern
+already used for personal access tokens (``app.services.access_token_service``)
+but scoped for automation/integration callers such as the MCP server.
 """
 
 from __future__ import annotations

--- a/backend/migrations/versions/004_integration_clients.py
+++ b/backend/migrations/versions/004_integration_clients.py
@@ -1,10 +1,7 @@
 """Add managed, database-backed integration clients.
 
-Replaces the long-lived static-token map parsed from
-WORKTIME_MCP_INTEGRATION_KEYS with revocable, rotatable, rate-limited,
-per-user credentials. WORKTIME_MCP_INTEGRATION_KEYS keeps working alongside
-this table for a documented overlap/migration period — see
-docs/integrations/LOCAL_MCP_SERVER.md.
+Adds revocable, rotatable, rate-limited per-user credentials for automation
+and integration callers.
 
 Revision ID: 004
 Revises: 003

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "alembic==1.18.5",
   "asyncpg==0.31.0",
   "fastapi==0.141.1",
-  "fastmcp==3.4.5",
+  "fastmcp==4.0.0b1",
   "httpx==0.28.1",
   "psycopg[binary]==3.3.4",
   "pycountry==26.2.16",
@@ -60,3 +60,6 @@ known-first-party = ["app"]
 
 [tool.ty.rules]
 unresolved-attribute = "warn"
+
+[tool.uv]
+constraint-dependencies = ["fastmcp-slim==4.0.0b1"]

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -27,7 +27,7 @@ def test_health_check(client):
 def test_root_endpoint(client):
     """Test the root endpoint."""
     response = client.get("/")
-    
+
     assert response.status_code == 200
     assert "Worktime Backend API" in response.text
     assert f"v{app.version}" in response.text
@@ -37,10 +37,10 @@ def test_root_endpoint(client):
 def test_openapi_docs(client):
     """Test that OpenAPI docs are accessible."""
     response = client.get("/openapi.json")
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     assert data["openapi"] == "3.1.0"
     assert data["info"]["title"] == "Worktime Backend API"
     assert data["info"]["version"] == app.version
@@ -51,7 +51,7 @@ def test_openapi_docs(client):
 def test_swagger_ui_docs(client):
     """Test that Swagger UI docs are accessible."""
     response = client.get("/docs")
-    
+
     assert response.status_code == 200
     assert "swagger" in response.text.lower()
 
@@ -59,7 +59,7 @@ def test_swagger_ui_docs(client):
 def test_redoc_docs(client):
     """Test that ReDoc docs are accessible."""
     response = client.get("/redoc")
-    
+
     assert response.status_code == 200
     assert "redoc" in response.text.lower()
 
@@ -83,4 +83,7 @@ def test_mcp_capabilities_reports_disabled_with_empty_tools_when_unmounted(clien
     data = response.json()
     assert data["enabled"] is False
     assert data["mount_path"] == "/mcp"
+    assert data["version"] is None
     assert data["tools"] == []
+    assert data["resources"] == []
+    assert data["prompts"] == []

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastmcp.server.auth import AccessToken, MultiAuth
@@ -15,9 +15,11 @@ from app.mcp_server import (
     MCP_TOOL_CAPABILITIES,
     DbIntegrationClientVerifier,
     McpAuthError,
+    ToolEffect,
     WorktimeMcpBackend,
     _build_auth_provider,
     create_mcp_server,
+    tool_annotations,
 )
 from app.schemas import GanttTaskCreate, LabelCreate, TaskCreate, TimeOffEntryCreate, UserCreate
 from app.services import db_service, integration_client_service
@@ -32,7 +34,7 @@ def _token_for_user(user_id: int, *, is_admin: bool = False) -> AccessToken:
         claims={
             "worktime_user_id": user_id,
             "worktime_is_admin": is_admin,
-            "sub": f"integration-key:{user_id}",
+            "sub": f"test-user:{user_id}",
             "realm_access": {"roles": roles},
         },
     )
@@ -51,8 +53,7 @@ def test_build_auth_provider_accepts_client_credentials_without_user_scopes(monk
         auth = _build_auth_provider()
 
     # Always wrapped in MultiAuth: the DB-backed managed-integration-client
-    # verifier (issue #1054) runs unconditionally alongside Keycloak, even
-    # with no legacy WORKTIME_MCP_INTEGRATION_KEYS configured.
+    # verifier runs unconditionally alongside Keycloak.
     assert isinstance(auth, MultiAuth)
     assert auth.server is provider.return_value
     assert len(auth.verifiers) == 1
@@ -63,22 +64,6 @@ def test_build_auth_provider_accepts_client_credentials_without_user_scopes(monk
         required_scopes=[],
         audience="worktime",
     )
-
-
-def test_build_auth_provider_adds_legacy_verifier_when_configured(monkeypatch) -> None:
-    """WORKTIME_MCP_INTEGRATION_KEYS still works, stacked on top of the DB verifier."""
-    from app.mcp_server import IntegrationKeyVerifier
-
-    monkeypatch.setenv("WORKTIME_MCP_BASE_URL", "https://api.example/mcp")
-    monkeypatch.setenv("WORKTIME_MCP_INTEGRATION_KEYS", "legacy-token=1:admin")
-
-    with patch("app.mcp_server.KeycloakAuthProvider"):
-        auth = _build_auth_provider()
-
-    assert isinstance(auth, MultiAuth)
-    assert len(auth.verifiers) == 2
-    assert isinstance(auth.verifiers[0], DbIntegrationClientVerifier)
-    assert isinstance(auth.verifiers[1], IntegrationKeyVerifier)
 
 
 async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) -> None:
@@ -131,6 +116,28 @@ async def test_capability_manifest_cannot_drift_from_registered_tools(test_db: A
         # test pins down so a future admin-scoped tool has to update it
         # deliberately rather than silently mis-tagging itself.
         assert capability.required_tier == "owner", name
+
+
+async def test_registered_tools_advertise_explicit_safety_annotations() -> None:
+    server = create_mcp_server(session_factory=MagicMock())
+    tools = await server.list_tools(run_middleware=False)
+
+    for tool in tools:
+        annotations = tool.annotations
+        capability = MCP_TOOL_CAPABILITIES[tool.name]
+        assert annotations is not None
+        assert annotations.read_only_hint is (capability.effect is ToolEffect.READ)
+        assert annotations.open_world_hint is False
+        if capability.effect is ToolEffect.READ:
+            assert annotations.destructive_hint is False
+            assert annotations.idempotent_hint is True
+
+
+def test_write_annotations_distinguish_creation_from_destructive_changes() -> None:
+    assert tool_annotations("create_gantt_task").destructive_hint is False
+    assert tool_annotations("update_gantt_task").destructive_hint is True
+    assert tool_annotations("delete_gantt_task").destructive_hint is True
+    assert tool_annotations("future_tool_without_policy").destructive_hint is True
 
 
 async def test_whoami_and_time_tracking_summary_happy_path(

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1099,10 +1099,34 @@ async def test_db_integration_client_verifier_accepts_active_client(
     access_token = await verifier.verify_token(raw_key)
 
     assert access_token is not None
+    assert access_token.scopes == [integration_client_service.MCP_SCOPE]
     assert access_token.claims["worktime_user_id"] == user.id
+    assert access_token.claims["auth_source"] == "integration"
+    assert access_token.claims["integration_client_id"] == client.id
     assert access_token.claims["worktime_integration_client_id"] == client.id
     assert access_token.claims["auth_type"] == "integration_client"
     assert access_token.claims["worktime_is_admin"] is False
+
+
+async def test_db_integration_client_verifier_requires_mcp_scope(
+    test_db: AsyncEngine,
+) -> None:
+    session_factory = _make_factory(test_db)
+
+    async with session_factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="admin-only-client", display_name="Admin only")
+        )
+        _, raw_key = await integration_client_service.create_integration_client(
+            session,
+            user.id,
+            name="admin-without-mcp",
+            scopes=[integration_client_service.ADMIN_SCOPE],
+        )
+
+    verifier = DbIntegrationClientVerifier(session_factory)
+
+    assert await verifier.verify_token(raw_key) is None
 
 
 async def test_db_integration_client_verifier_rejects_unknown_and_revoked(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "fastmcp-slim", specifier = "==4.0.0b1" }]
+
 [[package]]
 name = "aiofile"
 version = "3.11.1"
@@ -372,21 +375,22 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.5"
+version = "4.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/14/c1ffb91b7d1fece86c81e1f9df5474f30fd97e4cdaa398814bbbeee88568/fastmcp-3.4.5.tar.gz", hash = "sha256:a95f2bc876bef42e8b50f7872f24f3f2fe3b1d37408c734e8b9d9e03014b72d3", size = 28800521, upload-time = "2026-07-27T19:20:01.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fd/e513c524bb3e296203f65bd8e9e726e9236bd3b59315e7cbdeb095662c01/fastmcp-4.0.0b1.tar.gz", hash = "sha256:f98d69588a73e1672840558641d5d0f111e207baffe001f3465713a53ebb6b4c", size = 42065171, upload-time = "2026-07-28T21:18:15.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/66/41b503ef852eff83f3f0c04f46cd1fc738c5374fd509384fc6b96e45918f/fastmcp-4.0.0b1-py3-none-any.whl", hash = "sha256:d66eb7b0763ffff2ae0fc573778ea25604dcb7e59769e5afaf9851a806eb1129", size = 8064, upload-time = "2026-07-28T21:18:12.688Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.5"
+version = "4.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -394,16 +398,16 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1d/f3e271fbcd01ce01a4cf623b336d8e1305c192aa5d5e8e0223b7167462e9/fastmcp_slim-3.4.5.tar.gz", hash = "sha256:5badc3bceee61f61297eeb9494f499325f3ce1cafabf4611b31f6c3e9d7dff59", size = 591622, upload-time = "2026-07-27T19:15:19.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/33/f207166aac88c6d8be1b2a82c54fecd1e04b075ef12d027aa17b3134fc0f/fastmcp_slim-4.0.0b1.tar.gz", hash = "sha256:158efb25720e0cb301711146b2d05d181de95cd91fe70e87c251ad14b123d665", size = 660081, upload-time = "2026-07-28T21:17:50.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/3b/16d8aa8224094519f30b078138e725b8a731bf0a13f1f850e58b5f9b3cc4/fastmcp_slim-3.4.5-py3-none-any.whl", hash = "sha256:bc31217827c4999812543c83ee95ed9a47f3ed1e3fd0bd4f64371e375b748eca", size = 766478, upload-time = "2026-07-27T19:15:18.015Z" },
+    { url = "https://files.pythonhosted.org/packages/90/5d/fbe192d2ab50bb31b284fd0eb6c72d4347df7a57d836bee4f1973ffd1d7d/fastmcp_slim-4.0.0b1-py3-none-any.whl", hash = "sha256:dd907a3db5a2f479ca958c30157e227b4f7b340a56d333eb91de95719254597a", size = 827975, upload-time = "2026-07-28T21:17:48.747Z" },
 ]
 
 [package.optional-dependencies]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
@@ -414,7 +418,7 @@ server = [
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -512,6 +516,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -556,21 +573,37 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -796,15 +829,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -814,9 +847,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1347,8 +1393,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -1442,6 +1488,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -1713,7 +1768,7 @@ requires-dist = [
     { name = "alembic", specifier = "==1.18.5" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "fastapi", specifier = "==0.141.1" },
-    { name = "fastmcp", specifier = "==3.4.5" },
+    { name = "fastmcp", specifier = "==4.0.0b1" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pycountry", specifier = "==26.2.16" },

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -1,6 +1,6 @@
 # Local Worktime MCP Server
 
-Worktime ships a FastMCP v3 server in `backend/app/mcp_server.py` — split into
+Worktime ships a FastMCP v4 server in `backend/app/mcp_server.py` — split into
 a thin assembler (auth, tool registration) plus focused domain modules under
 `backend/app/mcp/` (identity, schedule, time_tracking, work_location,
 time_off, gantt) — exposing both read tools and personal write tools scoped
@@ -46,26 +46,6 @@ as `INTEGRATION_KEY_HASH_SECRET_PREVIOUS`. Credentials verified with the old
 secret are rehashed with the current secret on successful use. Remove the
 previous value after every active client has authenticated or after the
 operator-defined overlap window; only one previous secret is accepted.
-
-### Legacy static integration keys (deprecated, still supported)
-
-`WORKTIME_MCP_INTEGRATION_KEYS` — a comma-separated `token=user_id` or
-`token=user_id:admin` env var parsed once at process startup — still works
-alongside managed integration clients, for a migration/overlap period. It has
-**no rotation or revocation** short of removing the entry and restarting the
-process, so treat any configured value as a credential that needs manual
-lifecycle management. New integrations should provision a managed
-integration client instead; existing `WORKTIME_MCP_INTEGRATION_KEYS`
-deployments should migrate off it before its removal (tracked in a future
-issue). Support ends with the first Worktime release on or after **2026-11-01**;
-that release will refuse `WORKTIME_MCP_INTEGRATION_KEYS` and operators must
-provision managed clients before upgrading.
-
-Example (legacy, deprecated):
-
-```bash
-export WORKTIME_MCP_INTEGRATION_KEYS="local-agent-token=1:admin"
-```
 
 ## Run over stdio
 

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -47,44 +47,12 @@ secret are rehashed with the current secret on successful use. Remove the
 previous value after every active client has authenticated or after the
 operator-defined overlap window; only one previous secret is accepted.
 
-## Run over stdio
+## Connect over authenticated HTTP
 
-```bash
-cd backend
-uv run python -m app.mcp_server
-```
-
-## Example client config
-
-### Claude Desktop
-
-```json
-{
-  "mcpServers": {
-    "worktime": {
-      "command": "uv",
-      "args": ["run", "python", "-m", "app.mcp_server"],
-      "cwd": "/absolute/path/to/worktime/backend"
-    }
-  }
-}
-```
-
-### Codex CLI (example)
-
-```json
-{
-  "mcp": {
-    "servers": {
-      "worktime": {
-        "command": "uv",
-        "args": ["run", "python", "-m", "app.mcp_server"],
-        "cwd": "/absolute/path/to/worktime/backend"
-      }
-    }
-  }
-}
-```
+Worktime tools require an authenticated principal, so stdio is not a supported
+transport. Configure `WORKTIME_MCP_BASE_URL`, run the FastAPI backend, and
+connect to its `/mcp` endpoint using OAuth or a managed integration-client key
+that carries the `worktime:mcp` scope.
 
 ## Capability discovery
 


### PR DESCRIPTION
## What changed

- upgrade from FastMCP 3.4.5 to FastMCP 4.0.0b1 and constrain the matching `fastmcp-slim` beta
- adapt MCP server construction and authentication to the v4 API
- add explicit safety annotations for read-only, creation, update, and destructive tools
- remove the deprecated `WORKTIME_MCP_INTEGRATION_KEYS` parser and static token verifier
- retain Keycloak authentication and database-backed managed integration clients
- require the `worktime:mcp` scope on managed credentials before accepting them
- normalize managed-token identity claims while retaining Worktime-specific claims
- opt the HTTP MCP endpoint into stateless mode and align its capability envelope with the sibling apps
- expose the application version through FastMCP
- replace the unusable unauthenticated stdio path with a clear authenticated-HTTP requirement
- use FastMCP's public `TokenVerifier` import and remove legacy documentation/terminology

## Why

The static environment-key bridge duplicated the managed integration-client path and could only be rotated or revoked through configuration changes and a restart. Removing it leaves one runtime-manageable automation credential model. Scope enforcement prevents an admin-only managed key from implicitly becoming an MCP credential, and the HTTP-only contract ensures every tool call has a bearer principal.

## Impact

Worktime MCP accepts Keycloak tokens and managed database-backed integration-client credentials carrying `worktime:mcp` only. It uses stateless HTTP and publishes the same diagnostic envelope shape as the sibling apps. The production environment was checked before static-key removal and did not configure `WORKTIME_MCP_INTEGRATION_KEYS`. No production deployment is included.

## Validation

- `uv lock --check`
- `ruff check app tests`
- `ty check app`
- MCP annotation test — 1 passed
- direct capability-envelope probe — passed
- focused auth and MCP annotation tests from the original migration — 3 passed
- direct auth-provider construction probe
- legacy API/static-key residue scans
- `git diff --check`

Database-backed verifier and FastAPI lifespan fixtures require the unavailable local PostgreSQL test database; the new scope regression test is included for CI.