### PR TITLE
Add searchable MCP tool discovery

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -93,6 +93,8 @@ class Settings(BaseSettings):
     OIDC_ISSUER_URL: str = "http://localhost:9000/application/o/worktime"
     # OIDC_AUDIENCE: Expected audience claim in the JWT (leave empty to skip audience check)
     OIDC_AUDIENCE: str = ""
+    # Comma-separated OIDC client IDs allowed to manage MCP credentials.
+    MCP_INTERACTIVE_CLIENT_IDS: str = "worktime,worktime-android"
     # OIDC_JWKS_URI: optional JWKS endpoint override; discovered from OIDC metadata when empty
     OIDC_JWKS_URI: str = ""
     # OIDC_ALGORITHMS: Comma-separated list of accepted signing algorithms

--- a/backend/app/mcp/account.py
+++ b/backend/app/mcp/account.py
@@ -1,0 +1,112 @@
+"""Owner-scoped audit, preferences, and managed-client MCP operations."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit.db import DEFAULT_AUDIT_LIMIT, MAX_AUDIT_LIMIT, list_audit_entries
+from app.mcp.context import WorktimeMcpContext, actor_from_context
+from app.schemas import (
+    AuditEntryRead,
+    IntegrationClientRead,
+    IntegrationClientScope,
+    UserPreferencesRead,
+)
+from app.services.db_service import get_user_preferences
+from app.services.integration_client_service import (
+    ADMIN_SCOPE,
+    DEFAULT_RATE_LIMIT_PER_MINUTE,
+    create_integration_client,
+    list_integration_clients_for_user,
+    revoke_integration_client,
+    rotate_integration_client,
+)
+
+
+def _require_interactive(context: WorktimeMcpContext) -> None:
+    if context.auth_type != "oidc":
+        raise PermissionError("Integration-client management requires an interactive OIDC user")
+
+
+async def list_audit_entries_tool(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    limit: int = DEFAULT_AUDIT_LIMIT,
+    before_id: int | None = None,
+) -> dict[str, Any]:
+    limit = max(1, min(limit, MAX_AUDIT_LIMIT))
+    entries = await list_audit_entries(
+        db,
+        requesting_user_id=context.user_id,
+        is_admin=False,
+        target_user_id=context.user_id,
+        limit=limit,
+        before_id=before_id,
+    )
+    items = [AuditEntryRead.model_validate(entry, from_attributes=True).model_dump(mode="json") for entry in entries]
+    return {"items": items, "total": len(items)}
+
+
+async def get_preferences(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any] | None:
+    prefs = await get_user_preferences(db, context.user_id)
+    return (
+        UserPreferencesRead.model_validate(prefs, from_attributes=True).model_dump(mode="json")
+        if prefs is not None
+        else None
+    )
+
+
+async def list_integration_clients(context: WorktimeMcpContext, db: AsyncSession) -> dict[str, Any]:
+    _require_interactive(context)
+    clients = await list_integration_clients_for_user(db, context.user_id)
+    items = [
+        IntegrationClientRead.model_validate(client, from_attributes=True).model_dump(mode="json") for client in clients
+    ]
+    return {"items": items, "total": len(items)}
+
+
+async def create_integration_client_tool(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    name: str,
+    scopes: list[IntegrationClientScope] | None = None,
+    rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE,
+) -> dict[str, Any]:
+    _require_interactive(context)
+    effective_scopes = list(scopes or ["worktime:mcp"])
+    if ADMIN_SCOPE in effective_scopes and not context.is_admin:
+        raise PermissionError("Admin privileges are required to grant worktime:admin")
+    client, raw_key = await create_integration_client(
+        db,
+        context.user_id,
+        name=name,
+        scopes=effective_scopes,
+        rate_limit_per_minute=rate_limit_per_minute,
+        actor=actor_from_context(context),
+    )
+    return {
+        **IntegrationClientRead.model_validate(client, from_attributes=True).model_dump(mode="json"),
+        "key": raw_key,
+        "scopes": cast(list[IntegrationClientScope], client.scopes),
+    }
+
+
+async def rotate_integration_client_tool(
+    context: WorktimeMcpContext, db: AsyncSession, client_id: int
+) -> dict[str, Any]:
+    _require_interactive(context)
+    client, raw_key = await rotate_integration_client(db, context.user_id, client_id, actor=actor_from_context(context))
+    return {
+        **IntegrationClientRead.model_validate(client, from_attributes=True).model_dump(mode="json"),
+        "key": raw_key,
+    }
+
+
+async def revoke_integration_client_tool(
+    context: WorktimeMcpContext, db: AsyncSession, client_id: int
+) -> dict[str, Any]:
+    _require_interactive(context)
+    await revoke_integration_client(db, context.user_id, client_id, actor=actor_from_context(context))
+    return {"revoked": True, "client_id": client_id}

--- a/backend/app/mcp/holidays.py
+++ b/backend/app/mcp/holidays.py
@@ -1,0 +1,71 @@
+"""Cached public and school holiday MCP reads."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp.context import WorktimeMcpContext
+from app.routers.holidays import (
+    HOLIDAY_COUNTRY_CODE,
+    NAGER_BASE_URL,
+    OPENHOLIDAYS_BASE_URL,
+    OPENHOLIDAYS_GROUP_CODE,
+    _build_openholidays_params,
+    _get_or_fetch_holidays,
+    _normalize_country,
+    compute_paydates,
+)
+
+
+async def get_public_holidays(
+    context: WorktimeMcpContext, db: AsyncSession, year: int, country: str = HOLIDAY_COUNTRY_CODE
+) -> dict[str, Any]:
+    del context
+    country = _normalize_country(country)
+    data = await _get_or_fetch_holidays(
+        holiday_type="public",
+        country=country,
+        year=year,
+        language=None,
+        subdivision=None,
+        upstream_url=f"{NAGER_BASE_URL}/PublicHolidays/{year}/{country}",
+        upstream_params={},
+        db=db,
+        response_filter=lambda values: [item for item in values if "Public" in item.get("types", [])],
+    )
+    if data is None:
+        raise RuntimeError("Holiday API is unreachable and no cached data is available")
+    return {"year": year, "country": country, "holidays": data, "count": len(data)}
+
+
+async def get_school_holidays(
+    context: WorktimeMcpContext, db: AsyncSession, year: int, country: str = HOLIDAY_COUNTRY_CODE
+) -> dict[str, Any]:
+    del context
+    country = _normalize_country(country)
+    data = await _get_or_fetch_holidays(
+        holiday_type=f"school-{OPENHOLIDAYS_GROUP_CODE.lower()}",
+        country=country,
+        year=year,
+        language=None,
+        subdivision=None,
+        upstream_url=f"{OPENHOLIDAYS_BASE_URL}/SchoolHolidays",
+        upstream_params=_build_openholidays_params(year),
+        db=db,
+    )
+    if data is None:
+        raise RuntimeError("School holiday API is unreachable and no cached data is available")
+    return {"year": year, "country": country, "holidays": data, "count": len(data)}
+
+
+async def get_paydates(
+    context: WorktimeMcpContext, db: AsyncSession, year: int, country: str = HOLIDAY_COUNTRY_CODE
+) -> dict[str, Any]:
+    public = await get_public_holidays(context, db, year, country)
+    return {
+        "year": year,
+        "country": public["country"],
+        "paydates": compute_paydates(year, public["holidays"]),
+    }

--- a/backend/app/mcp/time_tracking.py
+++ b/backend/app/mcp/time_tracking.py
@@ -10,9 +10,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.audit import logger as audit
 from app.mcp.context import WorktimeMcpContext, actor_from_context
 from app.mcp.formatting import to_iso_datetime
-from app.schemas import TaskCreate, TaskRead, TaskUpdate
+from app.schemas import LabelCreate, LabelRead, LabelUpdate, TaskCreate, TaskRead, TaskUpdate
 from app.services.db_service import (
     NotFoundError,
+    create_label,
     create_task,
     delete_label,
     delete_task,
@@ -20,6 +21,7 @@ from app.services.db_service import (
     get_task,
     list_labels_for_user,
     list_tasks,
+    update_label,
     update_task,
 )
 
@@ -80,6 +82,33 @@ async def list_labels(context: WorktimeMcpContext, db: AsyncSession) -> dict[str
     """List the authenticated user's active time-tracking labels."""
     labels = await list_labels_for_user(db, context.user_id)
     return {"labels": [{"id": label.id, "name": label.name, "color": label.color} for label in labels]}
+
+
+async def create_label_tool(context: WorktimeMcpContext, db: AsyncSession, name: str, color: str) -> dict[str, Any]:
+    label = await create_label(
+        db, context.user_id, LabelCreate(name=name, color=color), actor=actor_from_context(context)
+    )
+    return LabelRead.model_validate(label, from_attributes=True).model_dump(mode="json")
+
+
+async def update_label_tool(
+    context: WorktimeMcpContext,
+    db: AsyncSession,
+    label_id: str,
+    name: str | None = None,
+    color: str | None = None,
+) -> dict[str, Any]:
+    payload = LabelUpdate.model_validate(
+        {key: value for key, value in {"name": name, "color": color}.items() if value is not None}
+    )
+    label = await update_label(
+        db,
+        context.user_id,
+        label_id,
+        payload,
+        actor=actor_from_context(context),
+    )
+    return LabelRead.model_validate(label, from_attributes=True).model_dump(mode="json")
 
 
 async def delete_label_tool(context: WorktimeMcpContext, db: AsyncSession, label_id: str) -> dict[str, Any]:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -24,6 +24,8 @@ from fastmcp import FastMCP
 from fastmcp.server.auth import AccessToken, MultiAuth, TokenVerifier
 from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
 from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.transforms.search import BM25SearchTransform
+from fastmcp.tools.base import Tool
 from mcp.types import ToolAnnotations
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -46,6 +48,20 @@ from app.services.db_service import get_user
 from app.version import APP_VERSION
 
 logger = logging.getLogger(__name__)
+
+
+def _search_serializer(tools: Sequence[Tool]) -> list[dict[str, Any]]:
+    """Preserve callable schemas and Worktime capability metadata in search results."""
+    return [
+        {
+            "name": tool.name,
+            "description": tool.description or "",
+            "input_schema": tool.parameters,
+            "required_tier": MCP_TOOL_CAPABILITIES[tool.name].required_tier,
+            "effect": MCP_TOOL_CAPABILITIES[tool.name].effect.value,
+        }
+        for tool in tools
+    ]
 
 __all__ = [
     "McpAuthError",
@@ -550,6 +566,15 @@ def create_mcp_server(
         version=APP_VERSION,
         instructions="Worktime assistant tools — read and personal write access",
         auth=_build_auth_provider(factory),
+        transforms=[
+            BM25SearchTransform(
+                max_results=10,
+                always_visible=["whoami"],
+                search_tool_name="search_tools",
+                call_tool_name="call_tool",
+                search_result_serializer=_search_serializer,
+            )
+        ],
     )
 
     for tool_name in MCP_TOOL_CAPABILITIES:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -619,8 +619,10 @@ _INTERACTIVE_ONLY_TOOLS = frozenset(
 def _require_interactive_auth(ctx: AuthContext) -> bool:
     if ctx.token is None or ctx.token.claims.get("auth_type", "oidc") != "oidc":
         return False
-    username = ctx.token.claims.get("preferred_username")
-    return not (isinstance(username, str) and username.startswith("service-account-"))
+    interactive_client_ids = {
+        client_id.strip() for client_id in settings.MCP_INTERACTIVE_CLIENT_IDS.split(",") if client_id.strip()
+    }
+    return ctx.token.claims.get("azp") in interactive_client_ids
 
 
 def tool_auth(tool_name: str) -> AuthCheck | None:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -21,7 +21,7 @@ from enum import StrEnum
 from typing import Any
 
 from fastmcp import FastMCP
-from fastmcp.server.auth import AccessToken, MultiAuth, TokenVerifier
+from fastmcp.server.auth import AccessToken, AuthCheck, AuthContext, MultiAuth, TokenVerifier
 from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
 from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.transforms.search import BM25SearchTransform
@@ -32,7 +32,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import settings
 from app.database.engine import get_session_factory
-from app.mcp import gantt, identity, schedule, time_off, time_tracking, work_location
+from app.mcp import account, gantt, holidays, identity, schedule, time_off, time_tracking, work_location
 from app.mcp.context import (
     McpAuthError,
     McpPermissionError,
@@ -42,7 +42,7 @@ from app.mcp.context import (
 from app.mcp.context import (
     map_domain_errors as _map_domain_errors,
 )
-from app.schemas import EntryFlag, EntryKind, EntryType
+from app.schemas import EntryFlag, EntryKind, EntryType, IntegrationClientScope
 from app.services import integration_client_service
 from app.services.db_service import get_user
 from app.version import APP_VERSION
@@ -62,6 +62,7 @@ def _search_serializer(tools: Sequence[Tool]) -> list[dict[str, Any]]:
         }
         for tool in tools
     ]
+
 
 __all__ = [
     "McpAuthError",
@@ -236,6 +237,18 @@ class WorktimeMcpBackend:
         async with self._tool_context() as (context, db):
             return await schedule.get_sync_status(context, db)
 
+    async def get_public_holidays(self, year: int, country: str = "NL") -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await holidays.get_public_holidays(context, db, year, country)
+
+    async def get_school_holidays(self, year: int, country: str = "NL") -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await holidays.get_school_holidays(context, db, year, country)
+
+    async def get_paydates(self, year: int, country: str = "NL") -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await holidays.get_paydates(context, db, year, country)
+
     # ------------------------------------------------------------------
     # Time tracking
     # ------------------------------------------------------------------
@@ -251,6 +264,16 @@ class WorktimeMcpBackend:
     async def list_labels(self) -> dict[str, Any]:
         async with self._tool_context() as (context, db):
             return await time_tracking.list_labels(context, db)
+
+    @_map_domain_errors
+    async def create_label(self, name: str, color: str) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await time_tracking.create_label_tool(context, db, name, color)
+
+    @_map_domain_errors
+    async def update_label(self, label_id: str, name: str | None = None, color: str | None = None) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await time_tracking.update_label_tool(context, db, label_id, name, color)
 
     @_map_domain_errors
     async def delete_label(self, label_id: str) -> dict[str, Any]:
@@ -478,6 +501,42 @@ class WorktimeMcpBackend:
         async with self._tool_context() as (context, db):
             return await gantt.delete_gantt_task(context, db, task_id)
 
+    # ------------------------------------------------------------------
+    # Account data and managed integrations
+    # ------------------------------------------------------------------
+
+    async def list_audit_entries(self, limit: int = 100, before_id: int | None = None) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await account.list_audit_entries_tool(context, db, limit, before_id)
+
+    async def get_preferences(self) -> dict[str, Any] | None:
+        async with self._tool_context() as (context, db):
+            return await account.get_preferences(context, db)
+
+    async def list_integration_clients(self) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await account.list_integration_clients(context, db)
+
+    @_map_domain_errors
+    async def create_integration_client(
+        self,
+        name: str,
+        scopes: list[IntegrationClientScope] | None = None,
+        rate_limit_per_minute: int = 120,
+    ) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await account.create_integration_client_tool(context, db, name, scopes, rate_limit_per_minute)
+
+    @_map_domain_errors
+    async def rotate_integration_client(self, client_id: int) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await account.rotate_integration_client_tool(context, db, client_id)
+
+    @_map_domain_errors
+    async def revoke_integration_client(self, client_id: int) -> dict[str, Any]:
+        async with self._tool_context() as (context, db):
+            return await account.revoke_integration_client_tool(context, db, client_id)
+
 
 # ---------------------------------------------------------------------------
 # Capability manifest (issue #1054)
@@ -518,9 +577,14 @@ MCP_TOOL_CAPABILITIES: dict[str, ToolCapability] = {
     "get_work_location_summary": ToolCapability(ToolEffect.READ, "owner"),
     "get_time_tracking_summary": ToolCapability(ToolEffect.READ, "owner"),
     "list_labels": ToolCapability(ToolEffect.READ, "owner"),
+    "create_label": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "update_label": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
     "delete_label": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
     "get_gantt_tasks": ToolCapability(ToolEffect.READ, "owner"),
     "get_sync_status": ToolCapability(ToolEffect.READ, "owner"),
+    "get_public_holidays": ToolCapability(ToolEffect.READ, "owner"),
+    "get_school_holidays": ToolCapability(ToolEffect.READ, "owner"),
+    "get_paydates": ToolCapability(ToolEffect.READ, "owner"),
     "start_time_entry": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
     "stop_time_entry": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
     "create_time_tracking_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
@@ -534,7 +598,34 @@ MCP_TOOL_CAPABILITIES: dict[str, ToolCapability] = {
     "create_gantt_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
     "update_gantt_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
     "delete_gantt_task": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "list_audit_entries": ToolCapability(ToolEffect.READ, "owner"),
+    "get_preferences": ToolCapability(ToolEffect.READ, "owner"),
+    "list_integration_clients": ToolCapability(ToolEffect.READ, "owner"),
+    "create_integration_client": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "rotate_integration_client": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
+    "revoke_integration_client": ToolCapability(ToolEffect.PERSONAL_WRITE, "owner"),
 }
+
+_INTERACTIVE_ONLY_TOOLS = frozenset(
+    {
+        "list_integration_clients",
+        "create_integration_client",
+        "rotate_integration_client",
+        "revoke_integration_client",
+    }
+)
+
+
+def _require_interactive_auth(ctx: AuthContext) -> bool:
+    if ctx.token is None or ctx.token.claims.get("auth_type", "oidc") != "oidc":
+        return False
+    username = ctx.token.claims.get("preferred_username")
+    return not (isinstance(username, str) and username.startswith("service-account-"))
+
+
+def tool_auth(tool_name: str) -> AuthCheck | None:
+    """Hide credential-management tools from managed/service credentials."""
+    return _require_interactive_auth if tool_name in _INTERACTIVE_ONLY_TOOLS else None
 
 
 def tool_annotations(tool_name: str) -> ToolAnnotations:
@@ -578,7 +669,11 @@ def create_mcp_server(
     )
 
     for tool_name in MCP_TOOL_CAPABILITIES:
-        server.tool(name=tool_name, annotations=tool_annotations(tool_name))(getattr(backend, tool_name))
+        server.tool(
+            name=tool_name,
+            annotations=tool_annotations(tool_name),
+            auth=tool_auth(tool_name),
+        )(getattr(backend, tool_name))
 
     return server
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -68,7 +68,7 @@ def test_build_auth_provider_accepts_client_credentials_without_user_scopes(monk
 
 async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) -> None:
     server = create_mcp_server(session_factory=_make_factory(test_db))
-    tools = await server.list_tools(run_middleware=False)
+    tools = await server.local_provider.list_tools()
     tool_names = {tool.name for tool in tools}
 
     assert tool_names == {
@@ -100,12 +100,48 @@ async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) 
     }
 
 
+async def test_search_transform_replaces_large_initial_catalog() -> None:
+    server = create_mcp_server(session_factory=MagicMock())
+
+    assert {tool.name for tool in await server.list_tools()} == {
+        "whoami",
+        "search_tools",
+        "call_tool",
+    }
+
+
+async def test_search_tools_finds_time_summary() -> None:
+    server = create_mcp_server(session_factory=MagicMock())
+    result = await server.call_tool(
+        "search_tools", {"query": "summarize tracked working time"}
+    )
+
+    assert result.structured_content is not None
+    names = [item["name"] for item in result.structured_content["result"]]
+    assert "get_time_tracking_summary" in names
+
+
+def test_search_serializer_preserves_schema_and_capabilities() -> None:
+    from app.mcp_server import _search_serializer
+
+    tool = MagicMock(name="tool")
+    tool.name = "get_time_tracking_summary"
+    tool.description = "Summarize tracked time"
+    tool.parameters = {"type": "object", "properties": {}}
+    result = _search_serializer([tool])[0]
+
+    assert result["name"] == tool.name
+    assert result["input_schema"] == tool.parameters
+    assert result["required_tier"] == "owner"
+    assert result["effect"] == "read"
+
+
 async def test_capability_manifest_cannot_drift_from_registered_tools(test_db: AsyncEngine) -> None:
     """MCP_TOOL_CAPABILITIES is the single source of truth create_mcp_server()
     registers tools from — this asserts that guarantee holds, and also
     that every capability entry has a sane effect/tier."""
     server = create_mcp_server(session_factory=_make_factory(test_db))
-    tools = await server.list_tools(run_middleware=False)
+    tools = await server.local_provider.list_tools()
     tool_names = {tool.name for tool in tools}
 
     assert tool_names == set(MCP_TOOL_CAPABILITIES)
@@ -120,7 +156,7 @@ async def test_capability_manifest_cannot_drift_from_registered_tools(test_db: A
 
 async def test_registered_tools_advertise_explicit_safety_annotations() -> None:
     server = create_mcp_server(session_factory=MagicMock())
-    tools = await server.list_tools(run_middleware=False)
+    tools = await server.local_provider.list_tools()
 
     for tool in tools:
         annotations = tool.annotations

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -192,20 +192,32 @@ async def test_integration_client_management_requires_interactive_oidc() -> None
     auth = tool_auth("create_integration_client")
     assert auth is not None
 
-    def context(auth_type: str, preferred_username: str = "owner") -> AuthContext:
+    def context(
+        auth_type: str,
+        preferred_username: str = "owner",
+        azp: str = "worktime",
+    ) -> AuthContext:
         return AuthContext(
             token=AccessToken(
                 token="test",
                 client_id="client",
                 scopes=[],
-                claims={"auth_type": auth_type, "preferred_username": preferred_username},
+                claims={
+                    "auth_type": auth_type,
+                    "preferred_username": preferred_username,
+                    "azp": azp,
+                },
             ),
             component=tools["create_integration_client"],
         )
 
     assert await run_auth_checks(auth, context("oidc"))
     assert not await run_auth_checks(auth, context("integration_client"))
-    assert not await run_auth_checks(auth, context("oidc", "service-account-automation"))
+    assert not await run_auth_checks(
+        auth,
+        context("oidc", "service-account-automation", "worktime-mcp"),
+    )
+    assert not await run_auth_checks(auth, context("oidc", azp="worktime-mcp"))
 
 
 async def test_mcp_label_preferences_and_audit_reads(test_db: AsyncEngine, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastmcp.server.auth import AccessToken, MultiAuth
+from fastmcp.server.auth import AccessToken, AuthContext, MultiAuth, run_auth_checks
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
@@ -20,6 +20,7 @@ from app.mcp_server import (
     _build_auth_provider,
     create_mcp_server,
     tool_annotations,
+    tool_auth,
 )
 from app.schemas import GanttTaskCreate, LabelCreate, TaskCreate, TimeOffEntryCreate, UserCreate
 from app.services import db_service, integration_client_service
@@ -81,9 +82,14 @@ async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) 
         "get_work_location_summary",
         "get_time_tracking_summary",
         "list_labels",
+        "create_label",
+        "update_label",
         "delete_label",
         "get_gantt_tasks",
         "get_sync_status",
+        "get_public_holidays",
+        "get_school_holidays",
+        "get_paydates",
         "start_time_entry",
         "stop_time_entry",
         "create_time_tracking_task",
@@ -97,6 +103,12 @@ async def test_create_mcp_server_registers_expected_tools(test_db: AsyncEngine) 
         "create_gantt_task",
         "update_gantt_task",
         "delete_gantt_task",
+        "list_audit_entries",
+        "get_preferences",
+        "list_integration_clients",
+        "create_integration_client",
+        "rotate_integration_client",
+        "revoke_integration_client",
     }
 
 
@@ -112,9 +124,7 @@ async def test_search_transform_replaces_large_initial_catalog() -> None:
 
 async def test_search_tools_finds_time_summary() -> None:
     server = create_mcp_server(session_factory=MagicMock())
-    result = await server.call_tool(
-        "search_tools", {"query": "summarize tracked working time"}
-    )
+    result = await server.call_tool("search_tools", {"query": "summarize tracked working time"})
 
     assert result.structured_content is not None
     names = [item["name"] for item in result.structured_content["result"]]
@@ -174,6 +184,63 @@ def test_write_annotations_distinguish_creation_from_destructive_changes() -> No
     assert tool_annotations("update_gantt_task").destructive_hint is True
     assert tool_annotations("delete_gantt_task").destructive_hint is True
     assert tool_annotations("future_tool_without_policy").destructive_hint is True
+
+
+async def test_integration_client_management_requires_interactive_oidc() -> None:
+    server = create_mcp_server(session_factory=MagicMock())
+    tools = {tool.name: tool for tool in await server.local_provider.list_tools()}
+    auth = tool_auth("create_integration_client")
+    assert auth is not None
+
+    def context(auth_type: str, preferred_username: str = "owner") -> AuthContext:
+        return AuthContext(
+            token=AccessToken(
+                token="test",
+                client_id="client",
+                scopes=[],
+                claims={"auth_type": auth_type, "preferred_username": preferred_username},
+            ),
+            component=tools["create_integration_client"],
+        )
+
+    assert await run_auth_checks(auth, context("oidc"))
+    assert not await run_auth_checks(auth, context("integration_client"))
+    assert not await run_auth_checks(auth, context("oidc", "service-account-automation"))
+
+
+async def test_mcp_label_preferences_and_audit_reads(test_db: AsyncEngine, monkeypatch: pytest.MonkeyPatch) -> None:
+    factory = _make_factory(test_db)
+    async with factory() as session:
+        user = await db_service.create_user(session, UserCreate(username="mcp-gaps", display_name="MCP Gaps"))
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
+    backend = WorktimeMcpBackend(factory)
+
+    label = await backend.create_label("Focus", "#112233")
+    updated = await backend.update_label(label["id"], name="Deep focus")
+    preferences = await backend.get_preferences()
+    audit = await backend.list_audit_entries()
+
+    assert updated["name"] == "Deep focus"
+    assert preferences is None
+    assert audit["total"] >= 2
+
+
+async def test_mcp_integration_client_lifecycle(test_db: AsyncEngine, monkeypatch: pytest.MonkeyPatch) -> None:
+    factory = _make_factory(test_db)
+    async with factory() as session:
+        user = await db_service.create_user(
+            session, UserCreate(username="mcp-integrations", display_name="MCP Integrations")
+        )
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: _token_for_user(user.id))
+    backend = WorktimeMcpBackend(factory)
+
+    created = await backend.create_integration_client("Automation")
+    rotated = await backend.rotate_integration_client(created["id"])
+    revoked = await backend.revoke_integration_client(created["id"])
+
+    assert created["key"].startswith("wtic_")
+    assert rotated["key"] != created["key"]
+    assert revoked == {"revoked": True, "client_id": created["id"]}
 
 
 async def test_whoami_and_time_tracking_summary_happy_path(


### PR DESCRIPTION
## What changed

- add FastMCP `BM25SearchTransform` as the standard MCP discovery surface
- initially expose only `whoami`, `search_tools`, and `call_tool`, while retaining the complete registry
- preserve schemas plus Worktime ownership-tier and effect metadata in search results
- complete label creation and update operations
- add owner-scoped audit and preference reads
- add public-holiday, school-holiday, and paydate tools
- add audited integration-client list/create/rotate/revoke operations
- enforce interactive OIDC authentication for credential-management tools

## Why

This aligns Worktime with the FastMCP v4 / MCP SDK 2 discovery model while filling worthwhile tool gaps. New mutations use existing audited service paths. Preference and template mutations remain out of MCP until their shared services accept an audit actor and can commit data and audit records transactionally.

## Validation

- `ruff check app/mcp app/mcp_server.py tests/test_mcp_server.py`
- `ty check app tests/test_mcp_server.py`
- non-database MCP tests pass locally
- database-backed MCP coverage added; full execution is delegated to CI because local PostgreSQL is unavailable

No experimental flag or production deployment is included.
